### PR TITLE
docs: require pull requests for every change to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,13 @@ Gate behind flags in `packages/agent-core/src/flags/registry.ts`. Check: `flags.
 
 ## Workflow
 
+- **Never commit to `main` directly.** Every change lands through a pull request: branch, push the
+  branch, open a PR, get the checks green, then merge. `main` enforces this for everyone including
+  admins, so a direct push is rejected outright (`GH006`) — do not try to work around it with
+  `--admin`, `--no-verify`, or a force push.
+- A PR is mergeable only when all six required checks pass (`build`, `test`, `lint`, `typecheck`,
+  `nix build .#pythinker-code`, `Check flake.nix workspace sync`), every review conversation is
+  resolved, and the branch is up to date with `main`.
 - Prefer `rg` / `rg --files` for code reading.
 - Follow existing boundaries and local patterns.
 - Replace internal identifiers with neutral placeholders in public text/test data. Audit diffs before PRs.


### PR DESCRIPTION
## Related Issue

No issue — this documents a repository setting change made directly on GitHub.

## Problem

`main` had branch protection, but `enforce_admins` was off and required approvals were `0`. Admins
bypassed every rule, so changes were landing on `main` by direct push with no PR and no gate. The
constraint existed on paper but not in practice.

## What changed

`main` branch protection now sets `enforce_admins: true`. Direct pushes are rejected for everyone,
admins included — verified by an empty commit that came back `GH006: Changes must be made through a
pull request`.

Required approvals stay at `0` deliberately: the repository has a single collaborator, and
`coderabbitai` only ever submits `COMMENTED` reviews, never `APPROVED`. Requiring an approval would
make every self-authored PR permanently unmergeable. The gate is therefore PR + green checks +
resolved conversations rather than a human approval signature.

This PR records the rule in `AGENTS.md`, where the other workflow constraints live, and is itself
the first change to go through the new flow.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — documentation only, nothing executable
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — docs-only, no CLI bump
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidelines requiring changes to be submitted through pull requests.
  * Documented requirements for passing checks, resolving review comments, and keeping branches up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->