### PR TITLE
fix(vscode): allow /yolo and /auto before the first message

### DIFF
--- a/.changeset/vscode-inline-code-color.md
+++ b/.changeset/vscode-inline-code-color.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Brighten the periwinkle accent in the VS Code extension's dark theme so inline code in chat is easier to read.

--- a/.changeset/vscode-permission-command-before-first-message.md
+++ b/.changeset/vscode-permission-command-before-first-message.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Let `/yolo` and `/auto` be used in the VS Code extension before the first message is sent — the request now applies to the session that chat opens next instead of failing with "Could not change the permission mode."

--- a/apps/vscode/src/handlers/chat.handler.ts
+++ b/apps/vscode/src/handlers/chat.handler.ts
@@ -6,6 +6,7 @@ import type { ApprovalResponse, ContentPart } from "../../shared/legacy-sdk";
 import { getUserMessage } from "../../shared/errors";
 import type { ErrorPhase } from "../../shared/types";
 import { VSCodeSettings } from "../config/vscode-settings";
+import { defaultPermissionMode } from "../runtime/permission-mode";
 import { normalizeEffort } from "../runtime/pythinker-runtime";
 import type { SessionRuntime } from "../runtime/session-runtime";
 import { isWorkspacePathContained, relativeWorkspacePath } from "../utils/workspace-path";
