### PR TITLE
chore: add Greptile code review configuration

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,11 +1,11 @@
 {
   "strictness": 2,
-  "commentTypes": ["logic", "syntax"],
+  "commentTypes": ["logic", "syntax", "style"],
   "triggerOnUpdates": true,
   "includeBranches": ["main"],
   "ignoreKeywords": "WIP\nDO NOT REVIEW",
   "ignorePatterns": "node_modules/**\ndist/**\nbuild/**\n**/*.min.js\npnpm-lock.yaml\nflake.lock\n**/*.snap\nreports/**\n**/*.webp\n**/*.png\n**/*.gif",
-  "instructions": "TypeScript pnpm monorepo for pythinker-code, a provider-agnostic AI coding agent. packages/* are published libraries; apps/* are the CLI/TUI, web UI, and dashboard. The root AGENTS.md is the authoritative contributor guide; nearest sub-directory AGENTS.md files add local rules.",
+  "instructions": "TypeScript pnpm monorepo for pythinker-code, a provider-agnostic AI coding agent. The published user-facing package is the CLI (@pythoughts/pythinker-code); packages/node-sdk is the public TypeScript SDK; packages/agent-core, kosong, kaos, oauth, and telemetry are internal engine packages. apps/* are the CLI/TUI, web UI, and dashboard. The root AGENTS.md is the authoritative contributor guide; nearest sub-directory AGENTS.md files add local rules.",
   "rules": [
     {
       "id": "no-type-weakening",
@@ -32,7 +32,7 @@
     },
     {
       "id": "changeset-required",
-      "rule": "PRs that change published package behavior need a changeset. Default to minor or patch; a major bump requires explicit maintainer confirmation.",
+      "rule": "Every PR that affects release artifacts (code, behavior, or public API) must include a changeset; only docs-only, test-only, or CI-only PRs may skip one. Default to minor or patch; a major bump requires explicit maintainer confirmation.",
       "severity": "medium"
     }
   ]

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,39 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax"],
+  "triggerOnUpdates": true,
+  "includeBranches": ["main"],
+  "ignoreKeywords": "WIP\nDO NOT REVIEW",
+  "ignorePatterns": "node_modules/**\ndist/**\nbuild/**\n**/*.min.js\npnpm-lock.yaml\nflake.lock\n**/*.snap\nreports/**\n**/*.webp\n**/*.png\n**/*.gif",
+  "instructions": "TypeScript pnpm monorepo for pythinker-code, a provider-agnostic AI coding agent. packages/* are published libraries; apps/* are the CLI/TUI, web UI, and dashboard. The root AGENTS.md is the authoritative contributor guide; nearest sub-directory AGENTS.md files add local rules.",
+  "rules": [
+    {
+      "id": "no-type-weakening",
+      "rule": "Do not weaken types to silence errors: no `any`, unconstrained `unknown`, `@ts-ignore`, or type assertions added only to make a type error go away.",
+      "scope": ["packages/**", "apps/**"],
+      "severity": "high"
+    },
+    {
+      "id": "flake-workspace-sync",
+      "rule": "When a workspace package is added or removed in pnpm-workspace.yaml, flake.nix workspacePaths and workspaceNames must be updated in the same PR. A missing path silently drops files from the Nix build.",
+      "severity": "high"
+    },
+    {
+      "id": "tests-can-fail",
+      "rule": "Tests must be able to fail. Flag vacuous assertions: empty-set matches, missing awaits on async expectations, and mocked units asserting on the mock itself.",
+      "scope": ["**/*.test.ts", "**/*.test.tsx"],
+      "severity": "medium"
+    },
+    {
+      "id": "tui-reactivity",
+      "rule": "Solid signals must not be destructured, rendering must stay allocation-light, and no blocking I/O on the render path.",
+      "scope": ["apps/pythinker-code/src/tui/**"],
+      "severity": "high"
+    },
+    {
+      "id": "changeset-required",
+      "rule": "PRs that change published package behavior need a changeset. Default to minor or patch; a major bump requires explicit maintainer confirmation.",
+      "severity": "medium"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,33 @@
+{
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "description": "Repository-wide contributor guide: product identity, project map, coding rules, and PR workflow"
+    },
+    {
+      "path": "apps/pythinker-code/AGENTS.md",
+      "description": "CLI / terminal UI app rules",
+      "scope": ["apps/pythinker-code/**"]
+    },
+    {
+      "path": "apps/pythinker-web/AGENTS.md",
+      "description": "Browser UI (Vue 3) rules",
+      "scope": ["apps/pythinker-web/**"]
+    },
+    {
+      "path": "packages/server/AGENTS.md",
+      "description": "Server package rules (REST + WS /api/v1)",
+      "scope": ["packages/server/**"]
+    },
+    {
+      "path": "packages/server-e2e/AGENTS.md",
+      "description": "E2E test suite rules",
+      "scope": ["packages/server-e2e/**"]
+    },
+    {
+      "path": "docs/AGENTS.md",
+      "description": "Documentation rules",
+      "scope": ["docs/**"]
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -15,6 +15,11 @@
       "scope": ["apps/pythinker-web/**"]
     },
     {
+      "path": "packages/agent-core/src/services/AGENTS.md",
+      "description": "Service layer rules: naming, layout, and registration conventions",
+      "scope": ["packages/agent-core/src/services/**"]
+    },
+    {
       "path": "packages/server/AGENTS.md",
       "description": "Server package rules (REST + WS /api/v1)",
       "scope": ["packages/server/**"]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,23 @@
+# Review Rules
+
+## TypeScript conventions
+
+- `user?: User`, never `user?: User | undefined`.
+- Pass `undefined` directly for optional props — no conditional spread.
+- Single-param internal methods stay single-param — no options-object wrapping.
+- Non-root `index.ts` files: prefer `export * from './module'`.
+- Prefer `import ... from '#/...'` over deep relative paths (equivalent to `@/...`).
+
+## Architecture boundaries
+
+- `apps/pythinker-code` and `apps/pythinker-web` must not depend on `packages/agent-core`. They consume the SDK (`@pythoughts/pythinker-code-sdk`) or the server REST/WS API.
+- The `Agent` class in `packages/agent-core` stays standalone: no mandatory `Session` or `agentId`; optional `sessionId` is a provider hint only.
+- `packages/acp-adapter` pins `@agentclientprotocol/sdk` to `^0.23.0` — flag any bump to 0.24+ (it broke the session-model API).
+- Experimental features are gated behind flags in `packages/agent-core/src/flags/registry.ts`, not shipped unguarded.
+
+## Hygiene
+
+- English-only code, comments, and identifiers. Unicode tests use ASCII/Latin fixtures (e.g. `café`).
+- No backward-compatibility shims; implement the current requirement directly.
+- Prefer adding tests to existing test files over creating new ones.
+- Internal identifiers must not appear in public text or test data — use neutral placeholders.


### PR DESCRIPTION
## Related Issue

No issue — repository tooling configuration, no product behavior change. Problem explained below.

## Problem

Greptile code review is enabled for this repository but runs unconfigured: default strictness, all comment types (including style/info nits), no repo-specific rules, and no pointers to the `AGENTS.md` contributor guides. This produces noisy reviews that overlap with CodeRabbit and miss repo-specific conventions.

## What changed

Add a root `.greptile/` configuration folder (the current recommended format; supersedes legacy `greptile.json`):

- `config.json` — strictness 2, `logic` + `syntax` comments only, re-review on PR updates, review only PRs targeting `main`, skip `WIP` / `DO NOT REVIEW` titles, ignore patterns mirrored from `.coderabbit.yaml`, and five scoped structured rules with stable IDs (type-weakening, flake.nix workspace sync, vacuous test assertions, TUI reactivity, changeset requirement) so nested configs can disable them later.
- `rules.md` — prose conventions distilled from `AGENTS.md`: TypeScript idioms, architecture boundaries, and hygiene rules.
- `files.json` — points the reviewer at the six `AGENTS.md` files, each scoped to its directory tree.

Settings cascade, so packages can add their own `.greptile/` overrides later without touching the root config. Docs: https://www.greptile.com/docs/code-review/greptile-config

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — N/A: review-bot configuration only, no code paths to test.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — No changeset: nothing enters any package output.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — No user-facing product change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for automated code reviews.
  * Documented TypeScript conventions, architectural boundaries, dependency and feature-flag constraints, and project hygiene requirements.
  * Added scoped guidance for CLI, web, server, end-to-end testing, service-layer, and documentation areas.
  * Configured review standards covering type safety, workspace synchronization, test effectiveness, interface responsiveness, and required release documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->