### PR TITLE
feat(agent): record the origin that entered dynamic workflow mode

### DIFF
--- a/.changeset/workflow-enter-origin.md
+++ b/.changeset/workflow-enter-origin.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Record the origin of the prompt that entered Dynamic Workflow mode, so a fan-out started by a scheduled job or hook is attributable in the session records.

--- a/packages/agent-core/src/agent/dynamic-workflow/index.ts
+++ b/packages/agent-core/src/agent/dynamic-workflow/index.ts
@@ -18,7 +18,14 @@ export class DynamicWorkflowMode {
 
   enter(trigger: DynamicWorkflowModeTrigger): void {
     if (this.active !== null) return;
-    this.agent.records.logRecord({ type: 'dynamic_workflow_mode.enter', trigger });
+    this.agent.records.logRecord({
+      type: 'dynamic_workflow_mode.enter',
+      trigger,
+      // The 'tool' trigger always fires inside a turn, so the origin names
+      // what drove the model to fan out (user, cron, hook, ...). The RPC
+      // triggers run between turns and record no origin.
+      origin: this.agent.turn.activeTurnOrigin,
+    });
     this.active = trigger;
     if (trigger !== 'tool') {
       const sizeNote = workflowSizeGuidelineNote(

--- a/packages/agent-core/src/agent/records/types.ts
+++ b/packages/agent-core/src/agent/records/types.ts
@@ -54,6 +54,12 @@ export interface AgentRecordEvents {
 
   'dynamic_workflow_mode.enter': {
     trigger: DynamicWorkflowModeTrigger;
+    /**
+     * Origin of the prompt whose turn entered the mode, so a cron- or
+     * hook-originated fan-out is attributable after the fact. Absent when the
+     * mode was entered outside a turn (e.g. the explicit RPC toggle).
+     */
+    origin?: PromptOrigin;
   };
   'dynamic_workflow_mode.exit': {};
 

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -62,6 +62,8 @@ interface ActiveTurn {
   readonly controller: AbortController;
   readonly promise: Promise<TurnEndResult>;
   readonly firstRequest: ControlledPromise<void>;
+  /** Origin of the prompt that launched this turn, for consumers that need to know who is driving (e.g. the dynamic_workflow_mode.enter record). */
+  readonly origin: PromptOrigin;
 }
 
 interface BufferedSteer {
@@ -229,6 +231,7 @@ export class TurnFlow {
       controller,
       promise,
       firstRequest,
+      origin,
     };
 
     void firstRequest.catch(() => undefined);
@@ -295,6 +298,13 @@ export class TurnFlow {
 
   get hasActiveTurn(): boolean {
     return this.activeTurn !== null && this.activeTurn !== 'resuming';
+  }
+
+  /** Origin of the prompt that launched the active turn; undefined between turns and while resuming. */
+  get activeTurnOrigin(): PromptOrigin | undefined {
+    return this.activeTurn === null || this.activeTurn === 'resuming'
+      ? undefined
+      : this.activeTurn.origin;
   }
 
   private ensureActiveTurn(): ActiveTurn {

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -533,7 +533,9 @@ describe('Agent turn flow', () => {
       .filter((origin) => origin?.kind === 'injection');
 
     expect(runQueued).toHaveBeenCalledTimes(1);
-    expect(enterEvent?.args).toMatchObject({ trigger: 'tool' });
+    // The enter record names who drove the fan-out: a cron- or hook-originated
+    // turn calling DynamicWorkflow is attributable after the fact.
+    expect(enterEvent?.args).toMatchObject({ trigger: 'tool', origin: { kind: 'user' } });
     expect(ctx.agent.dynamicWorkflowMode.isActive).toBe(false);
     expect(eventIndex(ctx, '[wire]', 'dynamic_workflow_mode.exit')).toBeGreaterThan(
       eventIndex(ctx, '[rpc]', 'turn.ended'),


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The `dynamic_workflow_mode.enter` session record named the trigger (`tool` or RPC) but not who drove it. A fan-out started by a scheduled job or a hook was indistinguishable from one started by the user, so after-the-fact attribution of workflow activity in session records was impossible.

## What changed

- `TurnFlow` keeps the `PromptOrigin` of the prompt that launched the active turn and exposes it as `activeTurnOrigin` (undefined between turns and while resuming).
- `DynamicWorkflowMode.enter` records that origin on the `dynamic_workflow_mode.enter` record. The `tool` trigger always fires inside a turn, so the origin names what drove the fan-out (user, cron, hook); the explicit RPC toggles run between turns and record no origin.

The field is optional on the record type, so existing readers are unaffected.

Tests: the turn suite now asserts the enter record carries the origin.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Session-record internals; no user-facing docs affected.)
