### PR TITLE
fix(agent-core): keep profile-routed subagent model on resume and retry

### DIFF
--- a/.changeset/keep-subagent-routed-model.md
+++ b/.changeset/keep-subagent-routed-model.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Keep a subagent on the model and effort its profile assigns when the subagent is resumed or retried, instead of reverting it to the main agent's model.

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -169,6 +169,11 @@ export class ConfigState {
       : createProvider(providerConfig).supportsFastMode === true;
   }
 
+  /** Whether this agent's provider can resolve `modelAlias` at all. */
+  canResolveModel(modelAlias: string | undefined): boolean {
+    return this.tryResolveProviderFor(modelAlias) !== undefined;
+  }
+
   get profileName(): string | undefined {
     return this._profileName;
   }
@@ -195,8 +200,13 @@ export class ConfigState {
   }
 
   private tryResolvedProviderConfig(): ResolvedRuntimeProvider | undefined {
+    return this.tryResolveProviderFor(this._modelAlias);
+  }
+
+  private tryResolveProviderFor(modelAlias: string | undefined): ResolvedRuntimeProvider | undefined {
+    if (modelAlias === undefined) return undefined;
     try {
-      return this.resolvedProviderConfig;
+      return this.agent.modelProvider?.resolveProviderConfig(modelAlias);
     } catch {
       return undefined;
     }

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -238,10 +238,9 @@ export class SessionSubagentHost {
     const completion = this.runWithActiveChild(agentId, options, async (runOptions) => {
       this.emitSubagentSpawned(parent, agentId, profileName, runOptions);
       try {
-        child.config.update({
-          modelAlias: parent.config.modelAlias,
-          fastMode: parent.config.fastMode,
-        });
+        child.config.update(
+          this.childModelConfig(parent, child, this.tryResolveProfile(parent, profileName), runOptions),
+        );
         return await this.runPromptTurn(parent, agentId, child, profileName, runOptions);
       } catch (error) {
         this.emitSubagentFailed(parent, agentId, runOptions, error);
@@ -257,10 +256,9 @@ export class SessionSubagentHost {
     const completion = this.runWithActiveChild(agentId, options, async (runOptions) => {
       try {
         runOptions.signal.throwIfAborted();
-        child.config.update({
-          modelAlias: parent.config.modelAlias,
-          fastMode: parent.config.fastMode,
-        });
+        child.config.update(
+          this.childModelConfig(parent, child, this.tryResolveProfile(parent, profileName), runOptions),
+        );
         this.emitSubagentStarted(parent, agentId, runOptions.parentToolCallId);
         const turnId = child.turn.retry('agent-host');
         if (turnId === null) {
@@ -374,6 +372,43 @@ export class SessionSubagentHost {
     return metadata.dynamicWorkflowItem;
   }
 
+  /**
+   * Model selection for a child: explicit option → profile → parent. Resume and
+   * retry re-resolve through the same precedence, so a profile that routes its
+   * subagents to another model (and provider) is not silently replaced by the
+   * parent's model on the second turn.
+   *
+   * An alias the provider cannot resolve (e.g. a typo, or a session built on
+   * SingleModelProvider) falls back to the parent's model instead of failing at
+   * generate time. fastMode stays a straight inherit: it is a preference the
+   * provider layer already drops when the active model cannot serve it.
+   */
+  private childModelConfig(
+    parent: Agent,
+    child: Agent,
+    profile: ResolvedAgentProfile | undefined,
+    options: Pick<RunSubagentOptions, 'modelAlias' | 'thinkingLevel'>,
+  ): { modelAlias: string | undefined; thinkingLevel: string | undefined; fastMode: boolean } {
+    const requested = options.modelAlias ?? profile?.model;
+    const modelAlias =
+      requested !== undefined && child.config.canResolveModel(requested)
+        ? requested
+        : parent.config.modelAlias;
+    return {
+      modelAlias,
+      thinkingLevel: options.thinkingLevel ?? profile?.effort ?? parent.config.thinkingLevel,
+      fastMode: parent.config.fastMode,
+    };
+  }
+
+  private tryResolveProfile(parent: Agent, profileName: string): ResolvedAgentProfile | undefined {
+    try {
+      return this.resolveProfile(parent, profileName);
+    } catch {
+      return undefined;
+    }
+  }
+
   private resolveProfile(parent: Agent, profileName: string): ResolvedAgentProfile {
     const configuredProfiles = this.session.agentProfiles;
     const profile =
@@ -484,9 +519,7 @@ export class SessionSubagentHost {
     child.setKaos(child.kaos.withCwd(cwd));
     child.config.update({
       cwd,
-      modelAlias: options.modelAlias ?? profile?.model ?? parent.config.modelAlias,
-      thinkingLevel: options.thinkingLevel ?? profile?.effort ?? parent.config.thinkingLevel,
-      fastMode: parent.config.fastMode,
+      ...this.childModelConfig(parent, child, profile, options),
     });
 
     if (options.forkContext === true) {

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -1371,6 +1371,58 @@ describe('SessionSubagentHost', () => {
     expect(child.agent.config.modelAlias).toBe(parent.agent.config.modelAlias);
     expect(child.agent.config.modelAlias).not.toBe('stale-model-from-initial-spawn');
   });
+
+  it('keeps a profile-routed model and effort across resume', async () => {
+    const parent = testAgent();
+    parent.configure();
+    parent.agent.permission.setMode('yolo');
+
+    const child = testAgent();
+    child.configure({ tools: ['Read'] });
+    // Register a second alias so the child's provider can resolve the model the
+    // profile routes to (in production this is a [models."..."] config entry
+    // that may point at an entirely different provider).
+    child.configureRuntimeModel({ type: 'pythinker', apiKey: 'test-key', model: 'implementer-model' });
+    child.agent.context.appendUserMessage([{ type: 'text', text: 'Earlier context' }]);
+    child.mockNextResponse({
+      type: 'text',
+      text: 'Resumed the routed subagent from its earlier context and carried the assigned task through to completion, then reported a full and detailed technical summary of every change so the parent agent can continue without repeating any prior work.',
+    });
+
+    const implementerProfile: ResolvedAgentProfile = {
+      name: 'implementer',
+      description: 'Cheap implementer routed to another model.',
+      systemPrompt: () => 'implementer system prompt',
+      tools: ['Read'],
+      model: 'implementer-model',
+      effort: 'medium',
+    };
+    child.agent.useProfile(implementerProfile);
+
+    const session = Object.assign(
+      fakeSession(parent.agent, child.agent, {
+        'agent-0': { type: 'sub', parentAgentId: 'main' },
+      }),
+      { agentProfiles: { implementer: implementerProfile } },
+    );
+    const host = new SessionSubagentHost(session, 'main');
+
+    const handle = await host.resume('agent-0', {
+      parentToolCallId: 'call_agent',
+      prompt: 'Continue from context',
+      description: 'Continue work',
+      runInBackground: false,
+      signal,
+    });
+    await handle.completion;
+
+    // Resume must re-resolve through the spawn precedence rather than copying
+    // the parent's model, or a routed implementer silently reverts to the
+    // orchestrator's (expensive) model on its second turn.
+    expect(child.agent.config.modelAlias).toBe('implementer-model');
+    expect(child.agent.config.modelAlias).not.toBe(parent.agent.config.modelAlias);
+    expect(child.agent.config.thinkingLevel).toBe('medium');
+  });
 });
 
 describe('Session resume permission parent chain', () => {

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -1423,6 +1423,54 @@ describe('SessionSubagentHost', () => {
     expect(child.agent.config.modelAlias).not.toBe(parent.agent.config.modelAlias);
     expect(child.agent.config.thinkingLevel).toBe('medium');
   });
+
+  it('keeps a profile-routed model and effort across retry', async () => {
+    const parent = testAgent();
+    parent.configure();
+    parent.agent.permission.setMode('yolo');
+
+    const child = testAgent();
+    child.configure({ tools: ['Read'] });
+    child.configureRuntimeModel({ type: 'pythinker', apiKey: 'test-key', model: 'implementer-model' });
+    child.agent.context.appendUserMessage([{ type: 'text', text: 'Earlier context' }]);
+    child.mockNextResponse({
+      type: 'text',
+      text: 'Retried the routed subagent from its earlier context and carried the assigned task through to completion, then reported a full and detailed technical summary of every change so the parent agent can continue without repeating any prior work.',
+    });
+
+    const implementerProfile: ResolvedAgentProfile = {
+      name: 'implementer',
+      description: 'Cheap implementer routed to another model.',
+      systemPrompt: () => 'implementer system prompt',
+      tools: ['Read'],
+      model: 'implementer-model',
+      effort: 'medium',
+    };
+    child.agent.useProfile(implementerProfile);
+
+    const session = Object.assign(
+      fakeSession(parent.agent, child.agent, {
+        'agent-0': { type: 'sub', parentAgentId: 'main' },
+      }),
+      { agentProfiles: { implementer: implementerProfile } },
+    );
+    const host = new SessionSubagentHost(session, 'main');
+
+    const handle = await host.retry('agent-0', {
+      parentToolCallId: 'call_agent',
+      prompt: 'Continue from context',
+      description: 'Continue work',
+      runInBackground: false,
+      signal,
+    });
+    await handle.completion;
+
+    // Retry re-runs the last turn, so it must re-resolve the routed model the
+    // same way resume does instead of inheriting the parent's.
+    expect(child.agent.config.modelAlias).toBe('implementer-model');
+    expect(child.agent.config.modelAlias).not.toBe(parent.agent.config.modelAlias);
+    expect(child.agent.config.thinkingLevel).toBe('medium');
+  });
 });
 
 describe('Session resume permission parent chain', () => {


### PR DESCRIPTION
## Related Issue

No issue — problem described below.

## Problem

An agent profile can route its subagents to a different model (a cheap
implementer under an expensive orchestrator, for example). That routing only
held on the initial spawn: resuming or retrying a subagent copied the parent
agent's model alias onto the child, so from the second turn on the subagent
silently ran on the orchestrator's model and the profile's effort setting was
dropped.

## What changed

Resume and retry now re-resolve the child's model through the same precedence
as spawn — explicit run option, then profile, then parent — instead of copying
the parent's model. An alias the child's provider cannot resolve falls back to
the parent's model rather than failing at generate time. Added a regression
test covering resume with a profile-routed model and effort.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (internal behavior, no CLI docs surface)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subagents now retain their assigned model and effort settings when resumed or retried.
  * Invalid or unavailable model aliases gracefully fall back to the parent agent’s model.
  * Profile configuration issues no longer prevent subagent resume or retry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->