### PR TITLE
fix: repair malformed JSON in model-written tool arguments

### DIFF
--- a/.changeset/tool-args-escape-repair.md
+++ b/.changeset/tool-args-escape-repair.md
@@ -2,4 +2,4 @@
 "@pythoughts/pythinker-code": patch
 ---
 
-Repair invalid escape sequences in model-written tool arguments instead of failing the tool call.
+Repair invalid escape sequences and unescaped quotes in model-written tool arguments instead of failing the tool call.

--- a/.changeset/tool-args-escape-repair.md
+++ b/.changeset/tool-args-escape-repair.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Repair invalid escape sequences in model-written tool arguments instead of failing the tool call.

--- a/packages/agent-core/src/loop/tool-call.ts
+++ b/packages/agent-core/src/loop/tool-call.ts
@@ -300,8 +300,59 @@ export function parseToolCallArguments(
   try {
     return { success: true, data: JSON.parse(raw) as unknown };
   } catch (error) {
+    const repaired = repairInvalidStringEscapes(raw);
+    if (repaired !== null) {
+      try {
+        return { success: true, data: JSON.parse(repaired) as unknown };
+      } catch {
+        // Report the original parse error below.
+      }
+    }
     return { success: false, error: errorMessage(error) };
   }
+}
+
+/**
+ * Models sometimes emit markdown-style escapes (\* \_ \[) inside JSON string
+ * values; strict JSON.parse rejects them while streaming previews tolerate
+ * them, so the call dies only at preflight. Rewrite ONLY invalid escapes to a
+ * literal backslash + character, leaving valid escapes and structure alone.
+ * Returns null when nothing was repaired.
+ */
+function repairInvalidStringEscapes(raw: string): string | null {
+  let result = '';
+  let inString = false;
+  let repaired = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const character = raw[index];
+    if (character === '"') {
+      inString = !inString;
+      result += character;
+      continue;
+    }
+    if (!inString || character !== '\\') {
+      result += character;
+      continue;
+    }
+
+    const next = raw[index + 1];
+    if (next !== undefined && '"\\/bfnrt'.includes(next)) {
+      result += character + next;
+      index += 1;
+      continue;
+    }
+    if (next === 'u' && /^[0-9a-fA-F]{4}$/.test(raw.slice(index + 2, index + 6))) {
+      result += raw.slice(index, index + 6);
+      index += 5;
+      continue;
+    }
+
+    result += '\\\\';
+    repaired = true;
+  }
+
+  return repaired ? result : null;
 }
 
 function validateExecutableToolArgs(tool: ExecutableTool, args: unknown): string | null {

--- a/packages/agent-core/src/loop/tool-call.ts
+++ b/packages/agent-core/src/loop/tool-call.ts
@@ -313,10 +313,11 @@ export function parseToolCallArguments(
 }
 
 /**
- * Models sometimes emit markdown-style escapes (\* \_ \[) inside JSON string
- * values; strict JSON.parse rejects them while streaming previews tolerate
- * them, so the call dies only at preflight. Rewrite ONLY invalid escapes to a
- * literal backslash + character, leaving valid escapes and structure alone.
+ * Models sometimes emit invalid escapes (\* \_ \[) or unescaped quotes inside
+ * JSON string values. Rewrite invalid escapes to a literal backslash +
+ * character and quotes that cannot terminate the string to escaped quotes.
+ * A content quote followed by a structural character is ambiguous and still
+ * closes the string; if reparsing fails, the original parse error is reported.
  * Returns null when nothing was repaired.
  */
 function repairInvalidStringEscapes(raw: string): string | null {
@@ -327,8 +328,22 @@ function repairInvalidStringEscapes(raw: string): string | null {
   for (let index = 0; index < raw.length; index += 1) {
     const character = raw[index];
     if (character === '"') {
-      inString = !inString;
-      result += character;
+      if (!inString) {
+        inString = true;
+        result += character;
+        continue;
+      }
+
+      let lookahead = index + 1;
+      while (lookahead < raw.length && ' \t\n\r'.includes(raw[lookahead]!)) lookahead += 1;
+      const next = raw[lookahead];
+      if (next === undefined || ',:}]'.includes(next)) {
+        inString = false;
+        result += character;
+      } else {
+        result += '\\"';
+        repaired = true;
+      }
       continue;
     }
     if (!inString || character !== '\\') {

--- a/packages/agent-core/src/loop/tool-call.ts
+++ b/packages/agent-core/src/loop/tool-call.ts
@@ -357,7 +357,7 @@ function repairInvalidStringEscapes(raw: string): string | null {
       index += 1;
       continue;
     }
-    if (next === 'u' && /^[0-9a-fA-F]{4}$/.test(raw.slice(index + 2, index + 6))) {
+    if (next === 'u' && /^[0-9a-fA-F]{4}$/u.test(raw.slice(index + 2, index + 6))) {
       result += raw.slice(index, index + 6);
       index += 5;
       continue;

--- a/packages/agent-core/test/loop/tool-call.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-call.e2e.test.ts
@@ -12,6 +12,7 @@ import type { ContentPart } from '@pythoughts/kosong';
 import { describe, expect, it } from 'vitest';
 
 import { createLoopEventDispatcher, runTurn as runTurnImpl, ToolAccesses } from '../../src/loop';
+import { parseToolCallArguments } from '../../src/loop/tool-call';
 import type { Logger } from '../../src/logging';
 import type {
   ExecutableTool,
@@ -117,6 +118,42 @@ function makeTestLogger(): {
   };
   return { log, entries };
 }
+
+describe('parseToolCallArguments', () => {
+  it('repairs markdown-style escapes inside string values', () => {
+    const result = parseToolCallArguments('{"a":"bold \\*text\\* and \\_x"}');
+
+    expect(result).toEqual({ success: true, data: { a: 'bold \\*text\\* and \\_x' } });
+  });
+
+  it('leaves valid escapes unchanged', () => {
+    const raw = '{"a":"line\\nquote\\" uA slash\\\\/"}';
+
+    expect(parseToolCallArguments(raw)).toEqual({ success: true, data: JSON.parse(raw) });
+  });
+
+  it('repairs a bad unicode escape inside a string value', () => {
+    const result = parseToolCallArguments('{"a":"\\u12ZZ"}');
+
+    expect(result).toEqual({ success: true, data: { a: '\\u12ZZ' } });
+  });
+
+  it('returns the original parse error for structurally broken input', () => {
+    const raw = '{"a":"truncated';
+    let originalError = '';
+    try {
+      JSON.parse(raw);
+    } catch (error) {
+      originalError = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(parseToolCallArguments(raw)).toEqual({ success: false, error: originalError });
+  });
+
+  it('does not repair a backslash outside a string', () => {
+    expect(parseToolCallArguments('{\\*"a":1}').success).toBe(false);
+  });
+});
 
 describe('runTurn — tool-call behaviour', () => {
   it('strips enabled intent before hooks, validation, execution, and persistence', async () => {

--- a/packages/agent-core/test/loop/tool-call.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-call.e2e.test.ts
@@ -177,7 +177,7 @@ describe('parseToolCallArguments', () => {
   });
 
   it('returns the original parse error after quote repair still fails', () => {
-    const raw = '{"a":[1,}';
+    const raw = String.raw`{"a":"bad \*","b":[}`;
 
     expect(parseToolCallArguments(raw)).toEqual({ success: false, error: parseErrorMessage(raw) });
   });

--- a/packages/agent-core/test/loop/tool-call.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-call.e2e.test.ts
@@ -138,6 +138,47 @@ describe('parseToolCallArguments', () => {
     expect(result).toEqual({ success: true, data: { a: '\\u12ZZ' } });
   });
 
+  it('repairs unescaped quotes inside items-array string values', () => {
+    const result = parseToolCallArguments(
+      '{"items":[{"prompt":"Review the "config" module carefully","i":"review config"}]}',
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: { items: [{ prompt: 'Review the "config" module carefully', i: 'review config' }] },
+    });
+  });
+
+  it('leaves a quote before a structural character unchanged', () => {
+    const raw = '{"a":"done","b":1}';
+
+    expect(parseToolCallArguments(raw)).toEqual({ success: true, data: JSON.parse(raw) });
+  });
+
+  it('repairs invalid escapes and unescaped quotes together', () => {
+    const result = parseToolCallArguments('{"a":"bold \\*x and a "quoted" word"}');
+
+    expect(result).toEqual({ success: true, data: { a: 'bold \\*x and a "quoted" word' } });
+  });
+
+  it('recognizes a string terminator separated from structure by whitespace', () => {
+    const result = parseToolCallArguments('{"a":"text" , "b":"x "y" z"}');
+
+    expect(result).toEqual({ success: true, data: { a: 'text', b: 'x "y" z' } });
+  });
+
+  it('returns the original parse error after quote repair still fails', () => {
+    const raw = '{"a":[1,}';
+    let originalError = '';
+    try {
+      JSON.parse(raw);
+    } catch (error) {
+      originalError = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(parseToolCallArguments(raw)).toEqual({ success: false, error: originalError });
+  });
+
   it('returns the original parse error for structurally broken input', () => {
     const raw = '{"a":"truncated';
     let originalError = '';

--- a/packages/agent-core/test/loop/tool-call.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-call.e2e.test.ts
@@ -49,6 +49,15 @@ function expectTextOutput(output: unknown): string {
   return output as string;
 }
 
+function parseErrorMessage(raw: string): string {
+  try {
+    JSON.parse(raw);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error(`expected ${raw} to fail JSON.parse`);
+}
+
 async function contentBlockOutput(output: ContentPart[]): Promise<ContentPart[]> {
   const blocks = new ContentBlocksTool({ output });
   const { context } = await runTurn({
@@ -169,26 +178,14 @@ describe('parseToolCallArguments', () => {
 
   it('returns the original parse error after quote repair still fails', () => {
     const raw = '{"a":[1,}';
-    let originalError = '';
-    try {
-      JSON.parse(raw);
-    } catch (error) {
-      originalError = error instanceof Error ? error.message : String(error);
-    }
 
-    expect(parseToolCallArguments(raw)).toEqual({ success: false, error: originalError });
+    expect(parseToolCallArguments(raw)).toEqual({ success: false, error: parseErrorMessage(raw) });
   });
 
   it('returns the original parse error for structurally broken input', () => {
     const raw = '{"a":"truncated';
-    let originalError = '';
-    try {
-      JSON.parse(raw);
-    } catch (error) {
-      originalError = error instanceof Error ? error.message : String(error);
-    }
 
-    expect(parseToolCallArguments(raw)).toEqual({ success: false, error: originalError });
+    expect(parseToolCallArguments(raw)).toEqual({ success: false, error: parseErrorMessage(raw) });
   });
 
   it('does not repair a backslash outside a string', () => {


### PR DESCRIPTION
## Summary

Model-written tool arguments sometimes fail strict `JSON.parse` and kill the tool call at preflight. Two failure classes were observed in real Dynamic Workflow launches:

- **Invalid escape sequences** — markdown-style escapes such as `\*` inside JSON string values (`Bad escaped character at position 3458`).
- **Unescaped inner quotes** — a literal `"` inside a string value that terminates it early (`Expected ',' or ']' after array element in JSON at position 2832`).

Both now repair instead of failing the call. The repair runs only as a fallback after `JSON.parse` rejects the input, and the original parse error is still reported when the repaired text also fails to parse.

## Approach

A single scanner pass rewrites invalid escapes to a literal backslash plus character, and rewrites an in-string `"` to `\"` unless the next non-whitespace character is structural (`,` `:` `}` `]`) or end of input. A content quote immediately followed by a structural character stays ambiguous and still closes the string; that limit is documented in the function comment.

## Test plan

- `packages/agent-core/test/loop/tool-call.e2e.test.ts` — 45 tests, including a reproduction of the observed items-array failure, mixed-class repair, whitespace before the terminator, and preservation of the original error on still-broken input.
- Full suite green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed tool arguments, including invalid escape sequences and unescaped quotation marks.
  * Preserves valid escapes while repairing recoverable formatting issues.
  * Provides clearer errors when arguments remain structurally invalid.

* **Tests**
  * Added coverage for malformed escapes, embedded quotes, combined errors, valid escapes, and invalid JSON structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->