### PR TITLE
fix(release): advertise only published versions on the update channel

### DIFF
--- a/.changeset/update-channel-published-versions-only.md
+++ b/.changeset/update-channel-published-versions-only.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Stop offering updates to versions that were never published: the update channel now advertises only the release that is actually available for download.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,15 +203,23 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-  # code.pythinker.com redeploys via Dokploy autodeploy on push to main
-  # (app Pythinker/code builds apps/site/Dockerfile from the repo, no npm
-  # registry dependency), so no deploy webhook is fired here — this job only
-  # verifies the published release is internally consistent.
+  # code.pythinker.com redeploys via Dokploy autodeploy on push to main (app
+  # Pythinker/code builds apps/site/Dockerfile from the repo), so no deploy
+  # webhook is fired here — this job verifies that the published release is
+  # internally consistent and that the CDN is not advertising a version npm
+  # does not have.
+  #
+  # It also runs on a `ci: release packages` merge that published nothing: that
+  # commit bumps the version on main, so gating the check on a successful
+  # publish hid the one case where the version and the published artifacts
+  # diverge — and every client polled the CDN for a release that never existed.
   verify-cdn-release:
     timeout-minutes: 15
     name: Verify release consistency
     needs: release
-    if: needs.release.outputs.packages_published == 'true'
+    if: >-
+      needs.release.outputs.packages_published == 'true'
+      || startsWith(github.event.head_commit.message, 'ci: release packages')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/apps/site/scripts/build-cdn.mjs
+++ b/apps/site/scripts/build-cdn.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { access, cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, parse, resolve } from 'node:path';
@@ -27,6 +28,47 @@ function parseArgs() {
   }
   if (!out) throw new Error('Usage: build-cdn.mjs --out <dir> [--skip-rg]');
   return { out, skipRg };
