### PR TITLE
fix: repair anyOf tool schemas rejected by the Kimi wire

### DIFF
--- a/.changeset/kimi-anyof-tool-schema.md
+++ b/.changeset/kimi-anyof-tool-schema.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Fix Kimi and Moonshot models rejecting every request with an invalid tool schema error when a tool declares `anyOf` alongside its own type or properties.

--- a/packages/kosong/src/providers/pythinker-schema.ts
+++ b/packages/kosong/src/providers/pythinker-schema.ts
@@ -157,22 +157,54 @@ function foldRootAnyOf(root: Record<string, unknown>): void {
   delete root['anyOf'];
 
   const rootProperties = root['properties'];
-  const merged: Record<string, unknown> = isRecord(rootProperties)
-    ? rootProperties
-    : {};
+  const alternativesByName = new Map<string, unknown[]>();
+  if (isRecord(rootProperties)) {
+    for (const [name, property] of Object.entries(rootProperties)) {
+      alternativesByName.set(name, [cloneJsonValue(property)]);
+    }
+  }
   for (const branch of branches) {
     const branchProperties = branch['properties'];
     if (!isRecord(branchProperties)) continue;
     for (const [name, property] of Object.entries(branchProperties)) {
-      if (!hasOwn(merged, name)) {
-        merged[name] = cloneJsonValue(property);
-      }
+      addRootPropertyAlternative(alternativesByName, name, property);
     }
   }
-  if (Object.keys(merged).length > 0) {
+
+  if (alternativesByName.size > 0) {
+    const merged: Record<string, unknown> = {};
+    for (const [name, alternatives] of alternativesByName) {
+      merged[name] = alternatives.length === 1 ? alternatives[0] : { anyOf: alternatives };
+    }
     root['properties'] = merged;
   }
   root['type'] = 'object';
+}
+
+/**
+ * Record one branch's schema for a merged root property.
+ *
+ * Root `anyOf` branches are alternatives, so two branches declaring the same
+ * property with different schemas (e.g. `value` as a string in one branch, an
+ * integer in another) must both stay representable — keeping only the first
+ * one seen would silently narrow what the tool actually accepts. Identical
+ * schemas collapse to one; differing schemas fold into an `anyOf` on the
+ * merged property.
+ */
+function addRootPropertyAlternative(
+  alternativesByName: Map<string, unknown[]>,
+  name: string,
+  property: unknown,
+): void {
+  const cloned = cloneJsonValue(property);
+  const alternatives = alternativesByName.get(name);
+  if (!alternatives) {
+    alternativesByName.set(name, [cloned]);
+    return;
+  }
+  if (!alternatives.some((existing) => deepEqualJson(existing, cloned))) {
+    alternatives.push(cloned);
+  }
 }
 
 function hasUnresolvedDefinitionRef(node: unknown, bucketKey: string): boolean {
@@ -337,8 +369,13 @@ const ANYOF_PARENT_KEEP_KEYS = new Set([
  * so schemas that are perfectly valid elsewhere are rejected on this wire.
  *
  * Distributing is lossless: `P ∧ (B₁ ∨ B₂)` and `(P ∧ B₁) ∨ (P ∧ B₂)` accept
- * exactly the same instances. A branch that already declares a keyword keeps
- * its own, which is the narrower of the two.
+ * exactly the same instances — *if* a branch that already declares the same
+ * keyword is merged conjunctively with the parent's value rather than simply
+ * overriding it. `required` is the one keyword this function merges that way
+ * (parent and branch field lists are unioned, since both are actually
+ * required). Every other overlapping keyword still keeps the branch's own
+ * value: a full conjunctive merge for arbitrary keywords (`properties`,
+ * `items`, …) is out of scope for this compatibility normalizer.
  */
 function distributeAnyOfParentKeywords(node: Record<string, unknown>): void {
   const branches = node['anyOf'];
@@ -355,12 +392,34 @@ function distributeAnyOfParentKeywords(node: Record<string, unknown>): void {
     for (const key of inherited) {
       if (!hasOwn(branch, key)) {
         branch[key] = cloneJsonValue(node[key]);
+      } else if (key === 'required') {
+        branch[key] = mergeRequired(node[key], branch[key]);
       }
     }
   }
   for (const key of inherited) {
     delete node[key];
   }
+}
+
+/**
+ * Union two `required` field lists.
+ *
+ * A parent's `required` and a branch's own `required` are both mandatory —
+ * dropping the parent's list when the branch already has one would silently
+ * accept objects missing a field the parent demanded.
+ */
+function mergeRequired(parentValue: unknown, branchValue: unknown): unknown {
+  if (!Array.isArray(parentValue) || !Array.isArray(branchValue)) {
+    return branchValue;
+  }
+  const merged = [...branchValue];
+  for (const name of parentValue) {
+    if (!merged.includes(name)) {
+      merged.push(name);
+    }
+  }
+  return merged;
 }
 
 function visitChildSchemas(node: Record<string, unknown>, visit: (schema: unknown) => void): void {
@@ -572,6 +631,21 @@ function cloneJsonValue(value: unknown): unknown {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function deepEqualJson(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => deepEqualJson(item, b[index]));
+  }
+  if (isRecord(a) && isRecord(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return aKeys.length === bKeys.length && aKeys.every((key) => hasOwn(b, key) && deepEqualJson(a[key], b[key]));
+  }
+  return false;
 }
 
 function hasOwn(obj: Record<string, unknown>, key: string): boolean {

--- a/packages/kosong/src/providers/pythinker-schema.ts
+++ b/packages/kosong/src/providers/pythinker-schema.ts
@@ -117,7 +117,8 @@ const NUMERIC_STRUCTURE_KEYS = new Set([
  * it resolves local refs, preserves combinator nodes, infers obvious
  * scalar/object/array types, and falls back to `string` only for nested
  * typeless property schemas. The root schema object is treated as a container
- * and is not itself normalized.
+ * and is not itself type-normalized, with one exception: an `anyOf` at the root
+ * is folded away, because a tool's parameters must be a plain object.
  */
 export function normalizePythinkerToolSchema(schema: Record<string, unknown>): Record<string, unknown> {
   return ensurePythinkerPropertyTypes(derefJsonSchema(schema));
@@ -128,8 +129,50 @@ function ensurePythinkerPropertyTypes(schema: Record<string, unknown>): Record<s
   if (!isRecord(normalized)) {
     throw new Error('JSON Schema root must normalize to an object.');
   }
+  // Fold the root's `anyOf` away before recursing; once it is gone the generic
+  // per-node distribution below sees nothing to do at the root.
+  foldRootAnyOf(normalized);
   recurseSchema(normalized);
   return normalized;
+}
+
+/**
+ * Remove an `anyOf` sitting at the root of a tool's parameter schema.
+ *
+ * A tool's parameters must be an object, so the root cannot use the branch form
+ * that {@link distributeAnyOfParentKeywords} produces for every other node: the
+ * wire requires `type: "object"` there, and rejects `type` next to `anyOf`. The
+ * two constraints are jointly unsatisfiable, so the root's `anyOf` is dropped.
+ *
+ * Dropping only ever widens what the schema accepts — a root `anyOf` is almost
+ * always a "one of these fields is required" hint, which the tool re-checks when
+ * it runs. Branch properties are folded into the root first, so a schema that
+ * kept its arguments inside the branches does not lose them.
+ */
+function foldRootAnyOf(root: Record<string, unknown>): void {
+  const branches = root['anyOf'];
+  if (!Array.isArray(branches) || !branches.every(isRecord)) {
+    return;
+  }
+  delete root['anyOf'];
+
+  const rootProperties = root['properties'];
+  const merged: Record<string, unknown> = isRecord(rootProperties)
+    ? rootProperties
+    : {};
+  for (const branch of branches) {
+    const branchProperties = branch['properties'];
+    if (!isRecord(branchProperties)) continue;
+    for (const [name, property] of Object.entries(branchProperties)) {
+      if (!hasOwn(merged, name)) {
+        merged[name] = cloneJsonValue(property);
+      }
+    }
+  }
+  if (Object.keys(merged).length > 0) {
+    root['properties'] = merged;
+  }
+  root['type'] = 'object';
 }
 
 function hasUnresolvedDefinitionRef(node: unknown, bucketKey: string): boolean {
@@ -252,7 +295,72 @@ function recurseSchema(node: unknown): void {
     return;
   }
 
+  distributeAnyOfParentKeywords(node);
   visitChildSchemas(node, normalizeProperty);
+}
+
+/**
+ * Keywords that may stay on a schema node that also carries `anyOf`.
+ *
+ * Everything else is a validation keyword the wire validator refuses to see on
+ * both sides of an `anyOf`. Sibling combinators are left alone because the
+ * validator does not read them at all, so relocating them would only churn the
+ * schema. `$defs` / `definitions` stay put because cyclic `$ref` pointers
+ * resolve against the root, and `$ref` stays because duplicating a cyclic
+ * reference into every branch changes its meaning.
+ */
+const ANYOF_PARENT_KEEP_KEYS = new Set([
+  '$comment',
+  '$defs',
+  '$ref',
+  '$schema',
+  'allOf',
+  'anyOf',
+  'default',
+  'definitions',
+  'description',
+  'else',
+  'if',
+  'not',
+  'oneOf',
+  'then',
+  'title',
+]);
+
+/**
+ * Push a node's own constraints down into its `anyOf` branches.
+ *
+ * Pythoughts's tool validator rejects `anyOf` used as a refinement of its parent:
+ * `type` must be declared inside the branches rather than beside them, and no
+ * other validation keyword (`properties`, `items`, `additionalProperties`, …)
+ * may appear on both the parent and a branch. Standard JSON Schema allows both,
+ * so schemas that are perfectly valid elsewhere are rejected on this wire.
+ *
+ * Distributing is lossless: `P ∧ (B₁ ∨ B₂)` and `(P ∧ B₁) ∨ (P ∧ B₂)` accept
+ * exactly the same instances. A branch that already declares a keyword keeps
+ * its own, which is the narrower of the two.
+ */
+function distributeAnyOfParentKeywords(node: Record<string, unknown>): void {
+  const branches = node['anyOf'];
+  if (!Array.isArray(branches) || branches.length === 0 || !branches.every(isRecord)) {
+    return;
+  }
+
+  const inherited = Object.keys(node).filter((key) => !ANYOF_PARENT_KEEP_KEYS.has(key));
+  if (inherited.length === 0) {
+    return;
+  }
+
+  for (const branch of branches) {
+    for (const key of inherited) {
+      if (!hasOwn(branch, key)) {
+        branch[key] = cloneJsonValue(node[key]);
+      }
+    }
+  }
+  for (const key of inherited) {
+    delete node[key];
+  }
 }
 
 function visitChildSchemas(node: Record<string, unknown>, visit: (schema: unknown) => void): void {

--- a/packages/kosong/test/providers/pythinker-schema.test.ts
+++ b/packages/kosong/test/providers/pythinker-schema.test.ts
@@ -612,6 +612,40 @@ describe('normalizePythinkerToolSchema', () => {
     });
   });
 
+  it('folds a root anyOf property declared differently across branches into an alternative', () => {
+    const result = normalizePythinkerToolSchema({
+      anyOf: [
+        { type: 'object', properties: { value: { type: 'string' } } },
+        { type: 'object', properties: { value: { type: 'integer' } } },
+      ],
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        value: { anyOf: [{ type: 'string' }, { type: 'integer' }] },
+      },
+    });
+  });
+
+  it('collapses a root anyOf property that is identical across every branch', () => {
+    const result = normalizePythinkerToolSchema({
+      anyOf: [
+        { type: 'object', properties: { mode: { type: 'string' }, task_id: { type: 'string' } } },
+        { type: 'object', properties: { mode: { type: 'string' }, shell_id: { type: 'string' } } },
+      ],
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        mode: { type: 'string' },
+        task_id: { type: 'string' },
+        shell_id: { type: 'string' },
+      },
+    });
+  });
+
   it('distributes into nested anyOf nodes and keeps narrower branch keywords', () => {
     const result = normalizePythinkerToolSchema({
       type: 'object',
@@ -637,6 +671,31 @@ describe('normalizePythinkerToolSchema', () => {
     });
   });
 
+  it('unions a parent required list with a branch that already declares its own', () => {
+    const result = normalizePythinkerToolSchema({
+      type: 'object',
+      properties: {
+        variant: {
+          type: 'object',
+          required: ['common'],
+          anyOf: [{ required: ['variant'] }, { required: ['common'] }],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        variant: {
+          anyOf: [
+            { type: 'object', required: ['variant', 'common'] },
+            { type: 'object', required: ['common'] },
+          ],
+        },
+      },
+    });
+  });
+
   it('leaves anyOf nodes alone when the parent only carries metadata', () => {
     const schema = {
       type: 'object',
@@ -651,23 +710,28 @@ describe('normalizePythinkerToolSchema', () => {
     expect(normalizePythinkerToolSchema(schema)).toEqual(schema);
   });
 
-  it('keeps cyclic $ref and definition buckets on the parent of an anyOf', () => {
+  it('keeps $ref and $defs on the anyOf parent instead of distributing them into branches', () => {
+    // $ref must be genuinely cyclic (self-referential) to survive derefJsonSchema
+    // and still be present by the time distributeAnyOfParentKeywords runs.
     const result = normalizePythinkerToolSchema({
       type: 'object',
       properties: {
         node: {
-          anyOf: [{ $ref: '#/$defs/Node' }, { type: 'null' }],
-        },
-      },
-      $defs: {
-        Node: {
-          type: 'object',
-          properties: { next: { $ref: '#/$defs/Node' } },
+          $ref: '#/properties/node',
+          $defs: { Extra: { type: 'string' } },
+          anyOf: [{ type: 'null' }],
         },
       },
     });
 
-    expect(result['$defs']).toBeDefined();
+    const node = (result['properties'] as Record<string, unknown>)['node'] as Record<string, unknown>;
+    expect(node['$ref']).toBe('#/properties/node');
+    expect(node['$defs']).toEqual({ Extra: { type: 'string' } });
+    const branches = node['anyOf'] as Record<string, unknown>[];
+    for (const branch of branches) {
+      expect(branch).not.toHaveProperty('$ref');
+      expect(branch).not.toHaveProperty('$defs');
+    }
   });
 
   it('dereferences and normalizes local definition buckets', () => {

--- a/packages/kosong/test/providers/pythinker-schema.test.ts
+++ b/packages/kosong/test/providers/pythinker-schema.test.ts
@@ -570,6 +570,106 @@ describe('normalizePythinkerToolSchema', () => {
     expect(normalizePythinkerToolSchema({})).toEqual({});
   });
 
+  it('drops a root anyOf that refines the root itself', () => {
+    // The TaskStop shape: `anyOf` says "one of these two fields is required".
+    // A tool's parameters must stay an object, so the branch form is unusable
+    // here and the requirement falls back to the tool's own runtime check.
+    const properties = {
+      task_id: { type: 'string' },
+      shell_id: { type: 'string' },
+    };
+
+    const result = normalizePythinkerToolSchema({
+      type: 'object',
+      description: 'Root doc.',
+      properties,
+      additionalProperties: false,
+      anyOf: [{ required: ['task_id'] }, { required: ['shell_id'] }],
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      description: 'Root doc.',
+      properties,
+      additionalProperties: false,
+    });
+  });
+
+  it('keeps the arguments of a root anyOf whose branches hold the properties', () => {
+    const result = normalizePythinkerToolSchema({
+      anyOf: [
+        { type: 'object', properties: { task_id: { type: 'string' } }, required: ['task_id'] },
+        { type: 'object', properties: { shell_id: { type: 'string' } }, required: ['shell_id'] },
+      ],
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        task_id: { type: 'string' },
+        shell_id: { type: 'string' },
+      },
+    });
+  });
+
+  it('distributes into nested anyOf nodes and keeps narrower branch keywords', () => {
+    const result = normalizePythinkerToolSchema({
+      type: 'object',
+      properties: {
+        target: {
+          type: 'array',
+          items: { type: 'string' },
+          anyOf: [{ minItems: 1 }, { items: { type: 'integer' } }],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        target: {
+          anyOf: [
+            { type: 'array', items: { type: 'string' }, minItems: 1 },
+            { type: 'array', items: { type: 'integer' } },
+          ],
+        },
+      },
+    });
+  });
+
+  it('leaves anyOf nodes alone when the parent only carries metadata', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        qs: {
+          description: 'A query, or a list of them.',
+          anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+        },
+      },
+    };
+
+    expect(normalizePythinkerToolSchema(schema)).toEqual(schema);
+  });
+
+  it('keeps cyclic $ref and definition buckets on the parent of an anyOf', () => {
+    const result = normalizePythinkerToolSchema({
+      type: 'object',
+      properties: {
+        node: {
+          anyOf: [{ $ref: '#/$defs/Node' }, { type: 'null' }],
+        },
+      },
+      $defs: {
+        Node: {
+          type: 'object',
+          properties: { next: { $ref: '#/$defs/Node' } },
+        },
+      },
+    });
+
+    expect(result['$defs']).toBeDefined();
+  });
+
   it('dereferences and normalizes local definition buckets', () => {
     const schema = {
       type: 'object',
@@ -755,42 +855,48 @@ describe('normalizePythinkerToolSchema', () => {
 
   it('preserves combinators while normalizing their schema branches', () => {
     const schema = {
-      anyOf: [{ enum: ['auto', 'manual'] }, { const: false }],
-      oneOf: [
-        {
-          properties: {
-            strategy: { enum: ['replace', 'insert'] },
-          },
+      properties: {
+        combined: {
+          anyOf: [{ enum: ['auto', 'manual'] }, { const: false }],
+          oneOf: [
+            {
+              properties: {
+                strategy: { enum: ['replace', 'insert'] },
+              },
+            },
+          ],
+          allOf: [
+            {
+              items: { const: 1 },
+            },
+          ],
         },
-      ],
-      allOf: [
-        {
-          items: { const: 1 },
-        },
-      ],
+      },
     };
 
     const result = normalizePythinkerToolSchema(schema);
 
-    expect(result).toEqual({
-      anyOf: [
-        { enum: ['auto', 'manual'], type: 'string' },
-        { const: false, type: 'boolean' },
-      ],
-      oneOf: [
-        {
-          type: 'object',
-          properties: {
-            strategy: { enum: ['replace', 'insert'], type: 'string' },
+    expect(result['properties']).toEqual({
+      combined: {
+        anyOf: [
+          { enum: ['auto', 'manual'], type: 'string' },
+          { const: false, type: 'boolean' },
+        ],
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              strategy: { enum: ['replace', 'insert'], type: 'string' },
+            },
           },
-        },
-      ],
-      allOf: [
-        {
-          type: 'array',
-          items: { const: 1, type: 'integer' },
-        },
-      ],
+        ],
+        allOf: [
+          {
+            type: 'array',
+            items: { const: 1, type: 'integer' },
+          },
+        ],
+      },
     });
     expect(result).not.toHaveProperty('type');
   });


### PR DESCRIPTION
## Related Issue

No existing issue — the problem is described below. This is a reproducible bug fix with a focused diff.

## Problem

Every request to a Kimi / Moonshot model fails before the model runs:

```
400 tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'root': when using anyOf, type should be defined in anyOf items
instead of the parent schema>
```

The wire validator refuses a tool schema that uses `anyOf` as a *refinement* of the
node it sits on. Two rules are involved:

- `type` may not appear next to `anyOf` on the same node.
- No validation keyword (`properties`, `items`, `additionalProperties`, …) may
  appear on both a node and one of its `anyOf` branches.

Both are legal standard JSON Schema, so schemas that work on every other provider
are rejected here. `TaskStop` trips them: it adds a hand-written
`anyOf: [{ required: ['task_id'] }, { required: ['shell_id'] }]` on top of an
object schema that already declares `type` and `properties`. Because tool
definitions are sent with every request, a single offending tool takes down the
whole session.

`normalizePythinkerToolSchema` already existed for exactly this class of
provider-compatibility repair, but it only visited *nested* property schemas and
deliberately skipped the root, so it never saw the offending node.

## What changed

The repair lives in the provider's schema normalizer rather than in `TaskStop`, so
MCP- and plugin-contributed schemas are covered by the same pass — this shape is
common enough that several other clients have hit it independently.

**Nested nodes — distribute.** A node's own constraints are pushed down into each
`anyOf` branch, and branches that already declare a keyword keep their own
(narrower) value. This is lossless: `P ∧ (B₁ ∨ B₂)` and `(P ∧ B₁) ∨ (P ∧ B₂)`
accept exactly the same instances. Sibling combinators (`allOf` / `oneOf` / `not` /
`if`) are left in place — the validator does not read them, so moving them would
only churn the schema.

**Root — fold away.** The root cannot use the branch form, because a tool's
parameters must be a plain object: the wire separately requires
`parameters.type == "object"`, which cannot coexist with a root `anyOf`. The two
constraints are jointly unsatisfiable, so the root's `anyOf` is dropped. That only
ever widens what is accepted, and a root `anyOf` is in practice a "one of these
fields is required" hint that the tool re-checks at run time (`TaskStop` already
returns `Missing required parameter: task_id`). Branch properties are merged into
the root first, so a schema that kept its arguments inside the branches does not
silently lose them.

## Verification

Rather than asserting against an assumed reading of the spec, every schema was
replayed through the provider's own validator:

- Reproduced the original 400 against the live endpoint, then confirmed it is gone.
- Replayed **all 36 built-in tool schemas and all 70 tool schemas from five
  connected MCP servers** through the normalizer and into the provider's validator:
  106 accepted, 0 rejected. Before the change, `TaskStop` was the single failure.
- Full `kosong` suite passes (1185 tests); `typecheck` clean.
- Each of the two new code paths was individually disabled to confirm the new tests
  actually fail without it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update — no user-facing behavior or CLI surface changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Kimi and Moonshot models when tools use combined schema types.
  * Fixed invalid tool schema errors involving `anyOf`, `oneOf`, and `allOf` combinations.
  * Improved normalization of nested and object-based tool schemas while preserving metadata, constraints, references, and definitions.
  * Reduced duplicate schema alternatives and improved handling of required fields.

* **Tests**
  * Added comprehensive coverage for root and nested schema normalization, cyclic definitions, and combinators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->