### PR TITLE
chore(deps): bump mermaid to 11.16.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "vitepress": "^1.6.4"
   },
   "dependencies": {
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "vitepress-plugin-llms": "^1.13.4",
     "vitepress-plugin-mermaid": "^2.0.17"
   }

--- a/flake.nix
+++ b/flake.nix
@@ -148,7 +148,7 @@
               inherit (finalAttrs) pname version src pnpmWorkspaces;
               inherit pnpm;
               fetcherVersion = 3;
-              hash = "sha256-GKfwTPY1YSCXyTICa/T2SrkqitM1EL/7l3Ry0VfNtY0=";
+              hash = "sha256-iNpwl+jjkjkDHUs4BdU1VxUjz4rgYDDPNzJQWmjTkz0=";
             };
 
             nativeBuildInputs = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,7 +279,7 @@ importers:
         version: 6.0.0
       markstream-vue:
         specifier: 1.0.1-beta.5
-        version: 1.0.1-beta.5(katex@0.17.0)(mermaid@11.16.0)(stream-markdown@0.0.16(react@19.2.8)(shiki@4.4.1)(solid-js@1.9.12)(vue@3.5.40(typescript@6.0.3)))(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 1.0.1-beta.5(katex@0.17.0)(mermaid@11.16.1)(stream-markdown@0.0.16(react@19.2.8)(shiki@4.4.1)(solid-js@1.9.12)(vue@3.5.40(typescript@6.0.3)))(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
       shiki:
         specifier: ^4.4.1
         version: 4.4.1
@@ -477,23 +477,23 @@ importers:
         version: 3.5.2(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)(yaml@2.9.0))
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.4(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.9))(jsdom@25.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)(yaml@2.9.0))
 
   docs:
     dependencies:
       mermaid:
-        specifier: ^11.16.0
-        version: 11.16.0
+        specifier: ^11.16.1
+        version: 11.16.1
       vitepress-plugin-llms:
         specifier: ^1.13.4
         version: 1.13.4
       vitepress-plugin-mermaid:
         specifier: ^2.0.17
-        version: 2.0.17(mermaid@11.16.0)(vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(search-insights@2.17.3)(typescript@6.0.3))
+        version: 2.0.17(mermaid@11.16.1)(vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@6.0.3))
     devDependencies:
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@6.0.3)
 
   packages/acp-adapter:
     dependencies:
@@ -7077,8 +7077,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -7298,6 +7298,11 @@ packages:
 
   nanoid@3.3.17:
     resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7747,6 +7752,10 @@ packages:
 
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -16040,7 +16049,7 @@ snapshots:
 
   markstream-core@1.0.0: {}
 
-  markstream-vue@1.0.1-beta.5(katex@0.17.0)(mermaid@11.16.0)(stream-markdown@0.0.16(react@19.2.8)(shiki@4.4.1)(solid-js@1.9.12)(vue@3.5.40(typescript@6.0.3)))(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)):
+  markstream-vue@1.0.1-beta.5(katex@0.17.0)(mermaid@11.16.1)(stream-markdown@0.0.16(react@19.2.8)(shiki@4.4.1)(solid-js@1.9.12)(vue@3.5.40(typescript@6.0.3)))(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)):
     dependencies:
       '@chenglou/pretext': 0.0.5
       '@floating-ui/dom': 1.8.0
@@ -16049,7 +16058,7 @@ snapshots:
       vue: 3.5.40(typescript@6.0.3)
     optionalDependencies:
       katex: 0.17.0
-      mermaid: 11.16.0
+      mermaid: 11.16.1
       stream-markdown: 0.0.16(react@19.2.8)(shiki@4.4.1)(solid-js@1.9.12)(vue@3.5.40(typescript@6.0.3))
       vue-i18n: 11.4.8(vue@3.5.40(typescript@6.0.3))
 
@@ -16245,7 +16254,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4
@@ -16641,6 +16650,8 @@ snapshots:
     optional: true
 
   nanoid@3.3.17: {}
+
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -17101,6 +17112,12 @@ snapshots:
   postcss@8.5.25:
     dependencies:
       nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -18814,7 +18831,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.25
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -18848,14 +18865,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress-plugin-mermaid@2.0.17(mermaid@11.16.0)(vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(search-insights@2.17.3)(typescript@6.0.3)):
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.16.1)(vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@6.0.3)):
     dependencies:
-      mermaid: 11.16.0
-      vitepress: 1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(search-insights@2.17.3)(typescript@6.0.3)
+      mermaid: 11.16.1
+      vitepress: 1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@6.0.3)
     optionalDependencies:
       '@mermaid-js/mermaid-mindmap': 9.3.0
 
-  vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(search-insights@2.17.3)(typescript@6.0.3):
+  vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.26)(search-insights@2.17.3)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)
@@ -18876,7 +18893,7 @@ snapshots:
       vite: 5.4.21(@types/node@26.1.2)(lightningcss@1.33.0)
       vue: 3.5.40(typescript@6.0.3)
     optionalDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -18905,7 +18922,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@4.1.4(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)(yaml@2.9.0)):
+  vitest@4.1.4(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.9))(jsdom@25.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.5)(yaml@2.9.0))


### PR DESCRIPTION
## Related Issue

No issue. The problem is described below.

## Problem

Dependabot reports nine open alerts against `main`. Five of them are `mermaid@11.16.0`, a direct dependency of the documentation site:

| Severity | Advisory |
| --- | --- |
| Medium | Configuration APIs allow prototype pollution |
| Medium | Architecture diagrams are vulnerable to prototype pollution |
| Medium | CSS injection applying to sibling elements of the diagram |
| Medium | Radar diagrams are vulnerable to denial of service |
| Low | XY charts are vulnerable to an infinite loop denial of service |

All five are fixed in `11.16.1`, which the declared `^11.16.0` range already permits — only the lockfile held the old version.

## What changed

- `mermaid` moves to `11.16.1` in `docs/package.json` and the lockfile.
- The `pnpmDeps` hash in `flake.nix` is refreshed, because any lockfile change invalidates it.

The remaining four alerts are out of scope and cannot be fixed here. They are `vite@5.4.21` (one high, two medium) and its `esbuild@0.21.5` dependency, both reached only through `vitepress@1.6.4`, which is the latest stable release and pins `vite: ^5.4.14`. The fix exists only in `vite@6.4.3` with no 5.x backport, so clearing them needs VitePress 2.0, currently an alpha. Every one of those advisories is a development-server issue, and the vulnerable copy exists only under `docs/` — the other five workspaces already pin `vite ^6.4.3`.

## Verification

- `nix build .#pythinker-code.pnpmDeps` passes with the new hash. The old hash was confirmed stale by forcing a mismatch: a fixed-output derivation is content-addressed, so a local build reuses the cached path and reports success even when the lockfile has moved.
- `node scripts/check-nix-workspace.mjs` passes.
- `pnpm exec vitest run` passes: 651 files, 9949 tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — Not applicable; this is a dependency bump with no behaviour change.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — No changeset: the bump touches only the documentation site's dependencies and does not enter the CLI bundle.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