@@ -177,15 +178,21 @@ const setPlanMode: Handler<{ enabled: boolean }, { ok: boolean; planMode: boolea
 /**
  * `/yolo` and `/auto` are control commands, not turns: the webview sends them
  * here instead of through the chat queue so they still take effect while the
- * agent is running — which is exactly when a pending approval blocks it.
+ * agent is running — which is exactly when a pending approval blocks it. Before
+ * the first message there is no session yet, so the request is parked on the
+ * view and applied to the session that view opens next.
  */
 const setPermissionMode: Handler<
   { mode: "yolo" | "auto"; request: PermissionCommandRequest },
   { ok: boolean; mode?: PermissionMode; message?: string }
 > = async (params, ctx) => {
-  const runtime = ctx.getSession();
-  if (runtime === undefined) return { ok: false };
-  const result = await applyPermissionCommand(runtime, params.mode, params.request);
+  const target =
+    ctx.getSession() ??
+    ctx.runtime.pendingPermissionTarget(
+      ctx.webviewId,
+      defaultPermissionMode(VSCodeSettings.yoloMode),
+    );
+  const result = await applyPermissionCommand(target, params.mode, params.request);
   return { ok: true, mode: result.mode, message: result.message };
 };
 

--- a/apps/vscode/src/handlers/slash-command.ts
+++ b/apps/vscode/src/handlers/slash-command.ts
@@ -10,6 +10,7 @@ import {
   type SkillSummary,
 } from "@pythoughts/pythinker-code-sdk";
 
+import type { PermissionModeTarget } from "../runtime/permission-mode";
 import type { SessionRuntime } from "../runtime/session-runtime";
 import {
   buildExportMarkdown,
@@ -167,10 +168,11 @@ export function parsePermissionCommandRequest(args: string): PermissionCommandRe
 /**
  * Applies a `/yolo` or `/auto` request and reports the resulting mode. Callers
  * own how the message is surfaced, so this runs identically whether the command
- * came in between turns or mid-turn over the bridge.
+ * came in between turns, mid-turn over the bridge, or before the view has a
+ * session at all.
  */
 export async function applyPermissionCommand(
-  runtime: SessionRuntime,
+  runtime: PermissionModeTarget,
   mode: "yolo" | "auto",
   request: PermissionCommandRequest,
 ): Promise<{ mode: PermissionMode; message: string }> {

--- a/apps/vscode/src/runtime/permission-mode.ts
+++ b/apps/vscode/src/runtime/permission-mode.ts
@@ -39,6 +39,17 @@ export async function persistPermissionMode(
   });
 }
 
+/**
+ * What `/yolo` and `/auto` act on. A live session is the usual target, but the
+ * command also arrives before the view has one, so the pending target below
+ * satisfies the same shape.
+ */
+export interface PermissionModeTarget {
+  readonly permissionMode: PermissionMode;
+  setPermissionMode(mode: PermissionMode): Promise<void>;
+  togglePermissionMode(mode: Exclude<PermissionMode, "manual">): Promise<PermissionMode>;
+}
+
 /** The `pythinker.yoloMode` setting seeds new sessions; it never overrides a stored mode. */
 export function defaultPermissionMode(yoloModeSetting: boolean): PermissionMode {
   return yoloModeSetting ? "yolo" : "manual";

--- a/apps/vscode/src/runtime/pythinker-runtime.ts
+++ b/apps/vscode/src/runtime/pythinker-runtime.ts
@@ -239,8 +239,13 @@ export class PythinkerRuntime {
   ): Promise<void> {
     const pending = this.pendingPermissionByView.get(webviewId);
     if (pending === undefined) return;
-    this.pendingPermissionByView.delete(webviewId);
     await runtime.setPermissionMode(pending);
+    // Dropped only once it landed, and only if it is still the request in hand:
+    // a failed apply keeps the command for the next attempt, and a command that
+    // arrived during the await outranks the one just applied.
+    if (this.pendingPermissionByView.get(webviewId) === pending) {
+      this.pendingPermissionByView.delete(webviewId);
+    }
   }
 
   private wrapSession(session: Session, permissionMode: PermissionMode): SessionRuntime {

--- a/apps/vscode/src/runtime/pythinker-runtime.ts
+++ b/apps/vscode/src/runtime/pythinker-runtime.ts
@@ -12,6 +12,7 @@ import {
   permissionModeMetadata,
   persistPermissionMode,
   readPermissionMode,
+  type PermissionModeTarget,
 } from "./permission-mode";
 import { SessionRuntime } from "./session-runtime";
 import { areSameFsPath } from "../utils/fs-path";
@@ -47,6 +48,7 @@ export class PythinkerRuntime {
   private readonly log: PythinkerRuntimeOptions["log"];
   private readonly sessions = new Map<string, SessionRuntime>();
   private readonly sessionByView = new Map<string, string>();
+  private readonly pendingPermissionByView = new Map<string, PermissionMode>();
   private closed = false;
 
   constructor(options: PythinkerRuntimeOptions) {
@@ -72,6 +74,29 @@ export class PythinkerRuntime {
 
   getSession(id: string): SessionRuntime | undefined {
     return this.sessions.get(id);
+  }
+
+  /**
+   * `/yolo` and `/auto` are usable before the view has opened a session — the
+   * first message is what creates one. The request is held per view and applied
+   * to the session that view opens next, so the command is never just lost.
+   */
+  pendingPermissionTarget(webviewId: string, fallback: PermissionMode): PermissionModeTarget {
+    const pending = this.pendingPermissionByView;
+    const target: PermissionModeTarget = {
+      get permissionMode(): PermissionMode {
+        return pending.get(webviewId) ?? fallback;
+      },
+      async setPermissionMode(mode: PermissionMode): Promise<void> {
+        pending.set(webviewId, mode);
+      },
+      async togglePermissionMode(mode: Exclude<PermissionMode, "manual">): Promise<PermissionMode> {
+        const next = target.permissionMode === mode ? "manual" : mode;
+        await target.setPermissionMode(next);
+        return next;
+      },
+    };
+    return target;
   }
 
   async openSession(options: OpenSessionOptions): Promise<SessionRuntime> {
@@ -119,6 +144,7 @@ export class PythinkerRuntime {
       }
     }
 
+    await this.applyPendingPermissionMode(options.webviewId, runtime);
     runtime.subscribe(options.webviewId);
     this.sessionByView.set(options.webviewId, runtime.id);
     await runtime.announceStatus(options.webviewId);
@@ -149,6 +175,7 @@ export class PythinkerRuntime {
         throw error;
       }
     }
+    await this.applyPendingPermissionMode(webviewId, runtime);
     runtime.subscribe(webviewId);
     this.sessionByView.set(webviewId, runtime.id);
     await runtime.announceStatus(webviewId);
@@ -203,6 +230,17 @@ export class PythinkerRuntime {
     this.sessions.clear();
     this.sessionByView.clear();
     await this.harness.close();
+  }
+
+  /** Hands a `/yolo` or `/auto` issued before this view had a session to the session it just got. */
+  private async applyPendingPermissionMode(
+    webviewId: string,
+    runtime: SessionRuntime,
+  ): Promise<void> {
+    const pending = this.pendingPermissionByView.get(webviewId);
+    if (pending === undefined) return;
+    this.pendingPermissionByView.delete(webviewId);
+    await runtime.setPermissionMode(pending);
   }
 
   private wrapSession(session: Session, permissionMode: PermissionMode): SessionRuntime {

--- a/apps/vscode/test/pythinker-runtime.test.ts
+++ b/apps/vscode/test/pythinker-runtime.test.ts
@@ -480,6 +480,19 @@ describe("Pythinker runtime (owns shared SDK sessions for Webviews)", () => {
     await expect(opened.session.getStatus()).resolves.toMatchObject({ permission: "yolo" });
   });
 
+  it("applies a permission mode requested before the view had a session", async () => {
+    const { runtime } = createRuntime();
+    const target = runtime.pendingPermissionTarget("view-1", "manual");
+
+    expect(await target.togglePermissionMode("yolo")).toBe("yolo");
+    const opened = await runtime.openSession(openOptions({ webviewId: "view-1" }));
+
+    expect(opened.permissionMode).toBe("yolo");
+    await expect(opened.session.getStatus()).resolves.toMatchObject({ permission: "yolo" });
+    // Consumed once: the next session opened by that view starts from its own mode.
+    expect(runtime.pendingPermissionTarget("view-1", "manual").permissionMode).toBe("manual");
+  });
+
   it("persists a mode change so the next attach restores it", async () => {
     const { runtime, sdk } = createRuntime();
     const session = sdk.addSession("saved-1", "/workspace", { permission: "manual" });

--- a/apps/vscode/test/pythinker-runtime.test.ts
+++ b/apps/vscode/test/pythinker-runtime.test.ts
@@ -493,6 +493,22 @@ describe("Pythinker runtime (owns shared SDK sessions for Webviews)", () => {
     expect(runtime.pendingPermissionTarget("view-1", "manual").permissionMode).toBe("manual");
   });
 
+  it("keeps a pending permission mode when applying it to the session fails", async () => {
+    const { runtime, sdk } = createRuntime();
+    const boundary = sdk.addSession("saved-1", "/workspace");
+    (boundary.session as { setPermission: (mode: PermissionMode) => Promise<void> }).setPermission =
+      async () => {
+        throw new Error("engine offline");
+      };
+    await runtime.pendingPermissionTarget("view-1", "manual").setPermissionMode("yolo");
+
+    await expect(
+      runtime.openSession(openOptions({ webviewId: "view-1", sessionId: "saved-1" })),
+    ).rejects.toThrow("engine offline");
+
+    expect(runtime.pendingPermissionTarget("view-1", "manual").permissionMode).toBe("yolo");
+  });
+
   it("persists a mode change so the next attach restores it", async () => {
     const { runtime, sdk } = createRuntime();
     const session = sdk.addSession("saved-1", "/workspace", { permission: "manual" });

--- a/apps/vscode/webview-ui/src/styles/index.css
+++ b/apps/vscode/webview-ui/src/styles/index.css
@@ -51,7 +51,7 @@
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   /* Muted periwinkle accent (CLI primary), dark variant. */
-  --brand: #aab3e8;
+  --brand: #b3b9f4;
   /* CLI darkColors.success — the "on" colour for toggles. */
   --success: #4ec87e;
   --success-foreground: oklch(0.141 0.005 285.823);


### PR DESCRIPTION
## Related Issue

No issue filed — the problem is described below.

## Problem

In the VS Code extension, typing `/yolo` (or `/auto`) before sending anything to the agent shows a "Could not change the permission mode." toast and does nothing. The same command works once a message has been sent.

`/yolo` and `/auto` take a control path to the extension host instead of the chat queue, so they still work mid-turn. That handler resolves the view's session and returns `{ ok: false }` when there is none — and a session is only created lazily, by the first message. Setting the mode up front, which is exactly when a user reaches for `/yolo`, was therefore the one case that always failed.

## What changed

The request is parked on the view and applied to the session that view opens next, so the command is never dropped:

- `PythinkerRuntime` holds a pending permission mode per webview and hands it to the session on open/attach, consuming it once.
- The `setPermissionMode` handler falls back to that pending target when the view has no session, seeded from the `pythinker.yoloMode` setting so a toggle reports the right resulting mode and message.
- `applyPermissionCommand` now takes a small target interface that both a live session and the pending target satisfy, so the toggle semantics and toast wording are identical in either path.

Also brightens the dark-theme periwinkle accent (`--brand`) used for inline code in chat, which was hard to read against the message background.

Covered by a new case in the runtime tests: a mode requested with no session is applied to the next session opened by that view, and is not reapplied afterwards. Verified the test fails when the apply step is removed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VS Code `/yolo` and `/auto` permission commands now work before the first message and apply to the next session.
* **Style**
  * Improved dark-theme inline-code readability with a brighter periwinkle accent.
* **Bug Fixes**
  * Permission settings are preserved when a session has not yet been opened and applied automatically when it starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->