+}
+
+/**
+ * Resolve the version this CDN advertises from a *published* release, never from
+ * the working tree.
+ *
+ * `apps/pythinker-code/package.json` is bumped by the `ci: release packages`
+ * merge and this site autodeploys on every push to main, so deriving the
+ * manifest from it advertised the next version the moment that merge landed —
+ * before the npm publish and the GitHub release assets existed, and permanently
+ * when the publish never ran at all. Installed clients then polled GitHub for
+ * assets that did not exist (~6 minutes per launch, every launch). The npm
+ * dist-tag is the publish barrier, so it is the only safe source.
+ *
+ * `publishedAt` comes from npm's own publish timestamp: stamping build time made
+ * every unrelated site deploy re-anchor the clients' rollout eligibility window.
+ *
+ * A registry read failure throws on purpose: a failed image build leaves the
+ * previous container serving the last good manifest, which is the safe outcome.
+ */
+async function resolvePublishedRelease(packageName) {
+  const pinned = process.env.PYTHINKER_CDN_VERSION?.trim();
+  if (pinned) return { version: pinned, publishedAt: new Date().toISOString() };
+  const view = JSON.parse(
+    execFileSync(
+      'npm',
+      ['view', packageName, 'dist-tags', 'time', '--json', '--registry=https://registry.npmjs.org'],
+      { encoding: 'utf8', timeout: 60_000 },
+    ),
+  );
+  const version = view['dist-tags']?.latest;
+  if (typeof version !== 'string' || !/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(
+      `npm dist-tag latest for ${packageName} is not a release version: ${String(version)}`,
+    );
+  }
+  const publishedAt = view.time?.[version];
+  return {
+    version,
+    publishedAt: typeof publishedAt === 'string' ? publishedAt : new Date().toISOString(),
+  };
 }
 
 async function copyPlugins(repoRoot, cdnRoot) {
@@ -101,10 +143,11 @@ const repoRoot = await findRepoRoot();
 const packageJson = JSON.parse(
   await readFile(join(repoRoot, 'apps/pythinker-code/package.json'), 'utf8'),
 );
-const version = packageJson.version;
-if (typeof version !== 'string' || version.trim() === '') {
-  throw new Error('apps/pythinker-code/package.json has no version');
+const packageName = packageJson.name;
+if (typeof packageName !== 'string' || packageName.trim() === '') {
+  throw new Error('apps/pythinker-code/package.json has no name');
 }
+const { version, publishedAt } = await resolvePublishedRelease(packageName);
 
 const siteDist = join(repoRoot, 'apps/site/dist');
 await access(join(siteDist, 'index.html'));
@@ -126,7 +169,7 @@ await mkdir(channelRoot, { recursive: true });
 await writeFile(join(channelRoot, 'latest'), `${version}\n`);
 await writeFile(join(channelRoot, 'latest.json'), `${JSON.stringify({
   version,
-  publishedAt: new Date().toISOString(),
+  publishedAt,
   rollout: [],
 }, null, 2)}\n`);
 await cp(

--- a/apps/site/scripts/build-cdn.mjs
+++ b/apps/site/scripts/build-cdn.mjs
@@ -30,6 +30,8 @@ function parseArgs() {
   return { out, skipRg };
 }
 
+const RELEASE_VERSION = /^\d+\.\d+\.\d+$/;
+
 /**
  * Resolve the version this CDN advertises from a *published* release, never from
  * the working tree.
@@ -50,7 +52,18 @@ function parseArgs() {
  */
 async function resolvePublishedRelease(packageName) {
   const pinned = process.env.PYTHINKER_CDN_VERSION?.trim();
-  if (pinned) return { version: pinned, publishedAt: new Date().toISOString() };
+  if (pinned) {
+    // The override answers to the same shape rule as the registry path below.
+    // A client rejects a manifest whose `version` is not semver, so an
+    // unusable override has to stop the build instead of publishing a
+    // latest.json that every installed client fails to parse.
+    if (!RELEASE_VERSION.test(pinned)) {
+      throw new Error(`PYTHINKER_CDN_VERSION is not a release version: ${pinned}`);
+    }
+    // Build time is the only timestamp available for a manual pin; the
+    // registry path below requires npm's own and never stamps one.
+    return { version: pinned, publishedAt: new Date().toISOString() };
+  }
   const view = JSON.parse(
     execFileSync(
       'npm',
@@ -59,16 +72,21 @@ async function resolvePublishedRelease(packageName) {
     ),
   );
   const version = view['dist-tags']?.latest;
-  if (typeof version !== 'string' || !/^\d+\.\d+\.\d+$/.test(version)) {
+  if (typeof version !== 'string' || !RELEASE_VERSION.test(version)) {
     throw new Error(
       `npm dist-tag latest for ${packageName} is not a release version: ${String(version)}`,
     );
   }
   const publishedAt = view.time?.[version];
-  return {
-    version,
-    publishedAt: typeof publishedAt === 'string' ? publishedAt : new Date().toISOString(),
-  };
+  // Stamping build time here is the bug this function documents: it would move
+  // the rollout anchor on every unrelated site deploy. Unreadable registry
+  // metadata is a failed read, and a failed read must fail the build.
+  if (typeof publishedAt !== 'string' || !Number.isFinite(Date.parse(publishedAt))) {
+    throw new Error(
+      `npm has no usable publish time for ${packageName}@${version}: ${String(publishedAt)}`,
+    );
+  }
+  return { version, publishedAt };
 }
 
 async function copyPlugins(repoRoot, cdnRoot) {

--- a/scripts/release/verify-release-consistency.mjs
+++ b/scripts/release/verify-release-consistency.mjs
@@ -4,9 +4,20 @@ import { readFileSync } from 'node:fs';
 const PACKAGE_NAME = '@pythoughts/pythinker-code';
 const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
+const CDN_MANIFEST_URL = 'https://code.pythinker.com/pythinker-code/latest.json';
+
 function fail(reason) {
   console.error(`consistency failed: ${reason}`);
   process.exit(1);
+}
+
+/** Numeric major/minor/patch compare over two SEMVER regex matches. */
+function compareRelease(left, right) {
+  for (let index = 1; index <= 3; index += 1) {
+    const diff = Number(left[index]) - Number(right[index]);
+    if (diff !== 0) return diff;
+  }
+  return 0;
 }
 
 let localVersion;
@@ -48,5 +59,32 @@ try {
   fail(`cannot read git tags: ${error.message}`);
 }
 if (!gitTags.trim().split('\n').includes(releaseTag)) fail(`missing git tag ${releaseTag}`);
+
+// The CDN manifest is what every installed client polls for updates, so a
+// version it advertises that npm does not have sends all of them into an install
+// that cannot succeed. Ahead of npm is a hard failure; behind is deploy lag,
+// since the site rebuilds on the next push to main.
+let cdnVersion;
+try {
+  const response = await fetch(CDN_MANIFEST_URL, { signal: AbortSignal.timeout(15_000) });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  cdnVersion = JSON.parse(await response.text()).version;
+} catch (error) {
+  console.warn(`warning: cannot read the CDN manifest (${error.message}) — CDN check skipped`);
+}
+
+if (typeof cdnVersion === 'string' && cdnVersion !== distTags.latest) {
+  const cdnMatch = cdnVersion.match(SEMVER);
+  if (!cdnMatch) fail(`CDN manifest version is not semver: ${cdnVersion}`);
+  if (compareRelease(cdnMatch, latestMatch) > 0) {
+    fail(
+      `CDN advertises ${cdnVersion} but npm latest is ${distTags.latest} — ` +
+        'clients would try to install a release that does not exist',
+    );
+  }
+  console.log(
+    `CDN is behind npm (cdn=${cdnVersion} latest=${distTags.latest}); it catches up on the next push to main`,
+  );
+}
 
 console.log(`consistency OK: latest=${distTags.latest} beta=${distTags.beta ?? '-'} dev=${distTags.dev ?? '-'}`);


### PR DESCRIPTION
## Related Issue

No issue filed — the problem is described below.

## Problem

Every installed client was being told to install a version that does not exist.

- `https://code.pythinker.com/pythinker-code/latest.json` advertised **0.11.0**.
- npm `dist-tags.latest` was **0.9.2**; there is no 0.10.0 and no 0.11.0 on npm.
- The latest GitHub release was **0.9.2**; there are no 0.10.0 or 0.11.0 release assets.

Two independent causes:

1. `apps/site/scripts/build-cdn.mjs` derived the advertised version from
   `apps/pythinker-code/package.json`. That file is bumped by the `ci: release packages` merge, and
   the site autodeploys on every push to main, so the CDN advertised the next version the moment the
   version PR merged — before npm and the release assets had it, and permanently when the publish
   never ran. The manifest also stamped `publishedAt` with the site *build* time, so every unrelated
   deploy re-anchored the clients' rollout eligibility window.

2. Publishing is gated on `steps.changesets.outputs.published`, and the changesets action only
   publishes when no changeset is pending. When a changeset lands on main while the version PR is
   open, merging that PR bumps the version and opens the *next* version PR instead of publishing —
   `published` stays false, all six publish jobs skip, and the run is **green**. This happened twice
   in a row (0.10.0, then 0.11.0). `scripts/release/verify-release-consistency.mjs` already compares
   the local version against the npm dist-tag and would have failed loudly, but its job is gated on
   the same successful-publish condition, so it was skipped exactly when it mattered.

Client-side effect: the native installer polled GitHub for missing release assets for ~360 s on every
launch, and `/update` reported an install "already in progress" that could never finish.

## What changed

- `apps/site/scripts/build-cdn.mjs`: resolve the advertised version from the npm `dist-tags.latest`
  of `@pythoughts/pythinker-code` instead of the working tree, and take `publishedAt` from npm's own
  publish timestamp for that version. `PYTHINKER_CDN_VERSION` pins it for local or offline builds.
  A registry read failure throws on purpose: a failed image build leaves the previous container
  serving the last good manifest, which is the safe direction.
- `scripts/release/verify-release-consistency.mjs`: also fail when the live CDN manifest advertises a
  version **newer** than the npm dist-tag. Being behind npm is only deploy lag, so that logs and
  passes.
- `.github/workflows/release.yml`: run the consistency job on `ci: release packages` merges too, not
  only when a publish succeeded, so a version bump that published nothing turns the run red instead
  of skipping the only guard.

Scope note: this makes the update channel truthful and makes the divergence loud. It does not change
the changesets publish path itself — a skipped version number is cosmetic, and surgery on the
irreversible npm publish step does not belong in the same PR.

`github.event.head_commit.message` is used inside an `if:` expression via `startsWith()`, evaluated by
the Actions expression engine; it is never interpolated into a `run:` block.

## Verification

No test harness exists for `apps/site/scripts/*.mjs` or `scripts/release/*.mjs`, so both scripts were
run directly:

- `node apps/site/scripts/build-cdn.mjs --out … --skip-rg` now emits
  `{"version": "0.9.2", "publishedAt": "2026-08-05T23:15:55.254Z", "rollout": []}` — the published
  version, with npm's real publish time.
- `node scripts/release/verify-release-consistency.mjs` fails with
  `consistency failed: local version 0.11.0 does not match latest 0.9.2`, which is the alarm this PR
  un-gates.
- The version comparator was checked against ordering cases including `0.10.0` vs `0.9.10` and
  `0.9.10` vs `0.9.9`.
- `pnpm lint` passes; the pre-push gates pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — no test harness covers these two scripts; see Verification above. The un-gated consistency job now acts as the CI check for the manifest generator.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update notifications now advertise only published versions available for download.
  * Release metadata now reflects the actual publication time.
  * Invalid, unavailable, or prematurely advertised releases are rejected.
* **Reliability**
  * Improved consistency checks between downloads, CDN data, and the latest published version.
  * Release verification now handles delayed CDN updates safely.
  * Release information remains accurate when package publication and CDN deployment occur at different times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->