### PR TITLE
fix(ci): send X-GitHub-Event on the CDN deploy webhook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,21 +250,29 @@ jobs:
               exit 0
               ;;
           esac
-          # The webhook matches the branch from the request body: a bare POST
-          # answers 301 {"message":"Branch Not Match"} and deploys nothing.
+          # The webhook reads the branch from the body, but only when the
+          # request also carries `X-GitHub-Event`: Dokploy's extractBranchName
+          # returns null without that header, so the request answers
+          # 301 {"message":"Branch Not Match"} and deploys nothing.
+          #
+          # 301 is not an error status, so `--fail` does not see it and curl
+          # exits 0. Capture the status code and treat anything but 2xx as a
+          # failed deploy.
           #
           # A transient failure must never fail the workflow. npm has already
           # published by now and that is irreversible, so dying here buys
           # nothing — an earlier version of this job was deleted because a
           # curl exit-28 timeout failed the 0.5.0 release. verify-cdn-release
-          # polls the manifest and is the gate that fails loudly. `--fail` is
-          # what makes an HTTP error status reach the retries and the warning
-          # instead of exiting 0 and reading as a successful deploy.
-          curl -sS --fail -X POST "$WEBHOOK" \
+          # polls the manifest and is the gate that fails loudly.
+          status=$(curl -sS -o /dev/stderr -w '%{http_code}' -X POST "$WEBHOOK" \
             -H 'Content-Type: application/json' \
+            -H 'X-GitHub-Event: push' \
             -d '{"ref":"refs/heads/main"}' \
-            --retry 3 --retry-all-errors --retry-delay 10 --max-time 60 \
-            || echo "::warning::CDN redeploy webhook failed — verify-cdn-release will catch a stale CDN."
+            --retry 3 --retry-all-errors --retry-delay 10 --max-time 60) || status=000
+          case "$status" in
+            2*) echo "CDN redeploy triggered (HTTP $status)." ;;
+            *) echo "::warning::CDN redeploy webhook returned HTTP $status — verify-cdn-release will catch a stale CDN." ;;
+          esac
 
   # Verifies that the published release is internally consistent and that the
   # CDN caught up with npm. It polls, so it must run after redeploy-cdn.


### PR DESCRIPTION
## Related Issue

No issue — the 0.13.1 release run failed in CI; the problem is described below.

## Problem

The `Redeploy CDN` job of the 0.13.1 release reported success but deployed
nothing, and `Verify release consistency` then failed after 600s with
`cdn=0.13.0 latest=0.13.1`, so the release stayed invisible to installed
clients.

Two causes:

1. Dokploy's `extractBranchName` reads `body.ref` **only** when the request
   carries an `X-GitHub-Event` (or gitea/gitlab/bitbucket) header. Without it
   the branch resolves to `null`, the handler answers
   `301 {"message":"Branch Not Match"}` and no deploy is queued.
2. `301` is not an error status, so `curl --fail` did not trip and the job
   exited 0 — the failed deploy read as a successful one.

Verified against the live webhook: the same POST plus
`-H 'X-GitHub-Event: push'` answers `200 {"message":"Application deployed
successfully"}`, and `https://code.pythinker.com/pythinker-code/latest.json`
now serves `0.13.1`. The re-run of `Verify release consistency` on the release
run is green.

## What changed

- Send `X-GitHub-Event: push` with the Dokploy deploy webhook.
- Capture the HTTP status and warn on anything that is not `2xx`, instead of
  relying on `--fail`, which cannot see a `301`. The job still never fails the
  workflow — `verify-cdn-release` remains the loud gate.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — not testable in the
      repo; verified against the live Dokploy webhook (200 + CDN now at 0.13.1).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — CI-only
      change, no package bump.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CDN redeployment reliability by adding automatic retries.
  * Added clearer handling and warnings for unsuccessful webhook responses.
  * Ensured successful redeployments are recognized only for valid 2xx responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->