### PR TITLE
test: sequence the advisor mock with ordered handlers

### DIFF
--- a/packages/agent-core/test/session/session-advisor.test.ts
+++ b/packages/agent-core/test/session/session-advisor.test.ts
@@ -77,15 +77,19 @@ describe('SessionAdvisor', () => {
     const reviewGate = createDeferred<void>();
     const activeTurnGate = createDeferred<void>();
     const generate = fixture.main.rawGenerate;
-    let generateCall = 0;
-    vi.spyOn(fixture.main, 'rawGenerate').mockImplementation(async (...args) => {
-      generateCall += 1;
-      const currentCall = generateCall;
-      const result = await generate(...args);
-      if (currentCall === 2) await reviewGate.promise;
-      if (currentCall === 3) await activeTurnGate.promise;
-      return result;
-    });
+    vi.spyOn(fixture.main, 'rawGenerate')
+      .mockImplementationOnce(generate)
+      .mockImplementationOnce(async (...args) => {
+        const result = await generate(...args);
+        await reviewGate.promise;
+        return result;
+      })
+      .mockImplementationOnce(async (...args) => {
+        const result = await generate(...args);
+        await activeTurnGate.promise;
+        return result;
+      })
+      .mockImplementation(generate);
     const steer = vi.spyOn(fixture.main.turn, 'steer').mockReturnValue(null);
     queueReview(fixture.scripted, 'Check the active turn.', 'concern');
 


### PR DESCRIPTION
## Summary

`packages/agent-core/test/session/session-advisor.test.ts` emitted two `vitest(no-conditional-in-test)` warnings from a call-counter mock that branched on which `rawGenerate` call it was handling.

A reviewer raised this on #59 and I declined it incorrectly, citing an `oxlint --quiet` run as evidence the rule did not fire. That flag suppresses warnings, so the evidence was an artifact of the command rather than a fact about the code. This is the follow-up.

## Approach

The three-call sequence is now expressed with ordered `mockImplementationOnce` handlers plus a trailing default, so an unexpected fourth call falls through to the real implementation instead of returning `undefined`.

No production code and no assertions changed.

## Test plan

- `pnpm --filter @pythoughts/agent-core exec vitest run test/session/session-advisor.test.ts` — all pass.
- `npx oxlint packages/agent-core/test/session/session-advisor.test.ts` (no `--quiet`) — 2 warnings before, 0 after.
- Red proof that the test still catches its bug: restoring the mid-turn `#deliverPending()` call in `session-advisor.ts` fails the test with `expected 1 to be +0` on `callsWhileActive`.

[skip changeset] — tests-only change under `packages/agent-core/test/`. No production source is touched and nothing enters the CLI bundle, so per the repo's changeset rules there is no user-visible change to record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mid-turn advisor coverage to validate review and active-turn behavior using explicit response sequencing.
  * Improved test reliability by removing dependence on call-count state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->