### PR TITLE
chore: migrate org references from Pythoughts-labs to PyModel

### DIFF
--- a/.agents/skills/gen-docs/SKILL.md
+++ b/.agents/skills/gen-docs/SKILL.md
@@ -7,7 +7,7 @@ description: Update Pythinker Code CLI user documentation after meaningful code 
 
 ## Overview
 
-This repository (`github.com/Pythoughts-labs/pythinker-code`) maintains English user documentation under `docs/`, published at **https://code.pythinker.com**.
+This repository (`github.com/PyModel/pythinker-code`) maintains English user documentation under `docs/`, published at **https://code.pythinker.com**.
 
 Use this skill to update the corresponding documentation whenever the codebase has changes that affect product behavior or user experience.
 

--- a/.agents/skills/sync-changelog/SKILL.md
+++ b/.agents/skills/sync-changelog/SKILL.md
@@ -38,7 +38,7 @@ Core rule: the English docs changelog is the source of truth for user-facing rel
 
 Before editing, confirm:
 
-- The released version exists on npm (`npm view @pythoughts/pythinker-code versions --json`) or has a matching GitHub Release tag on `Pythoughts-labs/pythinker-code`.
+- The released version exists on npm (`npm view @pythoughts/pythinker-code versions --json`) or has a matching GitHub Release tag on `PyModel/pythinker-code`.
 - The top of `apps/pythinker-code/CHANGELOG.md` is that new version.
 - The current branch is clean, or you are on a dedicated docs-sync branch.
 
@@ -66,7 +66,7 @@ Use upstream order: newest version first.
 Upstream entries look like this:
 
 ```markdown
-- [#317](https://github.com/Pythoughts-labs/pythinker-code/pull/317) [`2f51db4`](https://github.com/Pythoughts-labs/pythinker-code/commit/2f51db4) - Clean up lint warnings ...
+- [#317](https://github.com/PyModel/pythinker-code/pull/317) [`2f51db4`](https://github.com/PyModel/pythinker-code/commit/2f51db4) - Clean up lint warnings ...
 ```
 
 Keep:

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -63,7 +63,7 @@ Fill in the following:
 
 | Field | Value |
 | --- | --- |
-| GitHub Organization | `Pythoughts-labs` |
+| GitHub Organization | `PyModel` |
 | GitHub Repository | `pythinker-code` |
 | GitHub Workflow | `release.yml` |
 | Environment | leave empty |

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "changelog": ["@changesets/changelog-github", { "repo": "Pythoughts-labs/pythinker-code", "disableThanks": true }],
+  "changelog": ["@changesets/changelog-github", { "repo": "PyModel/pythinker-code", "disableThanks": true }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Thank you for your contribution to Pythinker Code!
 Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.
 
-See https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md for more.
+See https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md for more.
 -->
 
 ## Related Issue
@@ -21,7 +21,7 @@ Resolve #(issue_number)
 
 ## Checklist
 
-- [ ] I have read the [CONTRIBUTING](https://github.com/Pythoughts-labs/pythinker-code/blob/main/CONTRIBUTING.md) document.
+- [ ] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
 - [ ] I have linked a related issue, or explained the problem above.
 - [ ] I have added tests that prove my feature works.
 - [ ] Ran `gen-changesets` skill, or this PR needs no changeset.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   publish:
     name: Publish dev snapshot
-    if: github.repository_owner == 'Pythoughts-labs'
+    if: github.repository_owner == 'PyModel'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -15,7 +15,7 @@ jobs:
   publish:
     name: Publish Pythinker Code preview
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'Pythoughts-labs' && github.event.pull_request.draft == false
+    if: github.repository_owner == 'PyModel' && github.event.pull_request.draft == false
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   wait-for-checks:
     name: Wait for CI and Nix Build
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'Pythoughts-labs'
+    if: github.repository_owner == 'PyModel'
     timeout-minutes: 45
     permissions:
       actions: read
@@ -50,7 +50,7 @@ jobs:
     needs: wait-for-checks
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.repository_owner == 'Pythoughts-labs'
+    if: github.repository_owner == 'PyModel'
     outputs:
       packages_published: ${{ steps.changesets.outputs.published }}
       pythinker_native_release: ${{ steps.pythinker-release.outputs.should_publish }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ For the full project map, see [AGENTS.md](AGENTS.md).
 Prerequisites: Node.js >= 24.15.0, pnpm 10.33.0, Git.
 
 ```sh
-git clone https://github.com/Pythoughts-labs/pythinker-code.git
+git clone https://github.com/PyModel/pythinker-code.git
 cd pythinker-code
 pnpm install
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/pythinker_animated.svg" alt="Pythinker logo" width="34" align="top"> Pythinker Code
+# <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/pythinker_animated.svg" alt="Pythinker logo" width="34" align="top"> Pythinker Code
 
 ### *Think first, then code. Your terminal-native AI engineering agent.*
 
@@ -11,14 +11,14 @@
 
 [![npm version](https://img.shields.io/npm/v/@pythoughts/pythinker-code?style=for-the-badge&logo=npm&logoColor=white&color=CB3837&label=pythinker-code)](https://www.npmjs.com/package/@pythoughts/pythinker-code)
 [![Downloads](https://img.shields.io/npm/dm/@pythoughts/pythinker-code?style=for-the-badge&logo=npm&logoColor=white&color=2b89ff&label=downloads)](https://www.npmjs.com/package/@pythoughts/pythinker-code)
-[![Node.js](https://img.shields.io/badge/Node.js-26%2B-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://github.com/Pythoughts-labs/pythinker-code/blob/main/package.json)
-[![License: MIT](https://img.shields.io/badge/License-MIT-16a34a.svg?style=for-the-badge)](https://github.com/Pythoughts-labs/pythinker-code/blob/main/LICENSE)
-[![CI](https://img.shields.io/github/actions/workflow/status/Pythoughts-labs/pythinker-code/ci.yml?branch=main&label=CI&style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/Pythoughts-labs/pythinker-code/actions/workflows/ci.yml?query=branch%3Amain)
+[![Node.js](https://img.shields.io/badge/Node.js-26%2B-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://github.com/PyModel/pythinker-code/blob/main/package.json)
+[![License: MIT](https://img.shields.io/badge/License-MIT-16a34a.svg?style=for-the-badge)](https://github.com/PyModel/pythinker-code/blob/main/LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/PyModel/pythinker-code/ci.yml?branch=main&label=CI&style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/PyModel/pythinker-code/actions/workflows/ci.yml?query=branch%3Amain)
 
 [![Built with TypeScript](https://img.shields.io/badge/built%20with-TypeScript-3178c6.svg?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![ACP ready](https://img.shields.io/badge/ACP-ready-7c3aed.svg?style=flat-square)](https://agentclientprotocol.com/)
 [![MCP tools](https://img.shields.io/badge/MCP-tools-0891b2.svg?style=flat-square)](https://modelcontextprotocol.io/)
-[![Docs](https://img.shields.io/badge/docs-online-0284c7.svg?style=flat-square)](https://pythoughts-labs.github.io/pythinker-code/)
+[![Docs](https://img.shields.io/badge/docs-online-0284c7.svg?style=flat-square)](https://pymodel.github.io/pythinker-code/)
 [![Homepage](https://img.shields.io/badge/home-code.pythinker.com-ec4899.svg?style=flat-square)](https://code.pythinker.com)
 
 <br />
@@ -33,7 +33,7 @@
 
 <br /><br />
 
-<img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/terminal-ui.webp" alt="Pythinker Code terminal demo" width="860">
+<img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/terminal-ui.webp" alt="Pythinker Code terminal demo" width="860">
 
 </div>
 
@@ -128,11 +128,11 @@ Pythinker ships **native installers**— no Node.js prerequisite. Pick the row t
 
 | Platform | Recommended install | Source |
 |---|---|---|
-| <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/icons/apple.svg" width="16" height="16" alt="macOS" align="top"> <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/icons/linux.svg" width="16" height="16" alt="Linux" align="top"> **macOS / Linux**| `curl -fsSL https://code.pythinker.com/pythinker-code/install.sh \| bash` | [code.pythinker.com](https://code.pythinker.com) |
-| <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/icons/homebrew.svg" width="16" height="16" alt="Homebrew" align="top"> **Homebrew**| `brew install pythoughts-labs/tap/pythinker-code` | Homebrew |
-| <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/icons/windows11.svg" width="16" height="16" alt="Windows" align="top"> **Windows (PowerShell)**| `irm https://code.pythinker.com/pythinker-code/install.ps1 \| iex` | [code.pythinker.com](https://code.pythinker.com) |
-| <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/icons/nixos.svg" width="16" height="16" alt="Nix" align="top"> **Nix**| `nix run github:Pythoughts-labs/pythinker-code` | flake |
-| <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/icons/npm.svg" width="16" height="16" alt="npm" align="top"> **npm / pnpm fallback**| `npm install -g @pythoughts/pythinker-code` | requires Node.js ≥ 26.4.0 |
+| <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/icons/apple.svg" width="16" height="16" alt="macOS" align="top"> <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/icons/linux.svg" width="16" height="16" alt="Linux" align="top"> **macOS / Linux**| `curl -fsSL https://code.pythinker.com/pythinker-code/install.sh \| bash` | [code.pythinker.com](https://code.pythinker.com) |
+| <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/icons/homebrew.svg" width="16" height="16" alt="Homebrew" align="top"> **Homebrew**| `brew install pymodel/tap/pythinker-code` | Homebrew |
+| <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/icons/windows11.svg" width="16" height="16" alt="Windows" align="top"> **Windows (PowerShell)**| `irm https://code.pythinker.com/pythinker-code/install.ps1 \| iex` | [code.pythinker.com](https://code.pythinker.com) |
+| <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/icons/nixos.svg" width="16" height="16" alt="Nix" align="top"> **Nix**| `nix run github:PyModel/pythinker-code` | flake |
+| <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/icons/npm.svg" width="16" height="16" alt="npm" align="top"> **npm / pnpm fallback**| `npm install -g @pythoughts/pythinker-code` | requires Node.js ≥ 26.4.0 |
 
 > [!NOTE]
 > **Windows:**install [Git for Windows](https://gitforwindows.org/) before first launch — Pythinker Code uses the bundled Git Bash as its shell. For a custom Git Bash location, set `PYTHINKER_SHELL_PATH` to the absolute path of `bash.exe`.
@@ -173,7 +173,7 @@ Refactor the error handling in src/api/ to use a shared Result type — keep the
 | `/skill:<name>` | Invoke an installed skill |
 | `/help` | Built-in keyboard shortcut reference |
 
-For upgrade, uninstall, headless/automation usage, and platform-specific notes, see the [Getting Started guide](https://pythoughts-labs.github.io/pythinker-code/guides/getting-started).
+For upgrade, uninstall, headless/automation usage, and platform-specific notes, see the [Getting Started guide](https://pymodel.github.io/pythinker-code/guides/getting-started).
 
 ---
 
@@ -201,10 +201,10 @@ Add to `~/.config/zed/settings.json`:
 
 </details>
 
-Open a new conversation in Zed's Agent panel. For JetBrains setup, troubleshooting, and the full capability matrix, see [Using in IDEs](https://pythoughts-labs.github.io/pythinker-code/guides/ides) and the [`pythinker acp` reference](https://pythoughts-labs.github.io/pythinker-code/reference/pythinker-acp).
+Open a new conversation in Zed's Agent panel. For JetBrains setup, troubleshooting, and the full capability matrix, see [Using in IDEs](https://pymodel.github.io/pythinker-code/guides/ides) and the [`pythinker acp` reference](https://pymodel.github.io/pythinker-code/reference/pythinker-acp).
 
 <div align="center">
-<img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/acp-integration.gif" alt="ACP IDE integration demo" width="860">
+<img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/acp-integration.gif" alt="ACP IDE integration demo" width="860">
 </div>
 
 ---
@@ -219,7 +219,7 @@ Inside a session, `/mcp-config` manages everything conversationally:
 /mcp-config              # add, authenticate, test, and remove MCP servers
 ```
 
-See the [configuration docs](https://pythoughts-labs.github.io/pythinker-code/configuration/config-files) for config-file based setup.
+See the [configuration docs](https://pymodel.github.io/pythinker-code/configuration/config-files) for config-file based setup.
 
 ---
 
@@ -260,12 +260,12 @@ Pythinker is a small, extensible runtime — not a monolith. Build on it.
 
 | Topic | Link |
 |-------|------|
-| Getting Started | [guides/getting-started](https://pythoughts-labs.github.io/pythinker-code/guides/getting-started) |
-| Interaction & approvals | [guides/interaction](https://pythoughts-labs.github.io/pythinker-code/guides/interaction) |
-| Sessions | [guides/sessions](https://pythoughts-labs.github.io/pythinker-code/guides/sessions) |
-| IDE integration | [guides/ides](https://pythoughts-labs.github.io/pythinker-code/guides/ides) |
-| Configuration | [configuration/config-files](https://pythoughts-labs.github.io/pythinker-code/configuration/config-files) |
-| Command reference | [reference/pythinker-command](https://pythoughts-labs.github.io/pythinker-code/reference/pythinker-command) |
+| Getting Started | [guides/getting-started](https://pymodel.github.io/pythinker-code/guides/getting-started) |
+| Interaction & approvals | [guides/interaction](https://pymodel.github.io/pythinker-code/guides/interaction) |
+| Sessions | [guides/sessions](https://pymodel.github.io/pythinker-code/guides/sessions) |
+| IDE integration | [guides/ides](https://pymodel.github.io/pythinker-code/guides/ides) |
+| Configuration | [configuration/config-files](https://pymodel.github.io/pythinker-code/configuration/config-files) |
+| Command reference | [reference/pythinker-command](https://pymodel.github.io/pythinker-code/reference/pythinker-command) |
 | Pythinker Code product | [pythinker.com/code](https://pythinker.com/code) |
 
 ---
@@ -277,7 +277,7 @@ Pythinker is a small, extensible runtime — not a monolith. Build on it.
 **Requirements:**Node.js ≥ 26.4.0 · pnpm 10.34.3 · Git
 
 ```sh
-git clone https://github.com/Pythoughts-labs/pythinker-code.git
+git clone https://github.com/PyModel/pythinker-code.git
 cd pythinker-code
 pnpm install
 ```
@@ -360,8 +360,8 @@ Our TUI is built on [`pi-tui`](https://github.com/earendil-works/pi-mono/tree/ma
 
 [ code.pythinker.com](https://code.pythinker.com) &nbsp;·&nbsp;
 [ npm](https://www.npmjs.com/package/@pythoughts/pythinker-code) &nbsp;·&nbsp;
-[ GitHub](https://github.com/Pythoughts-labs/pythinker-code) &nbsp;·&nbsp;
-[ Docs](https://pythoughts-labs.github.io/pythinker-code/) &nbsp;·&nbsp;
+[ GitHub](https://github.com/PyModel/pythinker-code) &nbsp;·&nbsp;
+[ Docs](https://pymodel.github.io/pythinker-code/) &nbsp;·&nbsp;
 [ ACP](https://agentclientprotocol.com/) &nbsp;·&nbsp;
 [ MCP](https://modelcontextprotocol.io/)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ We take security seriously. **Please do not open a public issue for security vul
 
 Preferred channel:
 
-- GitHub Security Advisories — https://github.com/Pythoughts-labs/pythinker-code/security/advisories/new
+- GitHub Security Advisories — https://github.com/PyModel/pythinker-code/security/advisories/new
   (private disclosure, tracked with the codebase)
 
 Alternative channel:

--- a/apps/pythinker-code/CHANGELOG.md
+++ b/apps/pythinker-code/CHANGELOG.md
@@ -4,75 +4,75 @@
 
 ### Minor Changes
 
-- [#59](https://github.com/Pythoughts-labs/pythinker-code/pull/59) [`6999b68`](https://github.com/Pythoughts-labs/pythinker-code/commit/6999b685ff63fb275a179be61f47e8b5cb727ba5) - Add an opt-in advisor: a second model reviews the conversation after a completed user turn unless another review is already running, and its notes appear as an `<advisory>` block in the agent's next turn; enable with `[advisor] enabled = true` plus an advisor model (the `advisor` model role or `[advisor] model`), and it runs only when the advisor shares the session model's provider.
+- [#59](https://github.com/PyModel/pythinker-code/pull/59) [`6999b68`](https://github.com/PyModel/pythinker-code/commit/6999b685ff63fb275a179be61f47e8b5cb727ba5) - Add an opt-in advisor: a second model reviews the conversation after a completed user turn unless another review is already running, and its notes appear as an `<advisory>` block in the agent's next turn; enable with `[advisor] enabled = true` plus an advisor model (the `advisor` model role or `[advisor] model`), and it runs only when the advisor shares the session model's provider.
 
-- [#56](https://github.com/Pythoughts-labs/pythinker-code/pull/56) [`b71f094`](https://github.com/Pythoughts-labs/pythinker-code/commit/b71f09460825feb63bdf1dbb029c12a34e140598) - Add model roles: lock a model alias to the small, implementer, or advisor slot with `/model <role>`, list assignments with `/model roles`, and reference roles as `@small`, `@implementer`, or `@advisor` wherever a subagent model can be set; an assigned implementer role becomes the default model for subagents.
+- [#56](https://github.com/PyModel/pythinker-code/pull/56) [`b71f094`](https://github.com/PyModel/pythinker-code/commit/b71f09460825feb63bdf1dbb029c12a34e140598) - Add model roles: lock a model alias to the small, implementer, or advisor slot with `/model <role>`, list assignments with `/model roles`, and reference roles as `@small`, `@implementer`, or `@advisor` wherever a subagent model can be set; an assigned implementer role becomes the default model for subagents.
 
-- [#57](https://github.com/Pythoughts-labs/pythinker-code/pull/57) [`99c427c`](https://github.com/Pythoughts-labs/pythinker-code/commit/99c427ce686a2c7dca183cb60235f8ecc3fd393f) - Show what the agent is doing in the working indicator: eligible tool calls whose input schema accepts the injected field now carry a short model-written intent, streamed live into the spinner label (for example "check failing test…") instead of a rotating placeholder; disable with `PYTHINKER_CODE_EXPERIMENTAL_TOOL_INTENT=0`.
+- [#57](https://github.com/PyModel/pythinker-code/pull/57) [`99c427c`](https://github.com/PyModel/pythinker-code/commit/99c427ce686a2c7dca183cb60235f8ecc3fd393f) - Show what the agent is doing in the working indicator: eligible tool calls whose input schema accepts the injected field now carry a short model-written intent, streamed live into the spinner label (for example "check failing test…") instead of a rotating placeholder; disable with `PYTHINKER_CODE_EXPERIMENTAL_TOOL_INTENT=0`.
 
-- [#58](https://github.com/Pythoughts-labs/pythinker-code/pull/58) [`065bf2e`](https://github.com/Pythoughts-labs/pythinker-code/commit/065bf2e9b90cfe9f5ec103132996baae73daaf26) - Redesign core TUI surfaces: tool cards get state-tinted backgrounds with three new theme tokens, a status bar with a per-session accent color appears between the input box and footer, and the prompt box uses a neutral border while permission mode appears in the status bar. The working-label shimmer uses a calmer constant-velocity sweep with alternating mission-control highlights.
+- [#58](https://github.com/PyModel/pythinker-code/pull/58) [`065bf2e`](https://github.com/PyModel/pythinker-code/commit/065bf2e9b90cfe9f5ec103132996baae73daaf26) - Redesign core TUI surfaces: tool cards get state-tinted backgrounds with three new theme tokens, a status bar with a per-session accent color appears between the input box and footer, and the prompt box uses a neutral border while permission mode appears in the status bar. The working-label shimmer uses a calmer constant-velocity sweep with alternating mission-control highlights.
 
 ### Patch Changes
 
-- [#62](https://github.com/Pythoughts-labs/pythinker-code/pull/62) [`7fc36fd`](https://github.com/Pythoughts-labs/pythinker-code/commit/7fc36fdc4c5694812fce65c57151cd14c182b8fc) - Repair invalid escape sequences and unescaped quotes in model-written tool arguments instead of failing the tool call.
+- [#62](https://github.com/PyModel/pythinker-code/pull/62) [`7fc36fd`](https://github.com/PyModel/pythinker-code/commit/7fc36fdc4c5694812fce65c57151cd14c182b8fc) - Repair invalid escape sequences and unescaped quotes in model-written tool arguments instead of failing the tool call.
 
 ## 0.15.0
 
 ### Minor Changes
 
-- [#54](https://github.com/Pythoughts-labs/pythinker-code/pull/54) [`1f45a5f`](https://github.com/Pythoughts-labs/pythinker-code/commit/1f45a5fefbdf4d5d8006f82613d51e24adb2e413) - Show indeterminate lifecycle progress for Dynamic Workflow rows in the TUI, and report schema-error outcomes as failed.
+- [#54](https://github.com/PyModel/pythinker-code/pull/54) [`1f45a5f`](https://github.com/PyModel/pythinker-code/commit/1f45a5fefbdf4d5d8006f82613d51e24adb2e413) - Show indeterminate lifecycle progress for Dynamic Workflow rows in the TUI, and report schema-error outcomes as failed.
 
 ## 0.14.0
 
 ### Minor Changes
 
-- [#51](https://github.com/Pythoughts-labs/pythinker-code/pull/51) [`c8cdcc7`](https://github.com/Pythoughts-labs/pythinker-code/commit/c8cdcc78528f3fd8dedf9111ec0c91f3242e3012) - `/workflow save` accepts `--personal` to save into the home skills directory, resolves the repository root when saving from a subdirectory so the saved skill is discoverable, and persists the workflow size guideline into the saved skill.
+- [#51](https://github.com/PyModel/pythinker-code/pull/51) [`c8cdcc7`](https://github.com/PyModel/pythinker-code/commit/c8cdcc78528f3fd8dedf9111ec0c91f3242e3012) - `/workflow save` accepts `--personal` to save into the home skills directory, resolves the repository root when saving from a subdirectory so the saved skill is discoverable, and persists the workflow size guideline into the saved skill.
 
 ### Patch Changes
 
-- [#46](https://github.com/Pythoughts-labs/pythinker-code/pull/46) [`bceff21`](https://github.com/Pythoughts-labs/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Fix `pythinker doctor` crashing on native installs, and report the last recorded update outcome.
+- [#46](https://github.com/PyModel/pythinker-code/pull/46) [`bceff21`](https://github.com/PyModel/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Fix `pythinker doctor` crashing on native installs, and report the last recorded update outcome.
 
-- [#49](https://github.com/Pythoughts-labs/pythinker-code/pull/49) [`f35061e`](https://github.com/Pythoughts-labs/pythinker-code/commit/f35061e39de539476d3897c6acf4966991669576) - Model permission deny rules now also apply to subagent model overrides coming from agent profiles and from resume or retry, not only to models named in tool arguments; a denied override falls back to the parent agent's model.
+- [#49](https://github.com/PyModel/pythinker-code/pull/49) [`f35061e`](https://github.com/PyModel/pythinker-code/commit/f35061e39de539476d3897c6acf4966991669576) - Model permission deny rules now also apply to subagent model overrides coming from agent profiles and from resume or retry, not only to models named in tool arguments; a denied override falls back to the parent agent's model.
 
-- [#46](https://github.com/Pythoughts-labs/pythinker-code/pull/46) [`bceff21`](https://github.com/Pythoughts-labs/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Stop reporting an update as installed when the executable did not change; the version is checked after the installer finishes and a mismatch is recorded as a failure with the reason.
+- [#46](https://github.com/PyModel/pythinker-code/pull/46) [`bceff21`](https://github.com/PyModel/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Stop reporting an update as installed when the executable did not change; the version is checked after the installer finishes and a mismatch is recorded as a failure with the reason.
 
-- [#46](https://github.com/Pythoughts-labs/pythinker-code/pull/46) [`bceff21`](https://github.com/Pythoughts-labs/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Show download progress under the prompt while a Windows update installs, instead of nothing until it finishes.
+- [#46](https://github.com/PyModel/pythinker-code/pull/46) [`bceff21`](https://github.com/PyModel/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Show download progress under the prompt while a Windows update installs, instead of nothing until it finishes.
 
-- [#46](https://github.com/Pythoughts-labs/pythinker-code/pull/46) [`bceff21`](https://github.com/Pythoughts-labs/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Fix automatic updates on Windows for npm, pnpm, and yarn installs, which failed to start at all.
+- [#46](https://github.com/PyModel/pythinker-code/pull/46) [`bceff21`](https://github.com/PyModel/pythinker-code/commit/bceff2191cd196f30cd59a297ad29b642073030d) - Fix automatic updates on Windows for npm, pnpm, and yarn installs, which failed to start at all.
 
-- [#50](https://github.com/Pythoughts-labs/pythinker-code/pull/50) [`38e3504`](https://github.com/Pythoughts-labs/pythinker-code/commit/38e35047069dd4f9a22e3160e34861b6550b6b56) - Record the origin of the prompt that entered Dynamic Workflow mode, so a fan-out started by a scheduled job or hook is attributable in the session records.
+- [#50](https://github.com/PyModel/pythinker-code/pull/50) [`38e3504`](https://github.com/PyModel/pythinker-code/commit/38e35047069dd4f9a22e3160e34861b6550b6b56) - Record the origin of the prompt that entered Dynamic Workflow mode, so a fan-out started by a scheduled job or hook is attributable in the session records.
 
-- [#49](https://github.com/Pythoughts-labs/pythinker-code/pull/49) [`f35061e`](https://github.com/Pythoughts-labs/pythinker-code/commit/f35061e39de539476d3897c6acf4966991669576) - Subagent lifecycle events now carry the workflow name on start, completion and failure, and suspension events carry both the workflow run id and name, so clients can correlate every event without caching the spawn event.
+- [#49](https://github.com/PyModel/pythinker-code/pull/49) [`f35061e`](https://github.com/PyModel/pythinker-code/commit/f35061e39de539476d3897c6acf4966991669576) - Subagent lifecycle events now carry the workflow name on start, completion and failure, and suspension events carry both the workflow run id and name, so clients can correlate every event without caching the spawn event.
 
 ## 0.13.1
 
 ### Patch Changes
 
-- [#43](https://github.com/Pythoughts-labs/pythinker-code/pull/43) [`0ea74d4`](https://github.com/Pythoughts-labs/pythinker-code/commit/0ea74d4b7afa49e79440bff9464ed4019e3fcb1c) - Dim the wording on background task status lines so only the status dot is coloured.
+- [#43](https://github.com/PyModel/pythinker-code/pull/43) [`0ea74d4`](https://github.com/PyModel/pythinker-code/commit/0ea74d4b7afa49e79440bff9464ed4019e3fcb1c) - Dim the wording on background task status lines so only the status dot is coloured.
 
 ## 0.13.0
 
 ### Minor Changes
 
-- [#41](https://github.com/Pythoughts-labs/pythinker-code/pull/41) [`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Let permission rules gate the model a subagent runs on, so `Agent(model:some-model)` and `DynamicWorkflow(model:some-model)` now match instead of being silently ignored.
+- [#41](https://github.com/PyModel/pythinker-code/pull/41) [`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Let permission rules gate the model a subagent runs on, so `Agent(model:some-model)` and `DynamicWorkflow(model:some-model)` now match instead of being silently ignored.
 
-- [#41](https://github.com/Pythoughts-labs/pythinker-code/pull/41) [`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Show the Dynamic Workflow plan before the run in `auto` permission mode, which previously approved the call without displaying it. The approval is asked once per distinct plan; `yolo` still approves without asking.
+- [#41](https://github.com/PyModel/pythinker-code/pull/41) [`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Show the Dynamic Workflow plan before the run in `auto` permission mode, which previously approved the call without displaying it. The approval is asked once per distinct plan; `yolo` still approves without asking.
 
 ### Patch Changes
 
-- [#41](https://github.com/Pythoughts-labs/pythinker-code/pull/41) [`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix Dynamic Workflow recent activity showing one growing line three times instead of the last three lines an agent wrote.
+- [#41](https://github.com/PyModel/pythinker-code/pull/41) [`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix Dynamic Workflow recent activity showing one growing line three times instead of the last three lines an agent wrote.
 
-- [#41](https://github.com/Pythoughts-labs/pythinker-code/pull/41) [`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Drop the preamble every Dynamic Workflow task repeats so each agent row shows the part that names it.
+- [#41](https://github.com/PyModel/pythinker-code/pull/41) [`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Drop the preamble every Dynamic Workflow task repeats so each agent row shows the part that names it.
 
-- [#41](https://github.com/Pythoughts-labs/pythinker-code/pull/41) [`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix the Dynamic Workflow card clipping an agent's task down to one character once that agent returned a long summary.
+- [#41](https://github.com/PyModel/pythinker-code/pull/41) [`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix the Dynamic Workflow card clipping an agent's task down to one character once that agent returned a long summary.
 
-- [#41](https://github.com/Pythoughts-labs/pythinker-code/pull/41) [`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix `/workflow save` leaving the saved workflow uncallable until the session was reloaded, and add `Session.reloadSkills()` to re-discover skills written while a session is open.
+- [#41](https://github.com/PyModel/pythinker-code/pull/41) [`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix `/workflow save` leaving the saved workflow uncallable until the session was reloaded, and add `Session.reloadSkills()` to re-discover skills written while a session is open.
 
 ## 0.12.0
 
 ### Minor Changes
 
-- [#35](https://github.com/Pythoughts-labs/pythinker-code/pull/35) [`2ce6b5e`](https://github.com/Pythoughts-labs/pythinker-code/commit/2ce6b5e66935335567a6525413ad8e77b84d852f) - Show the plan before a Dynamic Workflow runs, and let a good one be saved as a command
+- [#35](https://github.com/PyModel/pythinker-code/pull/35) [`2ce6b5e`](https://github.com/PyModel/pythinker-code/commit/2ce6b5e66935335567a6525413ad8e77b84d852f) - Show the plan before a Dynamic Workflow runs, and let a good one be saved as a command
 
   Manual mode used to approve every `DynamicWorkflow` call outright. That approval
   only ever fired in manual mode — auto and yolo approve earlier in the chain — so
@@ -86,155 +86,155 @@
   `/workflow save <name>` writes the last run back out as a skill under
   `.pythinker-code/skills/`, so a fan-out that worked can be re-run by name.
 
-- [#38](https://github.com/Pythoughts-labs/pythinker-code/pull/38) [`44efbc7`](https://github.com/Pythoughts-labs/pythinker-code/commit/44efbc77360105de0efce185c86740fcf503944e) - Let a release declare a minimum supported version, so a client below it is offered the update without waiting for its staged rollout batch.
+- [#38](https://github.com/PyModel/pythinker-code/pull/38) [`44efbc7`](https://github.com/PyModel/pythinker-code/commit/44efbc77360105de0efce185c86740fcf503944e) - Let a release declare a minimum supported version, so a client below it is offered the update without waiting for its staged rollout batch.
 
-- [#38](https://github.com/Pythoughts-labs/pythinker-code/pull/38) [`44efbc7`](https://github.com/Pythoughts-labs/pythinker-code/commit/44efbc77360105de0efce185c86740fcf503944e) - Show update availability and live download progress in the status row under the prompt, replacing the startup banner chip that was computed once and never refreshed.
+- [#38](https://github.com/PyModel/pythinker-code/pull/38) [`44efbc7`](https://github.com/PyModel/pythinker-code/commit/44efbc77360105de0efce185c86740fcf503944e) - Show update availability and live download progress in the status row under the prompt, replacing the startup banner chip that was computed once and never refreshed.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Rename the ACP authentication method to reflect that login is multi-provider: it now reads "Log in with a provider" and explains that the provider is chosen in a terminal. Clients matching the previous wording will need updating.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Rename the ACP authentication method to reflect that login is multi-provider: it now reads "Log in with a provider" and explains that the provider is chosen in a terminal. Clients matching the previous wording will need updating.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Let a Dynamic Workflow require structured output from its subagents. Passing `output_schema` makes each subagent return a validated object instead of free text, and a subagent that cannot satisfy the schema is reported separately from one that failed outright.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Let a Dynamic Workflow require structured output from its subagents. Passing `output_schema` makes each subagent return a validated object instead of free text, and a subagent that cannot satisfy the schema is reported separately from one that failed outright.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - `pythinker login` now opens a provider picker instead of going straight to one provider, and accepts `--provider <id|name>` to skip it. The VS Code extension's sign-in offers the same providers, and both surfaces present the same thinking-effort levels for a given model.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - `pythinker login` now opens a provider picker instead of going straight to one provider, and accepts `--provider <id|name>` to skip it. The VS Code extension's sign-in offers the same providers, and both surfaces present the same thinking-effort levels for a given model.
 
-- [#34](https://github.com/Pythoughts-labs/pythinker-code/pull/34) [`42da384`](https://github.com/Pythoughts-labs/pythinker-code/commit/42da384cb36d29ecf0cc147f753790e022e13709) - Make the login platform layer provider-neutral. Model listing, capability derivation and the on-disk config shape are now one set of types shared by every login path, instead of living in a provider-specific module that other providers imported from; the duplicate copies of the capability derivation and the model-info parser are collapsed into one.
+- [#34](https://github.com/PyModel/pythinker-code/pull/34) [`42da384`](https://github.com/PyModel/pythinker-code/commit/42da384cb36d29ecf0cc147f753790e022e13709) - Make the login platform layer provider-neutral. Model listing, capability derivation and the on-disk config shape are now one set of types shared by every login path, instead of living in a provider-specific module that other providers imported from; the duplicate copies of the capability derivation and the model-info parser are collapsed into one.
 
   Logging in is an API key, a models.dev catalog provider, or OpenAI Codex OAuth. "Is the user logged in" is now a single predicate over configured providers with a usable credential, shared by the CLI, the VS Code extension and the ACP adapter. `/feedback` opens the issue tracker.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Give every Dynamic Workflow run an id and stamp it on the subagent events it produces, so a client can tell which run a given subagent belongs to when several are in flight.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Give every Dynamic Workflow run an id and stamp it on the subagent events it produces, so a client can tell which run a given subagent belongs to when several are in flight.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Add two ways to rein in Dynamic Workflow fan-out: `disableWorkflows` turns the tool off entirely, and `workflowSizeGuideline` sets an advisory ceiling that is mentioned to the model and warned about, on every surface, when a run exceeds it. Both are settable in config or by environment variable.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Add two ways to rein in Dynamic Workflow fan-out: `disableWorkflows` turns the tool off entirely, and `workflowSizeGuideline` sets an advisory ceiling that is mentioned to the model and warned about, on every surface, when a run exceeds it. Both are settable in config or by environment variable.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Bound subagent fan-out with hard caps: 128 subagents per call, 200 per session, and a nesting depth of 3. Nesting was previously unbounded, so a workflow that spawned workflows could grow without limit; past depth 3 the call now fails instead.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Bound subagent fan-out with hard caps: 128 subagents per call, 200 per session, and a nesting depth of 3. Nesting was previously unbounded, so a workflow that spawned workflows could grow without limit; past depth 3 the call now fails instead.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Replace the Dynamic Workflow progress bar with the two things it can actually know: how many tool calls each agent has made, and how long it has been silent. The old bar pinned every tool-using agent at 75% until it finished, so an agent working hard and one wedged for ten minutes looked identical. A row that goes quiet now turns amber, then red.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Replace the Dynamic Workflow progress bar with the two things it can actually know: how many tool calls each agent has made, and how long it has been silent. The old bar pinned every tool-using agent at 75% until it finished, so an agent working hard and one wedged for ten minutes looked identical. A row that goes quiet now turns amber, then red.
 
-- [#30](https://github.com/Pythoughts-labs/pythinker-code/pull/30) [`463b176`](https://github.com/Pythoughts-labs/pythinker-code/commit/463b1766a80389fe44cd675bff29b83b3ce6c86b) - Let a Dynamic Workflow run its subagents on a different model than the agent orchestrating them. `DynamicWorkflow` accepts `model` and `effort` for every subagent in the call, and `/workflow model <alias>` sets that model for the session so an expensive orchestrator can hand mechanical work to a cheaper or faster one.
+- [#30](https://github.com/PyModel/pythinker-code/pull/30) [`463b176`](https://github.com/PyModel/pythinker-code/commit/463b1766a80389fe44cd675bff29b83b3ce6c86b) - Let a Dynamic Workflow run its subagents on a different model than the agent orchestrating them. `DynamicWorkflow` accepts `model` and `effort` for every subagent in the call, and `/workflow model <alias>` sets that model for the session so an expensive orchestrator can hand mechanical work to a cheaper or faster one.
 
 ### Patch Changes
 
-- [#37](https://github.com/Pythoughts-labs/pythinker-code/pull/37) [`12069a8`](https://github.com/Pythoughts-labs/pythinker-code/commit/12069a890144380bff5d648ad51d7411ece94437) - Stop offering updates to versions that were never published: the update channel now advertises only the release that is actually available for download.
+- [#37](https://github.com/PyModel/pythinker-code/pull/37) [`12069a8`](https://github.com/PyModel/pythinker-code/commit/12069a890144380bff5d648ad51d7411ece94437) - Stop offering updates to versions that were never published: the update channel now advertises only the release that is actually available for download.
 
-- [#38](https://github.com/Pythoughts-labs/pythinker-code/pull/38) [`44efbc7`](https://github.com/Pythoughts-labs/pythinker-code/commit/44efbc77360105de0efce185c86740fcf503944e) - Stop offering an update with no build for the running platform, give every installer network call a timeout, expire a stale install lease instead of blocking updates forever, and say which version is installing and why a failed one stopped retrying.
+- [#38](https://github.com/PyModel/pythinker-code/pull/38) [`44efbc7`](https://github.com/PyModel/pythinker-code/commit/44efbc77360105de0efce185c86740fcf503944e) - Stop offering an update with no build for the running platform, give every installer network call a timeout, expire a stale install lease instead of blocking updates forever, and say which version is installing and why a failed one stopped retrying.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Survive two malformed inputs that used to end a run. A catalog entry that is not an object is now dropped when the catalog is read, instead of reaching the provider picker and throwing past the bundled-catalog fallback that was meant to save the login. A non-finite subagent concurrency limit now falls back to the default: `NaN` passed every clamp, and each free-slot test against it was false, so the batch launched nothing and never finished.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Survive two malformed inputs that used to end a run. A catalog entry that is not an object is now dropped when the catalog is read, instead of reaching the provider picker and throwing past the bundled-catalog fallback that was meant to save the login. A non-finite subagent concurrency limit now falls back to the default: `NaN` passed every clamp, and each free-slot test against it was false, so the batch launched nothing and never finished.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Offer a model's declared thinking-effort levels when signing in to OpenAI Codex. The picker previously fell back to low / medium / high regardless of what the model supports, disagreeing with the effort list recorded in the config it then wrote.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Offer a model's declared thinking-effort levels when signing in to OpenAI Codex. The picker previously fell back to low / medium / high regardless of what the model supports, disagreeing with the effort list recorded in the config it then wrote.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Accept a provider's plain id for `--provider` at login, so a catalog provider no longer has to be named by its full display name, and stop a cancelled OpenAI Codex sign-in from holding the process open for the rest of its two-minute callback timeout. In the editor extension, signing in now shows one cancellable progress notification, a repeated sign-in joins the one already running instead of opening a second set of prompts, and a completed sign-in is no longer reported as failed when the status refresh behind it fails.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Accept a provider's plain id for `--provider` at login, so a catalog provider no longer has to be named by its full display name, and stop a cancelled OpenAI Codex sign-in from holding the process open for the rest of its two-minute callback timeout. In the editor extension, signing in now shows one cancellable progress notification, a repeated sign-in joins the one already running instead of opening a second set of prompts, and a completed sign-in is no longer reported as failed when the status refresh behind it fails.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Save the thinking-effort level picked during login. Only an on/off flag was stored, so choosing `low`, `medium`, or `xhigh` reopened the session at `high`, and an OpenAI Codex login reopened at the model's maximum effort regardless of the choice.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Save the thinking-effort level picked during login. Only an on/off flag was stored, so choosing `low`, `medium`, or `xhigh` reopened the session at `high`, and an OpenAI Codex login reopened at the model's maximum effort regardless of the choice.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Write the thinking effort picked at login to disk. The apply step recorded the level, but the patch that saved the result listed everything except it, so an API-key login still reopened at the default effort. Choosing `off` now also clears a level a previous login left behind, which a patch that only merges could not do by omitting the key.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Write the thinking effort picked at login to disk. The apply step recorded the level, but the patch that saved the result listed everything except it, so an API-key login still reopened at the default effort. Choosing `off` now also clears a level a previous login left behind, which a patch that only merges could not do by omitting the key.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Keep the configured provider signed in when a login is abandoned. Backing out at the model picker, or a failure while fetching the model list, no longer clears the existing credentials, and dismissing the provider picker returns to the sign-in screen instead of reporting a failed login.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Keep the configured provider signed in when a login is abandoned. Backing out at the model picker, or a failure while fetching the model list, no longer clears the existing credentials, and dismissing the provider picker returns to the sign-in screen instead of reporting a failed login.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Refuse a device authorization whose verification URL is not HTTPS. Every surface hands that URL to the host's "open externally" API, so a provider answering with `file:`, `javascript:`, or an installed application's own scheme had the agent launch it. The check runs where the response is parsed, so the terminal, the TUI, and the editor extension are all covered.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Refuse a device authorization whose verification URL is not HTTPS. Every surface hands that URL to the host's "open externally" API, so a provider answering with `file:`, `javascript:`, or an installed application's own scheme had the agent launch it. The check runs where the response is parsed, so the terminal, the TUI, and the editor extension are all covered.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Finish handling blank Dynamic Workflow items. A run that dropped one reported its results after a note explaining the drop, which made the whole result parse as unsupported and rendered a successful run as failed; the note now follows the results. A blank entry also no longer leaves a row queued forever with the header stuck below its total, and no longer pushes a full item list over the subagent cap and back into whole-call rejection.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Finish handling blank Dynamic Workflow items. A run that dropped one reported its results after a note explaining the drop, which made the whole result parse as unsupported and rendered a successful run as failed; the note now follows the results. A blank entry also no longer leaves a row queued forever with the header stuck below its total, and no longer pushes a full item list over the subagent cap and back into whole-call rejection.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Ignore empty entries in a Dynamic Workflow's item list instead of rejecting the call. A trailing empty item used to fail argument validation, which discarded the whole workflow before any subagent started and forced the agent to send every prompt again. The dropped count is now reported with the results, and the launch panel counts only the subagents that will actually run.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Ignore empty entries in a Dynamic Workflow's item list instead of rejecting the call. A trailing empty item used to fail argument validation, which discarded the whole workflow before any subagent started and forced the agent to send every prompt again. The dropped count is now reported with the results, and the launch panel counts only the subagents that will actually run.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Stop a Dynamic Workflow row that has not started from reading as stalled. A queued row measured its silence from the launch of the whole run, so a long queue turned every waiting row amber and then red while nothing was wrong. A queued row now shows the same placeholder a finished one does, and a suspended row keeps its count without the alarm colours, because only a running row can stall.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Stop a Dynamic Workflow row that has not started from reading as stalled. A queued row measured its silence from the launch of the whole run, so a long queue turned every waiting row amber and then red while nothing was wrong. A queued row now shows the same placeholder a finished one does, and a suspended row keeps its count without the alarm colours, because only a running row can stall.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Keep a Dynamic Workflow subagent's output schema when a provider rate limit forces its turn to be retried. The retried turn lost the schema, so the subagent answered in prose and the workflow reported it as completed rather than as a schema failure.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Keep a Dynamic Workflow subagent's output schema when a provider rate limit forces its turn to be retried. The retried turn lost the schema, so the subagent answered in prose and the workflow reported it as completed rather than as a schema failure.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Show a Dynamic Workflow's running rows with a spinning grey dot, so a working agent reads as motion rather than as a static dot the eye cannot tell from a finished one, and shimmer the Orchestrating label in periwinkle instead of grey.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Show a Dynamic Workflow's running rows with a spinning grey dot, so a working agent reads as motion rather than as a static dot the eye cannot tell from a finished one, and shimmer the Orchestrating label in periwinkle instead of grey.
 
-- [#32](https://github.com/Pythoughts-labs/pythinker-code/pull/32) [`a504a82`](https://github.com/Pythoughts-labs/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Show the whole large-workflow warning in the editor extension. The line was truncated to the panel width, so in a narrow side panel the reader saw the opening words and no reason.
+- [#32](https://github.com/PyModel/pythinker-code/pull/32) [`a504a82`](https://github.com/PyModel/pythinker-code/commit/a504a820c4d9db14e213f4a021c86b048c4b916d) - Show the whole large-workflow warning in the editor extension. The line was truncated to the panel width, so in a narrow side panel the reader saw the opening words and no reason.
 
-- [#28](https://github.com/Pythoughts-labs/pythinker-code/pull/28) [`cf5b6b1`](https://github.com/Pythoughts-labs/pythinker-code/commit/cf5b6b16e999431bd1a8f511c09883c330fc569d) - Keep a subagent on the model and effort its profile assigns when the subagent is resumed or retried, instead of reverting it to the main agent's model.
+- [#28](https://github.com/PyModel/pythinker-code/pull/28) [`cf5b6b1`](https://github.com/PyModel/pythinker-code/commit/cf5b6b16e999431bd1a8f511c09883c330fc569d) - Keep a subagent on the model and effort its profile assigns when the subagent is resumed or retried, instead of reverting it to the main agent's model.
 
-- [#31](https://github.com/Pythoughts-labs/pythinker-code/pull/31) [`e5e9de4`](https://github.com/Pythoughts-labs/pythinker-code/commit/e5e9de46f0f51be6f3ab3d03d59a5841779c2215) - Brighten the periwinkle accent in the VS Code extension's dark theme so inline code in chat is easier to read.
+- [#31](https://github.com/PyModel/pythinker-code/pull/31) [`e5e9de4`](https://github.com/PyModel/pythinker-code/commit/e5e9de46f0f51be6f3ab3d03d59a5841779c2215) - Brighten the periwinkle accent in the VS Code extension's dark theme so inline code in chat is easier to read.
 
-- [#31](https://github.com/Pythoughts-labs/pythinker-code/pull/31) [`e5e9de4`](https://github.com/Pythoughts-labs/pythinker-code/commit/e5e9de46f0f51be6f3ab3d03d59a5841779c2215) - Let `/yolo` and `/auto` be used in the VS Code extension before the first message is sent — the request now applies to the session that chat opens next instead of failing with "Could not change the permission mode."
+- [#31](https://github.com/PyModel/pythinker-code/pull/31) [`e5e9de4`](https://github.com/PyModel/pythinker-code/commit/e5e9de46f0f51be6f3ab3d03d59a5841779c2215) - Let `/yolo` and `/auto` be used in the VS Code extension before the first message is sent — the request now applies to the session that chat opens next instead of failing with "Could not change the permission mode."
 
-- [#24](https://github.com/Pythoughts-labs/pythinker-code/pull/24) [`ae01098`](https://github.com/Pythoughts-labs/pythinker-code/commit/ae01098b862a567552c7d49a6d5bd1808077a794) - Fix the Dynamic Workflow card showing `[object Object]`, phantom extra agent rows, and tool labels fused into streamed text when a workflow is called with object items.
+- [#24](https://github.com/PyModel/pythinker-code/pull/24) [`ae01098`](https://github.com/PyModel/pythinker-code/commit/ae01098b862a567552c7d49a6d5bd1808077a794) - Fix the Dynamic Workflow card showing `[object Object]`, phantom extra agent rows, and tool labels fused into streamed text when a workflow is called with object items.
 
-- [#24](https://github.com/Pythoughts-labs/pythinker-code/pull/24) [`ae01098`](https://github.com/Pythoughts-labs/pythinker-code/commit/ae01098b862a567552c7d49a6d5bd1808077a794) - Show Dynamic Workflow member progress from the observed stage only, so a running subagent no longer sits at 99% for the rest of its run.
+- [#24](https://github.com/PyModel/pythinker-code/pull/24) [`ae01098`](https://github.com/PyModel/pythinker-code/commit/ae01098b862a567552c7d49a6d5bd1808077a794) - Show Dynamic Workflow member progress from the observed stage only, so a running subagent no longer sits at 99% for the rest of its run.
 
 ## 0.9.2
 
 ### Patch Changes
 
-- [#25](https://github.com/Pythoughts-labs/pythinker-code/pull/25) [`649ec69`](https://github.com/Pythoughts-labs/pythinker-code/commit/649ec69f8e039c031248ce939faadf253bee7259) - Let `/yolo` and `/auto` take effect in the VS Code extension while the agent is running, and auto-approve the requests already waiting on screen.
+- [#25](https://github.com/PyModel/pythinker-code/pull/25) [`649ec69`](https://github.com/PyModel/pythinker-code/commit/649ec69f8e039c031248ce939faadf253bee7259) - Let `/yolo` and `/auto` take effect in the VS Code extension while the agent is running, and auto-approve the requests already waiting on screen.
 
 ## 0.9.0
 
 ### Minor Changes
 
-- [#22](https://github.com/Pythoughts-labs/pythinker-code/pull/22) [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Name the managed OAuth provider after the platform that serves it. It is reached over `auth.kimi.com` and `api.kimi.com`, but it was registered as `managed:pythinker-code`, which read as a first-party service in a client that talks to several providers. The provider id is now `managed:kimi-code`, its models are aliased `kimi-code/*`, and its credentials are stored under `oauth/kimi-code`.
+- [#22](https://github.com/PyModel/pythinker-code/pull/22) [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Name the managed OAuth provider after the platform that serves it. It is reached over `auth.kimi.com` and `api.kimi.com`, but it was registered as `managed:pythinker-code`, which read as a first-party service in a client that talks to several providers. The provider id is now `managed:kimi-code`, its models are aliased `kimi-code/*`, and its credentials are stored under `oauth/kimi-code`.
 
   This is a breaking change for an existing config: the previous entries are not rewritten, so run `pythinker login` once to provision the managed provider under its current name, then remove the stale `managed:pythinker-code` entry.
 
-- [#22](https://github.com/Pythoughts-labs/pythinker-code/pull/22) [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Resolve a workspace's skills without opening a session, so an editor panel can list them before its first message.
+- [#22](https://github.com/PyModel/pythinker-code/pull/22) [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Resolve a workspace's skills without opening a session, so an editor panel can list them before its first message.
 
 ### Patch Changes
 
-- [#22](https://github.com/Pythoughts-labs/pythinker-code/pull/22) [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Add an SDK routine that imports a catalog provider and its models into the persisted config, and use it for the CLI provider import so both entry points preserve existing defaults the same way.
+- [#22](https://github.com/PyModel/pythinker-code/pull/22) [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Add an SDK routine that imports a catalog provider and its models into the persisted config, and use it for the CLI provider import so both entry points preserve existing defaults the same way.
 
-- [#22](https://github.com/Pythoughts-labs/pythinker-code/pull/22) [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Stop the fixed-layout TUI anchoring its first frames to the shell cursor, which pushed the panel border into scrollback.
+- [#22](https://github.com/PyModel/pythinker-code/pull/22) [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Stop the fixed-layout TUI anchoring its first frames to the shell cursor, which pushed the panel border into scrollback.
 
 ## 0.8.1
 
 ### Patch Changes
 
-- [`b5b7b97`](https://github.com/Pythoughts-labs/pythinker-code/commit/b5b7b976df2a5fddd28a15ad034a2bd7cc8babb7) - Fix the native install script exiting immediately without installing anything when run the documented way, `curl -fsSL … | bash`, which also broke automatic background updates for native installs.
+- [`b5b7b97`](https://github.com/PyModel/pythinker-code/commit/b5b7b976df2a5fddd28a15ad034a2bd7cc8babb7) - Fix the native install script exiting immediately without installing anything when run the documented way, `curl -fsSL … | bash`, which also broke automatic background updates for native installs.
 
-- [`d7a5db0`](https://github.com/Pythoughts-labs/pythinker-code/commit/d7a5db02c668ec88f94cb3ccbdb7f314d8a28791) - Report why an automatic update failed instead of failing silently: the installer's error output is now recorded and shown on the next update prompt, native installs on macOS and Linux pin the version the rollout picked, and update messages tell you to open a new terminal to apply the update.
+- [`d7a5db0`](https://github.com/PyModel/pythinker-code/commit/d7a5db02c668ec88f94cb3ccbdb7f314d8a28791) - Report why an automatic update failed instead of failing silently: the installer's error output is now recorded and shown on the next update prompt, native installs on macOS and Linux pin the version the rollout picked, and update messages tell you to open a new terminal to apply the update.
 
 ## 0.8.0
 
 ### Minor Changes
 
-- [`23e0bc7`](https://github.com/Pythoughts-labs/pythinker-code/commit/23e0bc7ed62e718cee0b709ab0ab483ef6b87708) - Improve performance and fix bugs.
+- [`23e0bc7`](https://github.com/PyModel/pythinker-code/commit/23e0bc7ed62e718cee0b709ab0ab483ef6b87708) - Improve performance and fix bugs.
 
-- [`c0f0976`](https://github.com/Pythoughts-labs/pythinker-code/commit/c0f09769e76c92002ca9b9a09d9cb820750f1046) - Remove the Pythinker Datasource plugin from the marketplace; its data gateway backend is not available, so every datasource query failed.
+- [`c0f0976`](https://github.com/PyModel/pythinker-code/commit/c0f09769e76c92002ca9b9a09d9cb820750f1046) - Remove the Pythinker Datasource plugin from the marketplace; its data gateway backend is not available, so every datasource query failed.
 
-- [`c0f0976`](https://github.com/Pythoughts-labs/pythinker-code/commit/c0f09769e76c92002ca9b9a09d9cb820750f1046) - Enable automatic updates for native installs on Windows: `/update` now installs the new version in the background instead of printing a manual command, and the installer safely replaces the running executable.
+- [`c0f0976`](https://github.com/PyModel/pythinker-code/commit/c0f09769e76c92002ca9b9a09d9cb820750f1046) - Enable automatic updates for native installs on Windows: `/update` now installs the new version in the background instead of printing a manual command, and the installer safely replaces the running executable.
 
 ### Patch Changes
 
-- [`c0f0976`](https://github.com/Pythoughts-labs/pythinker-code/commit/c0f09769e76c92002ca9b9a09d9cb820750f1046) - Fix Kimi and Moonshot models rejecting every request with an invalid tool schema error when a tool declares `anyOf` alongside its own type or properties.
+- [`c0f0976`](https://github.com/PyModel/pythinker-code/commit/c0f09769e76c92002ca9b9a09d9cb820750f1046) - Fix Kimi and Moonshot models rejecting every request with an invalid tool schema error when a tool declares `anyOf` alongside its own type or properties.
 
 ## 0.7.0
 
 ### Minor Changes
 
-- [#12](https://github.com/Pythoughts-labs/pythinker-code/pull/12) [`02f7f8d`](https://github.com/Pythoughts-labs/pythinker-code/commit/02f7f8d93ff138611298f8d46c5c54e928c7ae59) - Prepare verified Homebrew updates in the background and install them automatically on the next interactive launch.
+- [#12](https://github.com/PyModel/pythinker-code/pull/12) [`02f7f8d`](https://github.com/PyModel/pythinker-code/commit/02f7f8d93ff138611298f8d46c5c54e928c7ae59) - Prepare verified Homebrew updates in the background and install them automatically on the next interactive launch.
 
 ### Patch Changes
 
-- [#12](https://github.com/Pythoughts-labs/pythinker-code/pull/12) [`02f7f8d`](https://github.com/Pythoughts-labs/pythinker-code/commit/02f7f8d93ff138611298f8d46c5c54e928c7ae59) - Fix context compaction failing with provider "Invalid max_tokens" errors by capping requested completion tokens to the remaining context window and a safe output ceiling instead of the full context window size.
+- [#12](https://github.com/PyModel/pythinker-code/pull/12) [`02f7f8d`](https://github.com/PyModel/pythinker-code/commit/02f7f8d93ff138611298f8d46c5c54e928c7ae59) - Fix context compaction failing with provider "Invalid max_tokens" errors by capping requested completion tokens to the remaining context window and a safe output ceiling instead of the full context window size.
 
-- [#12](https://github.com/Pythoughts-labs/pythinker-code/pull/12) [`02f7f8d`](https://github.com/Pythoughts-labs/pythinker-code/commit/02f7f8d93ff138611298f8d46c5c54e928c7ae59) - Fix Dynamic Workflow progress sticking at 90% during long streaming, show a Finalizing state once all delegated agents finish, and fix member row alignment at narrow widths.
+- [#12](https://github.com/PyModel/pythinker-code/pull/12) [`02f7f8d`](https://github.com/PyModel/pythinker-code/commit/02f7f8d93ff138611298f8d46c5c54e928c7ae59) - Fix Dynamic Workflow progress sticking at 90% during long streaming, show a Finalizing state once all delegated agents finish, and fix member row alignment at narrow widths.
 
 ## 0.6.2
 
 ### Patch Changes
 
-- [#10](https://github.com/Pythoughts-labs/pythinker-code/pull/10) [`ad2391b`](https://github.com/Pythoughts-labs/pythinker-code/commit/ad2391b5601f173d7eecdaab55f1110f506c1ad1) - Clear the terminal before the install script's animated intro so earlier shell output no longer interleaves with the logo animation.
+- [#10](https://github.com/PyModel/pythinker-code/pull/10) [`ad2391b`](https://github.com/PyModel/pythinker-code/commit/ad2391b5601f173d7eecdaab55f1110f506c1ad1) - Clear the terminal before the install script's animated intro so earlier shell output no longer interleaves with the logo animation.
 
-- [#10](https://github.com/Pythoughts-labs/pythinker-code/pull/10) [`ad2391b`](https://github.com/Pythoughts-labs/pythinker-code/commit/ad2391b5601f173d7eecdaab55f1110f506c1ad1) - Restyle the browser OAuth sign-in confirmation pages for all providers to match the website's light design.
+- [#10](https://github.com/PyModel/pythinker-code/pull/10) [`ad2391b`](https://github.com/PyModel/pythinker-code/commit/ad2391b5601f173d7eecdaab55f1110f506c1ad1) - Restyle the browser OAuth sign-in confirmation pages for all providers to match the website's light design.
 
 ## 0.6.1
 
 ### Patch Changes
 
-- [#7](https://github.com/Pythoughts-labs/pythinker-code/pull/7) [`d396320`](https://github.com/Pythoughts-labs/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Prompt for an API key when connecting a catalog provider whose environment variable is not set, instead of failing with "Environment variable is not set or is empty". Applies to `/login`, `/provider`, and `pythinker provider catalog add`, which now also accepts `--api-key <key>`.
+- [#7](https://github.com/PyModel/pythinker-code/pull/7) [`d396320`](https://github.com/PyModel/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Prompt for an API key when connecting a catalog provider whose environment variable is not set, instead of failing with "Environment variable is not set or is empty". Applies to `/login`, `/provider`, and `pythinker provider catalog add`, which now also accepts `--api-key <key>`.
 
-- [#7](https://github.com/Pythoughts-labs/pythinker-code/pull/7) [`d396320`](https://github.com/Pythoughts-labs/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Explain in `/update` and the startup update notice that Homebrew installs do not auto-update, and point to the native installer for automatic background updates.
+- [#7](https://github.com/PyModel/pythinker-code/pull/7) [`d396320`](https://github.com/PyModel/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Explain in `/update` and the startup update notice that Homebrew installs do not auto-update, and point to the native installer for automatic background updates.
 
-- [#7](https://github.com/Pythoughts-labs/pythinker-code/pull/7) [`d396320`](https://github.com/Pythoughts-labs/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Point the native install scripts at the published release assets.
+- [#7](https://github.com/PyModel/pythinker-code/pull/7) [`d396320`](https://github.com/PyModel/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Point the native install scripts at the published release assets.
 
-- [#7](https://github.com/Pythoughts-labs/pythinker-code/pull/7) [`d396320`](https://github.com/Pythoughts-labs/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Show a clear requirement message with the native-installer alternative when the CLI is launched on Node.js older than 26.4, instead of failing with a cryptic flag error.
+- [#7](https://github.com/PyModel/pythinker-code/pull/7) [`d396320`](https://github.com/PyModel/pythinker-code/commit/d396320235e31ce09f04f0da244ec5a694e2bcfe) - Show a clear requirement message with the native-installer alternative when the CLI is launched on Node.js older than 26.4, instead of failing with a cryptic flag error.
 
-- [#8](https://github.com/Pythoughts-labs/pythinker-code/pull/8) [`9b1b195`](https://github.com/Pythoughts-labs/pythinker-code/commit/9b1b19577a5826f33a2bd70116c48bfeb46362ad) - Fix the CLI failing to start on Windows with "process.execve is unavailable" by using the spawn fallback instead of calling execve there.
+- [#8](https://github.com/PyModel/pythinker-code/pull/8) [`9b1b195`](https://github.com/PyModel/pythinker-code/commit/9b1b19577a5826f33a2bd70116c48bfeb46362ad) - Fix the CLI failing to start on Windows with "process.execve is unavailable" by using the spawn fallback instead of calling execve there.
 
 ## 0.6.0
 
 ### Minor Changes
 
-- [`d7a2554`](https://github.com/Pythoughts-labs/pythinker-code/commit/d7a25545a6f6fb0c2024a11dcde8012a087c9e44) - Maintenance release with internal improvements and dependency updates.
+- [`d7a2554`](https://github.com/PyModel/pythinker-code/commit/d7a25545a6f6fb0c2024a11dcde8012a087c9e44) - Maintenance release with internal improvements and dependency updates.
 
 ## 0.5.1
 
@@ -258,104 +258,104 @@
 
 ### Minor Changes
 
-- [`fc6a226`](https://github.com/Pythoughts-labs/pythinker-code/commit/fc6a22694298d884070130d5918ce7b14c585fdb) - Add the `/update` slash command (alias `/upgrade`) the welcome banner has been advertising: it checks the CDN for a newer version and installs it in the background, falling back to a copyable command for installs that cannot self-update (e.g. Homebrew). `pythinker doctor` now reports whether auto-update is on, off via `tui.toml [upgrade].auto_install`, or disabled by `PYTHINKER_CODE_NO_AUTO_UPDATE`.
+- [`fc6a226`](https://github.com/PyModel/pythinker-code/commit/fc6a22694298d884070130d5918ce7b14c585fdb) - Add the `/update` slash command (alias `/upgrade`) the welcome banner has been advertising: it checks the CDN for a newer version and installs it in the background, falling back to a copyable command for installs that cannot self-update (e.g. Homebrew). `pythinker doctor` now reports whether auto-update is on, off via `tui.toml [upgrade].auto_install`, or disabled by `PYTHINKER_CODE_NO_AUTO_UPDATE`.
 
 ## 0.2.0
 
 ### Minor Changes
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add provider-native Fast mode controls for supported OpenAI and Anthropic models.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add provider-native Fast mode controls for supported OpenAI and Anthropic models.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add validated session and persistent workspace directories with SDK, CLI, and TUI management.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add validated session and persistent workspace directories with SDK, CLI, and TUI management.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the precedence-resolved agent profile catalog through the SDK and a searchable TUI command.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the precedence-resolved agent profile catalog through the SDK and a searchable TUI command.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persistent named agent teams with background teammate spawning, shared task scopes, direct and broadcast messaging, assignment delivery, shutdown coordination, and native terminal identities.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persistent named agent teams with background teammate spawning, shared task scopes, direct and broadcast messaging, assignment delivery, shutdown coordination, and native terminal identities.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add project, user, and namespaced plugin subagent profiles with per-profile turn limits and persistent memory, context-fork workers, per-agent model and working-directory overrides, and Git worktree isolation with native terminal status.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add project, user, and namespaced plugin subagent profiles with per-profile turn limits and persistent memory, context-fork workers, per-agent model and working-directory overrides, and Git worktree isolation with native terminal status.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add Anthropic Claude Code marketplace browsing and installation with searchable source selection and install-definition support.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add Anthropic Claude Code marketplace browsing and installation with searchable source selection and install-definition support.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve full truncated Bash output on disk, interpret informational exit codes, and expand destructive-command warnings in the terminal approval flow.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve full truncated Bash output on disk, interpret informational exit codes, and expand destructive-command warnings in the terminal approval flow.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add clearer TUI startup status, effort heat, Dynamic Workflow progress colors, and a brighter dark-theme primary.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add clearer TUI startup status, effort heat, Dynamic Workflow progress colors, and a brighter dark-theme primary.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add catalog-backed provider connections with interactive or environment-referenced credentials, live model discovery, provider-aware model selection, and model-specific thinking controls.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add catalog-backed provider connections with interactive or environment-referenced credentials, live model discovery, provider-aware model selection, and model-specific thinking controls.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add an agent-callable Config tool for approved, validated reads and writes of supported Pythinker settings.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add an agent-callable Config tool for approved, validated reads and writes of supported Pythinker settings.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add configurable Global and Chat TUI keybindings with unbinding, two-key chords, reserved shortcuts, dynamic help labels, template creation, and editor-backed reload.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add configurable Global and Chat TUI keybindings with unbinding, two-key chords, reserved shortcuts, dynamic help labels, template creation, and editor-backed reload.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose files loaded by Read through the SDK and a `/files` TUI command.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose files loaded by Read through the SDK and a `/files` TUI command.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the model-visible context breakdown through the SDK and a `/context` TUI report.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the model-visible context breakdown through the SDK and a `/context` TUI report.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Show Dynamic Workflow in a coral-framed mission-control panel with live per-agent progress, and let workflow agents run without an automatic timeout.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Show Dynamic Workflow in a coral-framed mission-control panel with live per-agent progress, and let workflow agents run without an automatic timeout.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persisted file checkpoints with preview and recovery-backed code or conversation rewind through the SDK, CLI, and TUI.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persisted file checkpoints with preview and recovery-backed code or conversation rewind through the SDK, CLI, and TUI.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add fail-closed Read/Edit/Write state tracking, quote-preserving edits, automatic parent creation, and cell-aware Jupyter notebook editing with terminal summaries.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add fail-closed Read/Edit/Write state tracking, quote-preserving edits, automatic parent creation, and cell-aware Jupyter notebook editing with terminal summaries.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add unchanged-range deduplication and structured Jupyter notebook reads with cell, text-output, and image-output support.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add unchanged-range deduplication and structured Jupyter notebook reads with cell, text-output, and image-output support.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Rework the TUI into a fixed full-height layout: the input box and status bar stay pinned to the bottom, the mouse wheel scrolls the conversation, drag-selecting text copies it to the clipboard, and `layout = "inline"` in tui.toml restores the legacy inline behavior.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Rework the TUI into a fixed full-height layout: the input box and status bar stay pinned to the bottom, the mouse wheel scrolls the conversation, drag-selecting text copies it to the clipboard, and `layout = "inline"` in tui.toml restores the legacy inline behavior.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add configurable context-aware keybindings across dialogs, plugins, rewind,
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add configurable context-aware keybindings across dialogs, plugins, rewind,
   message actions, footer controls, and both terminal renderers.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add experimental plugin-configured language-server support with lazy stdio servers and agent-callable navigation, symbol, hover, reference, implementation, and call-hierarchy operations.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add experimental plugin-configured language-server support with lazy stdio servers and agent-callable navigation, symbol, hover, reference, implementation, and call-hierarchy operations.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add MCP resource discovery and reading with terminal-native summaries.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add MCP resource discovery and reading with terminal-native summaries.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add live instruction refresh and a `/memory` command for user and project memory files.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add live instruction refresh and a `/memory` command for user and project memory files.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add discoverable built-in, user, project, and plugin output styles with config-backed prompt injection and TUI selection.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add discoverable built-in, user, project, and plugin output styles with config-backed prompt injection and TUI selection.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add experimental native PowerShell execution on Windows with non-interactive invocation, streamed foreground and background output, timeout handling, exact-command approval, and terminal language metadata.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add experimental native PowerShell execution on Windows with non-interactive invocation, streamed foreground and background output, timeout handling, exact-command approval, and terminal language metadata.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add responsive option previews, per-question notes, answer annotations, automatic Other choices, and source telemetry tags to structured questions.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add responsive option previews, per-question notes, answer annotations, automatic Other choices, and source telemetry tags to structured questions.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Complete Glob and Grep parity with absolute glob patterns, sensitive-name filtering, context aliases, and multiple glob filters.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Complete Glob and Grep parity with absolute glob patterns, sensitive-name filtering, context aliases, and multiple glob filters.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add `/cost` to show accumulated session spend and current model token rates, with pricing data available through SDK session status.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add `/cost` to show accumulated session spend and current model token rates, with pricing data available through SDK session status.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose session metadata through the SDK and add searchable session tags with `/tag`.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose session metadata through the SDK and add searchable session tags with `/tag`.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add explicitly requested session worktree entry and exit with named resume, cwd and hook rebinding, safe keep behavior, and fail-closed removal confirmation.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add explicitly requested session worktree entry and exit with named resume, cwd and hook rebinding, safe keep behavior, and fail-closed removal confirmation.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add JSON Schema validated structured output to prompt mode.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add JSON Schema validated structured output to prompt mode.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persistent project-task creation, lookup, dependency-aware listing, and updates while retaining explicit background-task listing.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persistent project-task creation, lookup, dependency-aware listing, and updates while retaining explicit background-task listing.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add per-model thinking effort levels: pick the level in the model selector or with the new `/effort` command, cycle it with Ctrl-T, and see the current level in the footer and on the input box border.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add per-model thinking effort levels: pick the level in the model selector or with the new `/effort` command, cycle it with Ctrl-T, and see the current level in the footer and on the input box border.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Show estimated token throughput while output streams in the TUI footer, then replace it with the provider-reported completed rate.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Show estimated token throughput while output streams in the TUI footer, then replace it with the provider-reported completed rate.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a TUI copy command for recent assistant responses and fenced code blocks with clipboard and file fallbacks.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a TUI copy command for recent assistant responses and fenced code blocks with clipboard and file fallbacks.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Build the OpenTUI dialog slice with native searchable-dialog interactions.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Build the OpenTUI dialog slice with native searchable-dialog interactions.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose configuration and keybinding diagnostics through the TUI doctor command.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose configuration and keybinding diagnostics through the TUI doctor command.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add `/colors` and polish terminal progress, context, question, and Markdown activity displays while preserving reasoning-summary boundaries.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add `/colors` and polish terminal progress, context, question, and Markdown activity displays while preserving reasoning-summary boundaries.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add native TUI management for persisted allow, ask, and deny permission rules.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add native TUI management for persisted allow, ask, and deny permission rules.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add TUI commands for listing discovered skills and configured hooks.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add TUI commands for listing discovered skills and configured hooks.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expand the TUI colour palette from 18 to 50 semantic tokens — shimmer variants, eight per-subagent identity colours, dimmed diff shades, a rainbow set, mode-identity badges, background surfaces, and progress-bar fill — and add a curried theme-aware `colorize` helper that accepts either a palette token or a raw hex.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expand the TUI colour palette from 18 to 50 semantic tokens — shimmer variants, eight per-subagent identity colours, dimmed diff shades, a rainbow set, mode-identity badges, background surfaces, and progress-bar fill — and add a curried theme-aware `colorize` helper that accepts either a palette token or a raw hex.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Wire the vim core into the composer behind an opt-in `vimMode` option. A narrow, version-pinned bridge is the only seam to pi-tui's private editor state; terminal escape sequences and bracketed pastes are classified before vim sees them, so paste, arrows, and Kitty-protocol keys keep working in every mode.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Wire the vim core into the composer behind an opt-in `vimMode` option. A narrow, version-pinned bridge is the only seam to pi-tui's private editor state; terminal escape sequences and bracketed pastes are classified before vim sees them, so paste, arrows, and Kitty-protocol keys keep working in every mode.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add the `vim_mode` experimental flag, off by default, so modal editing in the composer can be toggled through `/vim` or `/experiments`, `PYTHINKER_CODE_EXPERIMENTAL_VIM_MODE`, or config. The editor picks the flag up when the snapshot lands and follows runtime configuration changes.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add the `vim_mode` experimental flag, off by default, so modal editing in the composer can be toggled through `/vim` or `/experiments`, `PYTHINKER_CODE_EXPERIMENTAL_VIM_MODE`, or config. The editor picks the flag up when the snapshot lands and follows runtime configuration changes.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add the vim-mode state machine for the composer: NORMAL/INSERT transitions, counts, and the full movement set (character, line, word, line-anchored, document, and line-local find with repeat). Pure and renderer-agnostic — editing operators, text objects, and visual mode follow, as does the editor wiring.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add the vim-mode state machine for the composer: NORMAL/INSERT transitions, counts, and the full movement set (character, line, word, line-anchored, document, and line-local find with repeat). Pure and renderer-agnostic — editing operators, text objects, and visual mode follow, as does the editor wiring.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add vim editing operators to the composer state machine: `d`/`c`/`y` over any motion, doubled linewise forms, the single-key shortcuts (`x`, `X`, `s`, `S`, `D`, `C`, `Y`), text objects (`iw`/`aw`, quotes, nested brackets), and an unnamed register with charwise and linewise paste.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add vim editing operators to the composer state machine: `d`/`c`/`y` over any motion, doubled linewise forms, the single-key shortcuts (`x`, `X`, `s`, `S`, `D`, `C`, `Y`), text objects (`iw`/`aw`, quotes, nested brackets), and an unnamed register with charwise and linewise paste.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Complete the vim core for the composer: charwise and linewise visual mode with selection operators, and dot-repeat (`.`) driven by a structured repeat spec rather than replayed keystrokes.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Complete the vim core for the composer: charwise and linewise visual mode with selection operators, and dot-repeat (`.`) driven by a structured repeat spec rather than replayed keystrokes.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a read-only verification agent and request independent checks when multi-step task lists close without verification.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a read-only verification agent and request independent checks when multi-step task lists close without verification.
   Accept TodoWrite-compatible checklist items and show their active labels while tasks are in progress.
   Cache successful local URL fetches for 15 minutes with a 50 MiB bound.
   Preserve binary URL responses and save them through Kaos with MIME-derived filenames.
@@ -440,93 +440,93 @@
   Handle MCP form elicitation through the existing question UI with typed JSON Schema validation and paged fields.
   Run source-compatible `Elicitation` and `ElicitationResult` hooks around MCP forms, including validated hook-supplied responses.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add cancellable URL fetching with per-host approval and safe redirect handoff, plus allowed and blocked domain filters for web search.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add cancellable URL fetching with per-host approval and safe redirect handoff, plus allowed and blocked domain filters for web search.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose bounded working-tree diffs through the SDK and a native `/diff` browser.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose bounded working-tree diffs through the SDK and a native `/diff` browser.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a configurable `[status_line]` TUI section to toggle footer status items, and show the YOLO indicator on a dedicated row beneath the model.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a configurable `[status_line]` TUI section to toggle footer status items, and show the YOLO indicator on a dedicated row beneath the model.
 
 ### Patch Changes
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Align Anthropic-compatible thinking profiles, output limits, and incomplete stream handling with model capabilities.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Align Anthropic-compatible thinking profiles, output limits, and incomplete stream handling with model capabilities.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Pulse the Bash activity marker while a command is running and keep the completed marker green.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Pulse the Bash activity marker while a command is running and keep the completed marker green.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Accept `/branch` and `/rewind` as compatibility aliases for `/fork` and `/undo`.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Accept `/branch` and `/rewind` as compatibility aliases for `/fork` and `/undo`.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Allow provider catalog refresh for providers that register an API key directly instead of an environment variable.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Allow provider catalog refresh for providers that register an API key directly instead of an environment variable.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Update OpenAI Codex OAuth for the new model catalog: bump the models client_version gate to 0.145.0 so the gpt-5.6 family appears, carry each model's supported reasoning efforts into config, send real max effort on the wire (ultra maps in as max), clamp requests to what each model supports, and default Codex sign-in to the top supported effort.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Update OpenAI Codex OAuth for the new model catalog: bump the models client_version gate to 0.145.0 so the gpt-5.6 family appears, carry each model's supported reasoning efforts into config, send real max effort on the wire (ultra maps in as max), clamp requests to what each model supports, and default Codex sign-in to the top supported effort.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Align context usage displays with 1024-based units and ceiled percentages.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Align context usage displays with 1024-based units and ceiled percentages.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Prevent repeated session debug exports from overwriting earlier archives by including a timestamp in the default filename.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Prevent repeated session debug exports from overwriting earlier archives by including a timestamp in the default filename.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Default agent reasoning and responses to English unless the user explicitly requests another language.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Default agent reasoning and responses to English unless the user explicitly requests another language.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Increase the default per-step LLM retry budget from 3 to 10 attempts.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Increase the default per-step LLM retry budget from 3 to 10 attempts.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Allow DynamicWorkflow items to be complete prompts when no template is supplied.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Allow DynamicWorkflow items to be complete prompts when no template is supplied.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Show DynamicWorkflow request failures once instead of repeating the reason for every member.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Show DynamicWorkflow request failures once instead of repeating the reason for every member.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Pin @agentclientprotocol/sdk to ^0.23.0 to restore the unstable session-model API the ACP adapter implements, and fix the adapter's typecheck.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Pin @agentclientprotocol/sdk to ^0.23.0 to restore the unstable session-model API the ACP adapter implements, and fix the adapter's typecheck.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Rename the stale afk reference to auto in the built-in MCP configuration guidance.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Rename the stale afk reference to auto in the built-in MCP configuration guidance.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Prevent agent idle cleanup failures from surfacing as unhandled rejections.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Prevent agent idle cleanup failures from surfacing as unhandled rejections.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Translate binary download failures through the standard fetch error path.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Translate binary download failures through the standard fetch error path.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix Unicode-safe Vim editing, application shortcuts, selector state, key chords, mouse-selection auto-scrolling, and active-tab contrast.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix Unicode-safe Vim editing, application shortcuts, selector state, key chords, mouse-selection auto-scrolling, and active-tab contrast.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve graceful shutdown and exit codes under repeated signals or closed output streams, persist provider removals and cleared defaults, reject unsafe marketplace refs, and recover safely from stalled marketplace loads and interrupted update installs.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve graceful shutdown and exit codes under repeated signals or closed output streams, persist provider removals and cleared defaults, reject unsafe marketplace refs, and recover safely from stalled marketplace loads and interrupted update installs.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix ctrl+b / ctrl+f paging in the approval preview and task output viewer under the Kitty keyboard protocol. Both shortcuts compared raw C0 bytes, so they did nothing in terminals that send CSI-u — including VSCode's integrated terminal — while the page-up/page-down checks beside them worked.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix ctrl+b / ctrl+f paging in the approval preview and task output viewer under the Kitty keyboard protocol. Both shortcuts compared raw C0 bytes, so they did nothing in terminals that send CSI-u — including VSCode's integrated terminal — while the page-up/page-down checks beside them worked.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Keep Dynamic Workflow results bounded and correctly decoded while preventing undone workflows from receiving late events.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Keep Dynamic Workflow results bounded and correctly decoded while preventing undone workflows from receiving late events.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve MCP prompt client binding during skill activation.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve MCP prompt client binding during skill activation.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Honor an explicit thinking off setting on OpenAI-compatible providers.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Honor an explicit thinking off setting on OpenAI-compatible providers.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Correct the YOLO and Auto permission mode descriptions in CLI help output and ACP session mode selectors.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Correct the YOLO and Auto permission mode descriptions in CLI help output and ACP session mode selectors.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Correct the YOLO and Auto permission mode descriptions in the web slash command list and mobile permission sheet.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Correct the YOLO and Auto permission mode descriptions in the web slash command list and mobile permission sheet.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Clarify that YOLO auto-approves tool actions while Auto runs fully autonomously without asking questions.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Clarify that YOLO auto-approves tool actions while Auto runs fully autonomously without asking questions.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix TypeScript errors in the TUI welcome/logo components and their tests (index-signature env access, possibly-undefined logo rows).
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix TypeScript errors in the TUI welcome/logo components and their tests (index-signature env access, possibly-undefined logo rows).
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Prevent silent exits from clipboard image failures and report unhandled promise rejections in crash telemetry.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Prevent silent exits from clipboard image failures and report unhandled promise rejections in crash telemetry.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve extended Unicode characters when normalizing replacement quotes.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Preserve extended Unicode characters when normalizing replacement quotes.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix sessions getting stuck after a provider records an assistant message with no sendable content.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix sessions getting stuck after a provider records an assistant message with no sendable content.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix duplicate workspace groups on Windows when the same folder is opened with different path spellings, keeping all of the folder's sessions in one merged group.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix duplicate workspace groups on Windows when the same folder is opened with different path spellings, keeping all of the folder's sessions in one merged group.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Correct the YOLO mode notice shown when replaying a session.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Correct the YOLO mode notice shown when replaying a session.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Include the underlying network cause in OAuth connection error messages instead of only reporting a generic fetch failure.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Include the underlying network cause in OAuth connection error messages instead of only reporting a generic fetch failure.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Resolve every bare `solid-js` import to OpenTUI's client runtime so Solid signal updates reach the terminal buffer.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Resolve every bare `solid-js` import to OpenTUI's client runtime so Solid signal updates reach the terminal buffer.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Stop showing a status message after successful automatic keybinding reloads.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Stop showing a status message after successful automatic keybinding reloads.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Record and close tool calls that never ran after an interrupted model response.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Record and close tool calls that never ran after an interrupted model response.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Replay empty thinking content verbatim on preserved-thinking endpoints.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Replay empty thinking content verbatim on preserved-thinking endpoints.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Scope inferred Anthropic thinking profiles to non-managed Anthropic-compatible providers.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Scope inferred Anthropic thinking profiles to non-managed Anthropic-compatible providers.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix the built-in URL fetch tool's network safeguards so crafted domains and redirect chains cannot reach loopback or internal network services.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix the built-in URL fetch tool's network safeguards so crafted domains and redirect chains cannot reach loopback or internal network services.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Render the slash command menu below the composer and give the selected command a themed pointer and muted description lines.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Render the slash command menu below the composer and give the selected command a themed pointer and muted description lines.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Make MCP startup status lines transient in the TUI: connected/disabled rows show a success mark and disappear after 3 seconds instead of permanently cluttering the transcript, while failed and needs-auth rows stay visible. The welcome-header aggregate remains the durable indicator.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Make MCP startup status lines transient in the TUI: connected/disabled rows show a success mark and disappear after 3 seconds instead of permanently cluttering the transcript, while failed and needs-auth rows stay visible. The welcome-header aggregate remains the durable indicator.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix display-width measurement on the OpenTUI render path: strip ANSI escapes before measuring, segment by grapheme cluster so ZWJ emoji and skin-tone modifiers count once, and expand tabs to match the legacy renderer. Footer, composer, and dialog-list text no longer mis-truncate when coloured or containing emoji.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Fix display-width measurement on the OpenTUI render path: strip ANSI escapes before measuring, segment by grapheme cluster so ZWJ emoji and skin-tone modifiers count once, and expand tabs to match the legacy renderer. Footer, composer, and dialog-list text no longer mis-truncate when coloured or containing emoji.
 
 ## 0.17.1
 

--- a/apps/pythinker-code/README.md
+++ b/apps/pythinker-code/README.md
@@ -2,10 +2,10 @@
 
 > The Starting Point for Next-Gen Agents
 
-[![npm](https://img.shields.io/npm/v/@pythoughts/pythinker-code)](https://www.npmjs.com/package/@pythoughts/pythinker-code) [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)  [![Docs](https://img.shields.io/badge/docs-online-blue)](https://pythoughts-labs.github.io/pythinker-code/)
+[![npm](https://img.shields.io/npm/v/@pythoughts/pythinker-code)](https://www.npmjs.com/package/@pythoughts/pythinker-code) [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)  [![Docs](https://img.shields.io/badge/docs-online-blue)](https://pymodel.github.io/pythinker-code/)
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/Pythoughts-labs/pythinker-code/main/docs/media/terminal-ui.webp" alt="Pythinker Code terminal demo" width="860">
+  <img src="https://raw.githubusercontent.com/PyModel/pythinker-code/main/docs/media/terminal-ui.webp" alt="Pythinker Code terminal demo" width="860">
 </p>
 
 ## What is Pythinker Code CLI
@@ -50,7 +50,7 @@ Or with pnpm:
 pnpm add -g @pythoughts/pythinker-code
 ```
 
-For upgrade and uninstall instructions, see the [Getting Started guide](https://pythoughts-labs.github.io/pythinker-code/guides/getting-started).
+For upgrade and uninstall instructions, see the [Getting Started guide](https://pymodel.github.io/pythinker-code/guides/getting-started).
 
 ## Quick Start
 
@@ -79,13 +79,13 @@ Take a look at this project and explain the main directories.
 
 ## Documentation
 
-- Full docs: https://pythoughts-labs.github.io/pythinker-code/
-- Getting Started: https://pythoughts-labs.github.io/pythinker-code/guides/getting-started
+- Full docs: https://pymodel.github.io/pythinker-code/
+- Getting Started: https://pymodel.github.io/pythinker-code/guides/getting-started
 
 ## Repository & Issues
 
-- Source: https://github.com/Pythoughts-labs/pythinker-code
-- Issues: https://github.com/Pythoughts-labs/pythinker-code/issues
+- Source: https://github.com/PyModel/pythinker-code
+- Issues: https://github.com/PyModel/pythinker-code/issues
 - Security: see SECURITY.md in the main repository
 
 ## License

--- a/apps/pythinker-code/package.json
+++ b/apps/pythinker-code/package.json
@@ -4,14 +4,14 @@
   "description": "The Starting Point for Next-Gen Agents",
   "license": "MIT",
   "author": "Pythoughts",
-  "homepage": "https://github.com/Pythoughts-labs/pythinker-code/tree/main/apps/pythinker-code#readme",
+  "homepage": "https://github.com/PyModel/pythinker-code/tree/main/apps/pythinker-code#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "apps/pythinker-code"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "keywords": [
     "pythinker",

--- a/apps/pythinker-code/src/cli/commands.ts
+++ b/apps/pythinker-code/src/cli/commands.ts
@@ -31,7 +31,7 @@ export function createProgram(
     .configureHelp({ helpWidth: 100 })
     .helpOption('-h, --help', 'Show help.')
     .usage('[options] [command]')
-    .addHelpText('after', '\nDocumentation:        https://pythoughts-labs.github.io/pythinker-code/\n');
+    .addHelpText('after', '\nDocumentation:        https://pymodel.github.io/pythinker-code/\n');
 
   program
     .addOption(

--- a/apps/pythinker-code/src/constant/app.ts
+++ b/apps/pythinker-code/src/constant/app.ts
@@ -38,9 +38,9 @@ export const PYTHINKER_CODE_BANNER_STATE_FILE_NAME = 'state.json';
 // auto-propagates instead of silently breaking the startup recovery path.
 export const OAUTH_LOGIN_REQUIRED_CODE = ErrorCodes.AUTH_LOGIN_REQUIRED;
 
-export const FEEDBACK_ISSUE_URL = 'https://github.com/Pythoughts-labs/pythinker-code/issues';
+export const FEEDBACK_ISSUE_URL = 'https://github.com/PyModel/pythinker-code/issues';
 export const PYTHINKER_CODE_CHANGELOG_URL =
-  'https://pythoughts-labs.github.io/pythinker-code/release-notes/changelog.html';
+  'https://pymodel.github.io/pythinker-code/release-notes/changelog.html';
 
 // Sent in the feedback `version` field so the backend can distinguish this
 // TypeScript client from clients that send a bare version.

--- a/apps/pythinker-code/src/tui/theme/theme-schema.json
+++ b/apps/pythinker-code/src/tui/theme/theme-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/pythoughts-labs/pythinker-code/blob/main/apps/pythinker-code/src/tui/theme/theme-schema.json",
+  "$id": "https://github.com/pymodel/pythinker-code/blob/main/apps/pythinker-code/src/tui/theme/theme-schema.json",
   "title": "Pythinker Code Custom Theme",
   "description": "Schema for Pythinker Code TUI custom theme definitions",
   "type": "object",

--- a/apps/pythinker-code/src/tui/utils/refresh-providers.ts
+++ b/apps/pythinker-code/src/tui/utils/refresh-providers.ts
@@ -404,7 +404,7 @@ export async function refreshAllProviderModels(
   }
 
   // -------------------------------------------------------------------------
-  // 2. Open Platforms (pythoughts-cn, pythoughts-labs, …)
+  // 2. Open Platforms (pythoughts-cn, pymodel, …)
   // -------------------------------------------------------------------------
   const openPlatformIds = Object.keys(config.providers).filter((id) => isOpenPlatformId(id));
   for (const providerId of openPlatformIds) {

--- a/apps/pythinker-code/test/cli/update/cdn.test.ts
+++ b/apps/pythinker-code/test/cli/update/cdn.test.ts
@@ -85,7 +85,7 @@ describe('fetchUpdateManifest', () => {
       publishedAt: '2026-06-12T00:00:00.000Z',
       platforms: {
         'darwin-arm64': {
-          url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
+          url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
           sha256: 'nope',
         },
       },
@@ -145,11 +145,11 @@ describe('fetchUpdateManifest', () => {
       rollout: [],
       platforms: {
         'darwin-arm64': {
-          url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
+          url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
           sha256: 'a'.repeat(64),
         },
         'linux-x64': {
-          url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-linux-x64.zip',
+          url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-linux-x64.zip',
           sha256: 'b'.repeat(64),
         },
       },
@@ -159,11 +159,11 @@ describe('fetchUpdateManifest', () => {
     expect(result.version).toBe('2.0.0');
     expect(result.platforms).toEqual({
       'darwin-arm64': {
-        url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
+        url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
         sha256: 'a'.repeat(64),
       },
       'linux-x64': {
-        url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-linux-x64.zip',
+        url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-linux-x64.zip',
         sha256: 'b'.repeat(64),
       },
     });
@@ -262,7 +262,7 @@ describe('manifestArtifactAvailability', () => {
       rollout: [],
       platforms: {
         'darwin-arm64': {
-          url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
+          url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
           sha256: 'a'.repeat(64),
         },
       },
@@ -277,7 +277,7 @@ describe('manifestArtifactAvailability', () => {
       rollout: [],
       platforms: {
         'darwin-arm64': {
-          url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
+          url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
           sha256: 'a'.repeat(64),
         },
       },
@@ -302,7 +302,7 @@ describe('manifestArtifactAvailability', () => {
       rollout: [],
       platforms: {
         [`${process.platform}-${process.arch}`]: {
-          url: 'https://github.com/Pythoughts-labs/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
+          url: 'https://github.com/PyModel/pythinker-code/releases/download/%40pythoughts%2Fpythinker-code%400.9.2/pythinker-code-darwin-arm64.zip',
           sha256: 'a'.repeat(64),
         },
       },

--- a/apps/pythinker-code/test/cli/update/preflight.test.ts
+++ b/apps/pythinker-code/test/cli/update/preflight.test.ts
@@ -1815,7 +1815,7 @@ describe('runUpdatePreflight', () => {
     const rendered = stdout.join('');
     expect(rendered).toContain('Pythinker Code updated to v0.5.0');
     expect(rendered).toContain(
-      'https://pythoughts-labs.github.io/pythinker-code/release-notes/changelog.html',
+      'https://pymodel.github.io/pythinker-code/release-notes/changelog.html',
     );
     expect(track).toHaveBeenCalledWith('update_success_notice_shown', expect.objectContaining({
       version: '0.5.0',

--- a/apps/pythinker-code/test/cli/update/prompt.test.ts
+++ b/apps/pythinker-code/test/cli/update/prompt.test.ts
@@ -34,7 +34,7 @@ describe('install prompt helpers', () => {
 
 describe('promptForInstallChoice', () => {
   it('renders changelog hyperlink in the prompt output', async () => {
-    const CHANGELOG_URL = 'https://pythoughts-labs.github.io/pythinker-code/release-notes/changelog.html';
+    const CHANGELOG_URL = 'https://pymodel.github.io/pythinker-code/release-notes/changelog.html';
 
     const input = Object.assign(new EventEmitter(), {
       isRaw: false,

--- a/apps/pythinker-code/test/tui/pythinker-tui-message-flow.test.ts
+++ b/apps/pythinker-code/test/tui/pythinker-tui-message-flow.test.ts
@@ -4577,7 +4577,7 @@ command = "vim"
       const transcript = stripSgr(renderTranscript(driver));
       expect(transcript).toContain('Release notes');
       expect(transcript).toContain(
-        'https://pythoughts-labs.github.io/pythinker-code/release-notes/changelog.html',
+        'https://pymodel.github.io/pythinker-code/release-notes/changelog.html',
       );
     });
     expect(session.prompt).not.toHaveBeenCalled();

--- a/apps/pythinker-web/public/install.ps1
+++ b/apps/pythinker-web/public/install.ps1
@@ -36,7 +36,7 @@ param(
   $ErrorActionPreference = "Stop"
   Set-StrictMode -Version 2.0
 
-  $Repo = "Pythoughts-labs/pythinker-code"
+  $Repo = "PyModel/pythinker-code"
   $CdnLatestUrl = "https://code.pythinker.com/pythinker-code/latest"
   $InstallShUrl = "https://code.pythinker.com/pythinker-code/install.sh"
   $InstallPs1Url = "https://code.pythinker.com/pythinker-code/install.ps1"

--- a/apps/pythinker-web/public/install.sh
+++ b/apps/pythinker-web/public/install.sh
@@ -25,7 +25,7 @@ VERSION=""
 INSTALL_PREFIX="${PYTHINKER_INSTALL_PREFIX:-$HOME/.local}"
 NO_COLOR="${NO_COLOR:-}"
 
-REPO="Pythoughts-labs/pythinker-code"
+REPO="PyModel/pythinker-code"
 CDN_LATEST_URL="https://code.pythinker.com/pythinker-code/latest"
 
 # Network timeout policy. The script owns retry — _download_with_progress and

--- a/apps/site/Caddyfile
+++ b/apps/site/Caddyfile
@@ -9,7 +9,7 @@
 
 	header Content-Signal "ai-train=no, search=yes, ai-input=yes"
 	header / {
-		Link "<https://pythoughts-labs.github.io/pythinker-code/>; rel=\"describedby\"; type=\"text/html\", </index.md>; rel=\"alternate\"; type=\"text/markdown\""
+		Link "<https://pymodel.github.io/pythinker-code/>; rel=\"describedby\"; type=\"text/html\", </index.md>; rel=\"alternate\"; type=\"text/markdown\""
 		Vary "Accept"
 	}
 	header @markdown Content-Type "text/markdown; charset=utf-8"

--- a/apps/site/public/index.md
+++ b/apps/site/public/index.md
@@ -28,13 +28,13 @@ irm https://code.pythinker.com/pythinker-code/install.ps1 | iex
 ### Homebrew
 
 ```sh
-brew install pythoughts-labs/tap/pythinker-code
+brew install pymodel/tap/pythinker-code
 ```
 
 ### Nix
 
 ```sh
-nix run github:Pythoughts-labs/pythinker-code
+nix run github:PyModel/pythinker-code
 ```
 
 ### npm
@@ -61,9 +61,9 @@ Verify the installation with `pythinker --version`.
 
 ## Resources
 
-- [Documentation](https://pythoughts-labs.github.io/pythinker-code/)
-- [Getting started](https://pythoughts-labs.github.io/pythinker-code/guides/getting-started)
-- [Configuration](https://pythoughts-labs.github.io/pythinker-code/configuration/config-files)
-- [Command reference](https://pythoughts-labs.github.io/pythinker-code/reference/pythinker-command)
-- [GitHub repository](https://github.com/Pythoughts-labs/pythinker-code)
+- [Documentation](https://pymodel.github.io/pythinker-code/)
+- [Getting started](https://pymodel.github.io/pythinker-code/guides/getting-started)
+- [Configuration](https://pymodel.github.io/pythinker-code/configuration/config-files)
+- [Command reference](https://pymodel.github.io/pythinker-code/reference/pythinker-command)
+- [GitHub repository](https://github.com/PyModel/pythinker-code)
 - [npm package](https://www.npmjs.com/package/@pythoughts/pythinker-code)

--- a/apps/site/scripts/build-cdn.mjs
+++ b/apps/site/scripts/build-cdn.mjs
@@ -89,7 +89,7 @@ async function resolvePublishedRelease(packageName) {
   return { version, publishedAt };
 }
 
-const RELEASE_DOWNLOAD_BASE = 'https://github.com/Pythoughts-labs/pythinker-code/releases/download';
+const RELEASE_DOWNLOAD_BASE = 'https://github.com/PyModel/pythinker-code/releases/download';
 
 // Set to a version string only when an older client can no longer work against
 // the current services; it makes every client below it take the update without

--- a/apps/site/src/App.vue
+++ b/apps/site/src/App.vue
@@ -10,8 +10,8 @@ const version = __PYTHINKER_VERSION__;
 const installRows = [
   ['macOS / Linux', 'curl -fsSL https://code.pythinker.com/pythinker-code/install.sh | bash', '/brand/apple.svg'],
   ['Windows (PowerShell)', 'irm https://code.pythinker.com/pythinker-code/install.ps1 | iex', '/brand/windows11.svg'],
-  ['Homebrew', 'brew install pythoughts-labs/tap/pythinker-code'],
-  ['Nix', 'nix run github:Pythoughts-labs/pythinker-code'],
+  ['Homebrew', 'brew install pymodel/tap/pythinker-code'],
+  ['Nix', 'nix run github:PyModel/pythinker-code'],
   ['npm', 'npm install -g @pythoughts/pythinker-code', '/brand/npm.svg'],
   ['Verify', 'pythinker --version'],
 ];
@@ -203,8 +203,8 @@ onUnmounted(() => {
       <a href="/" class="nav-brand"><PythinkerMascot :width="26" :height="32" /><span>Pythinker Code</span></a>
       <div class="nav-actions">
         <div class="nav-links">
-          <a href="https://pythoughts-labs.github.io/pythinker-code/" target="_blank" rel="noopener">Docs</a>
-          <a href="https://github.com/Pythoughts-labs/pythinker-code" target="_blank" rel="noopener"><img src="/brand/github.svg" alt="" width="16" height="16" />GitHub</a>
+          <a href="https://pymodel.github.io/pythinker-code/" target="_blank" rel="noopener">Docs</a>
+          <a href="https://github.com/PyModel/pythinker-code" target="_blank" rel="noopener"><img src="/brand/github.svg" alt="" width="16" height="16" />GitHub</a>
           <a href="https://www.npmjs.com/package/@pythoughts/pythinker-code" target="_blank" rel="noopener"><img src="/brand/npm.svg" alt="" width="16" height="16" />npm</a>
         </div>
         <a class="button button-primary nav-cta" href="#install">Get started</a>
@@ -214,8 +214,8 @@ onUnmounted(() => {
           </button>
           <Transition name="mobile-menu">
             <div v-show="menuOpen" class="mobile-menu-panel">
-              <a href="https://pythoughts-labs.github.io/pythinker-code/" target="_blank" rel="noopener" @click="closeMenu(false)">Docs</a>
-              <a href="https://github.com/Pythoughts-labs/pythinker-code" target="_blank" rel="noopener" @click="closeMenu(false)"><img src="/brand/github.svg" alt="" width="16" height="16" />GitHub</a>
+              <a href="https://pymodel.github.io/pythinker-code/" target="_blank" rel="noopener" @click="closeMenu(false)">Docs</a>
+              <a href="https://github.com/PyModel/pythinker-code" target="_blank" rel="noopener" @click="closeMenu(false)"><img src="/brand/github.svg" alt="" width="16" height="16" />GitHub</a>
               <a href="https://www.npmjs.com/package/@pythoughts/pythinker-code" target="_blank" rel="noopener" @click="closeMenu(false)"><img src="/brand/npm.svg" alt="" width="16" height="16" />npm</a>
             </div>
           </Transition>
@@ -473,10 +473,10 @@ onUnmounted(() => {
           </tbody>
         </table>
         <div class="link-rail">
-          <a href="https://pythoughts-labs.github.io/pythinker-code/guides/getting-started" target="_blank" rel="noopener"><span>Getting Started</span><small>Install, authenticate, and run your first task.</small></a>
-          <a href="https://pythoughts-labs.github.io/pythinker-code/guides/ides" target="_blank" rel="noopener"><span>Using in IDEs</span><small>Connect Pythinker Code through ACP.</small></a>
-          <a href="https://pythoughts-labs.github.io/pythinker-code/configuration/config-files" target="_blank" rel="noopener"><span>Configuration</span><small>Set models, providers, and permissions.</small></a>
-          <a href="https://pythoughts-labs.github.io/pythinker-code/reference/pythinker-command" target="_blank" rel="noopener"><span>Command reference</span><small>Review CLI commands and options.</small></a>
+          <a href="https://pymodel.github.io/pythinker-code/guides/getting-started" target="_blank" rel="noopener"><span>Getting Started</span><small>Install, authenticate, and run your first task.</small></a>
+          <a href="https://pymodel.github.io/pythinker-code/guides/ides" target="_blank" rel="noopener"><span>Using in IDEs</span><small>Connect Pythinker Code through ACP.</small></a>
+          <a href="https://pymodel.github.io/pythinker-code/configuration/config-files" target="_blank" rel="noopener"><span>Configuration</span><small>Set models, providers, and permissions.</small></a>
+          <a href="https://pymodel.github.io/pythinker-code/reference/pythinker-command" target="_blank" rel="noopener"><span>Command reference</span><small>Review CLI commands and options.</small></a>
         </div>
       </div>
     </section>
@@ -486,7 +486,7 @@ onUnmounted(() => {
         <h2 id="cta-title">Install it. Point it at a repo. Ship.</h2>
         <div class="cta-actions">
           <a class="button button-primary" href="#install">Get started</a>
-          <a class="button button-secondary" href="https://pythoughts-labs.github.io/pythinker-code/" target="_blank" rel="noopener">Read the docs</a>
+          <a class="button button-secondary" href="https://pymodel.github.io/pythinker-code/" target="_blank" rel="noopener">Read the docs</a>
         </div>
       </div>
     </section>
@@ -496,11 +496,11 @@ onUnmounted(() => {
     <div class="container footer-inner">
       <div><div class="footer-brand"><PythinkerMascot :width="16" :height="20" /><p class="wordmark">Pythinker Code</p><span class="footer-version">v{{ version }}</span></div><p class="footer-caption">Built by Pythoughts. MIT License.</p></div>
       <div class="footer-links">
-        <a href="https://github.com/Pythoughts-labs/pythinker-code" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/PyModel/pythinker-code" target="_blank" rel="noopener">GitHub</a>
         <a href="https://www.npmjs.com/package/@pythoughts/pythinker-code" target="_blank" rel="noopener">npm</a>
-        <a href="https://pythoughts-labs.github.io/pythinker-code/" target="_blank" rel="noopener">Docs</a>
+        <a href="https://pymodel.github.io/pythinker-code/" target="_blank" rel="noopener">Docs</a>
         <a href="https://pythinker.com" target="_blank" rel="noopener">pythinker.com</a>
-        <a href="https://github.com/Pythoughts-labs/pythinker-code/blob/main/SECURITY.md" target="_blank" rel="noopener">Security</a>
+        <a href="https://github.com/PyModel/pythinker-code/blob/main/SECURITY.md" target="_blank" rel="noopener">Security</a>
       </div>
     </div>
   </footer>

--- a/apps/site/src/components/InstallCommand.vue
+++ b/apps/site/src/components/InstallCommand.vue
@@ -142,7 +142,7 @@ onUnmounted(() => {
           <svg v-if="selectedId === channel.id" aria-hidden="true" viewBox="0 0 20 20"><path d="m4 10 4 4 8-9" /></svg>
         </button>
         <div class="install-divider" role="separator"></div>
-        <a href="https://github.com/Pythoughts-labs/pythinker-code" target="_blank" rel="noopener">
+        <a href="https://github.com/PyModel/pythinker-code" target="_blank" rel="noopener">
           <span class="channel-label"><img src="/brand/github.svg" alt="" width="16" height="16" />GitHub repository</span>
           <svg aria-hidden="true" viewBox="0 0 20 20"><path d="M6 14 14 6M8 6h6v6" /></svg>
         </a>

--- a/apps/site/src/install-channels.js
+++ b/apps/site/src/install-channels.js
@@ -1,7 +1,7 @@
 export const INSTALL_CHANNELS = [
   { id: 'unix', label: 'Mac / Linux', command: 'curl -fsSL https://code.pythinker.com/pythinker-code/install.sh | bash', icon: '/brand/apple.svg' },
   { id: 'windows', label: 'Windows', command: 'irm https://code.pythinker.com/pythinker-code/install.ps1 | iex', icon: '/brand/windows11.svg' },
-  { id: 'brew', label: 'Homebrew', command: 'brew install pythoughts-labs/tap/pythinker-code' },
-  { id: 'nix', label: 'Nix', command: 'nix run github:Pythoughts-labs/pythinker-code' },
+  { id: 'brew', label: 'Homebrew', command: 'brew install pymodel/tap/pythinker-code' },
+  { id: 'nix', label: 'Nix', command: 'nix run github:PyModel/pythinker-code' },
   { id: 'npm', label: 'npm', command: 'npm install -g @pythoughts/pythinker-code', icon: '/brand/npm.svg' },
 ];

--- a/apps/vscode/CHANGELOG.md
+++ b/apps/vscode/CHANGELOG.md
@@ -4,55 +4,55 @@
 
 ### Minor Changes
 
-- [#48](https://github.com/Pythoughts-labs/pythinker-code/pull/48) [`17967df`](https://github.com/Pythoughts-labs/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Combine permission mode, plan mode, and thinking effort into one composer menu, and answer approval prompts with number keys.
+- [#48](https://github.com/PyModel/pythinker-code/pull/48) [`17967df`](https://github.com/PyModel/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Combine permission mode, plan mode, and thinking effort into one composer menu, and answer approval prompts with number keys.
 
-- [#48](https://github.com/Pythoughts-labs/pythinker-code/pull/48) [`17967df`](https://github.com/Pythoughts-labs/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Add a config hub page that shows models, providers, MCP servers, the local config file, and extension settings in one place.
+- [#48](https://github.com/PyModel/pythinker-code/pull/48) [`17967df`](https://github.com/PyModel/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Add a config hub page that shows models, providers, MCP servers, the local config file, and extension settings in one place.
 
-- [#48](https://github.com/Pythoughts-labs/pythinker-code/pull/48) [`17967df`](https://github.com/Pythoughts-labs/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - The extension UI now follows the editor color theme, including light, dark, and high-contrast themes.
+- [#48](https://github.com/PyModel/pythinker-code/pull/48) [`17967df`](https://github.com/PyModel/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - The extension UI now follows the editor color theme, including light, dark, and high-contrast themes.
 
-- [#48](https://github.com/Pythoughts-labs/pythinker-code/pull/48) [`17967df`](https://github.com/Pythoughts-labs/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Add a status bar indicator, quick-fix code actions, terminal and editor context menu entries, a getting-started walkthrough, and a new-conversation keybinding.
+- [#48](https://github.com/PyModel/pythinker-code/pull/48) [`17967df`](https://github.com/PyModel/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Add a status bar indicator, quick-fix code actions, terminal and editor context menu entries, a getting-started walkthrough, and a new-conversation keybinding.
 
 ### Patch Changes
 
-- [#48](https://github.com/Pythoughts-labs/pythinker-code/pull/48) [`17967df`](https://github.com/Pythoughts-labs/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Render long conversations with a virtualized list, fix control overlap at narrow sidebar widths, and make sign-out work from the command palette.
+- [#48](https://github.com/PyModel/pythinker-code/pull/48) [`17967df`](https://github.com/PyModel/pythinker-code/commit/17967dffb7ca3ed6f23f9bc0346042fc8a1b2bf0) - Render long conversations with a virtualized list, fix control overlap at narrow sidebar widths, and make sign-out work from the command palette.
 
-- Updated dependencies [[`c8cdcc7`](https://github.com/Pythoughts-labs/pythinker-code/commit/c8cdcc78528f3fd8dedf9111ec0c91f3242e3012)]:
+- Updated dependencies [[`c8cdcc7`](https://github.com/PyModel/pythinker-code/commit/c8cdcc78528f3fd8dedf9111ec0c91f3242e3012)]:
   - @pythoughts/pythinker-code-sdk@0.15.0
 
 ## 0.8.8
 
 ### Patch Changes
 
-- Updated dependencies [[`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950)]:
+- Updated dependencies [[`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950)]:
   - @pythoughts/pythinker-code-sdk@0.14.0
 
 ## 0.8.7
 
 ### Patch Changes
 
-- [#39](https://github.com/Pythoughts-labs/pythinker-code/pull/39) [`acf57d1`](https://github.com/Pythoughts-labs/pythinker-code/commit/acf57d197631ce90ef64cf0768bfc22009cda820) - Publish the VS Code extension to Open VSX by creating the publisher namespace first, so Cursor, VSCodium and Windsurf can install it, and report the registry's own error when a publish fails instead of only the CLI exit line.
+- [#39](https://github.com/PyModel/pythinker-code/pull/39) [`acf57d1`](https://github.com/PyModel/pythinker-code/commit/acf57d197631ce90ef64cf0768bfc22009cda820) - Publish the VS Code extension to Open VSX by creating the publisher namespace first, so Cursor, VSCodium and Windsurf can install it, and report the registry's own error when a publish fails instead of only the CLI exit line.
 
 ## 0.8.6
 
 ### Patch Changes
 
-- Updated dependencies [[`2ce6b5e`](https://github.com/Pythoughts-labs/pythinker-code/commit/2ce6b5e66935335567a6525413ad8e77b84d852f)]:
+- Updated dependencies [[`2ce6b5e`](https://github.com/PyModel/pythinker-code/commit/2ce6b5e66935335567a6525413ad8e77b84d852f)]:
   - @pythoughts/pythinker-code-sdk@0.13.0
 
 ## 0.8.5
 
 ### Patch Changes
 
-- Updated dependencies [[`42da384`](https://github.com/Pythoughts-labs/pythinker-code/commit/42da384cb36d29ecf0cc147f753790e022e13709)]:
+- Updated dependencies [[`42da384`](https://github.com/PyModel/pythinker-code/commit/42da384cb36d29ecf0cc147f753790e022e13709)]:
   - @pythoughts/pythinker-code-sdk@0.12.0
 
 ## 0.8.4
 
 ### Patch Changes
 
-- [#22](https://github.com/Pythoughts-labs/pythinker-code/pull/22) [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Show the assistant logo beside replies without breaking the step timeline, complete a picked slash command in the input instead of sending it on its own, ship a decodable Marketplace icon, and retry transient registry failures when publishing.
+- [#22](https://github.com/PyModel/pythinker-code/pull/22) [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Show the assistant logo beside replies without breaking the step timeline, complete a picked slash command in the input instead of sending it on its own, ship a decodable Marketplace icon, and retry transient registry failures when publishing.
 
-- Updated dependencies [[`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32), [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32)]:
+- Updated dependencies [[`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32), [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32)]:
   - @pythoughts/pythinker-code-sdk@0.11.0
 
 ## 0.6.7

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -30,7 +30,7 @@ cross-process session locking is not guaranteed.
 
 ## Docs
 
-Full documentation is available at [pythoughts-labs.github.io/pythinker-code](https://pythoughts-labs.github.io/pythinker-code/).
+Full documentation is available at [pymodel.github.io/pythinker-code](https://pymodel.github.io/pythinker-code/).
 
 ## License
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "apps/vscode"
   },
   "engines": {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,7 +34,7 @@ const config = withMermaid(defineConfig({
     outline: [2, 3],
     search: { provider: 'local' },
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/Pythoughts-labs/pythinker-code' },
+      { icon: 'github', link: 'https://github.com/PyModel/pythinker-code' },
     ],
     nav: [
       { text: 'Guides', link: '/guides/getting-started', activeMatch: '/guides/' },

--- a/docs/.vitepress/theme/components/HomeHero.vue
+++ b/docs/.vitepress/theme/components/HomeHero.vue
@@ -10,7 +10,7 @@ const copy = {
   primaryText: 'Get started',
   primaryHref: '/guides/getting-started',
   secondaryText: 'View on GitHub',
-  secondaryHref: 'https://github.com/Pythoughts-labs/pythinker-code',
+  secondaryHref: 'https://github.com/PyModel/pythinker-code',
 }
 </script>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,5 +9,5 @@ hero:
       link: /guides/getting-started
     - theme: alt
       text: GitHub
-      link: https://github.com/Pythoughts-labs/pythinker-code
+      link: https://github.com/PyModel/pythinker-code
 ---

--- a/flake.nix
+++ b/flake.nix
@@ -211,7 +211,7 @@
 
             meta = {
               description = "Pythinker Code CLI";
-              homepage = "https://github.com/Pythoughts-labs/pythinker-code";
+              homepage = "https://github.com/PyModel/pythinker-code";
               license = lib.licenses.mit;
               mainProgram = "pythinker";
               platforms = systems;

--- a/packages/acp-adapter/README.md
+++ b/packages/acp-adapter/README.md
@@ -2,7 +2,7 @@
 
 Agent Client Protocol adapter for pythinker-code. Exposes the pythinker-code agent over the [Agent Client Protocol](https://agentclientprotocol.com/) so that ACP-compatible clients (editors, IDEs, custom front-ends) can drive a pythinker-code session over stdio.
 
-Part of the [Pythinker Code](https://github.com/Pythoughts-labs/pythinker-code) monorepo.
+Part of the [Pythinker Code](https://github.com/PyModel/pythinker-code) monorepo.
 
 ## Minimum usage
 

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -2,7 +2,7 @@
 
 The unified agent engine for Pythinker Code.
 
-Part of the [Pythinker Code](https://github.com/Pythoughts-labs/pythinker-code) monorepo.
+Part of the [Pythinker Code](https://github.com/PyModel/pythinker-code) monorepo.
 
 See the main repository for documentation, issues, and contribution guidelines.
 

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -5,14 +5,14 @@
   "description": "The unified agent engine for Pythinker",
   "license": "MIT",
   "author": "Pythoughts",
-  "homepage": "https://github.com/Pythoughts-labs/pythinker-code/tree/main/packages/agent-core#readme",
+  "homepage": "https://github.com/PyModel/pythinker-code/tree/main/packages/agent-core#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/agent-core"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "keywords": [
     "pythinker",

--- a/packages/agent-core/src/skill/builtin/custom-theme.md
+++ b/packages/agent-core/src/skill/builtin/custom-theme.md
@@ -52,7 +52,7 @@ Use the first line when it is non-empty; otherwise use the second line. In the r
 Before choosing colors, use **FetchURL** to fetch the official custom-theme docs as the authoritative list of tokens and what each controls:
 
 ```
-https://pythoughts-labs.github.io/pythinker-code/customization/themes.html
+https://pymodel.github.io/pythinker-code/customization/themes.html
 ```
 
 Only set tokens from this set — unknown keys are silently ignored at load. If FetchURL is unavailable or the fetch fails, fall back to the embedded reference below (it mirrors the same tokens) and tell the user you're working from the built-in list rather than the live docs.

--- a/packages/agent-core/src/skill/builtin/update-config.md
+++ b/packages/agent-core/src/skill/builtin/update-config.md
@@ -30,7 +30,7 @@ The "read → copy → Edit → validate → back up → overwrite" flow below a
 Before touching any config, use **FetchURL** to fetch the official config docs as the one authoritative reference for fields (key names, types, allowed values, owning section):
 
 ```
-https://pythoughts-labs.github.io/pythinker-code/configuration/config-files.html
+https://pymodel.github.io/pythinker-code/configuration/config-files.html
 ```
 
 - Use the **snake_case key names and sections exactly as documented** — don't invent them, don't guess camelCase.

--- a/packages/kaos/README.md
+++ b/packages/kaos/README.md
@@ -2,7 +2,7 @@
 
 Execution environment abstraction used by Pythinker Code.
 
-Part of the [Pythinker Code](https://github.com/Pythoughts-labs/pythinker-code) monorepo.
+Part of the [Pythinker Code](https://github.com/PyModel/pythinker-code) monorepo.
 
 See the main repository for documentation, issues, and contribution guidelines.
 

--- a/packages/kaos/package.json
+++ b/packages/kaos/package.json
@@ -5,14 +5,14 @@
   "description": "Execution environment abstraction for AI agent applications",
   "license": "MIT",
   "author": "Pythoughts",
-  "homepage": "https://github.com/Pythoughts-labs/pythinker-code/tree/main/packages/kaos#readme",
+  "homepage": "https://github.com/PyModel/pythinker-code/tree/main/packages/kaos#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/kaos"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "keywords": [
     "pythinker",

--- a/packages/kosong/README.md
+++ b/packages/kosong/README.md
@@ -2,7 +2,7 @@
 
 LLM and provider abstraction layer used by Pythinker Code (`@pythoughts/kosong`).
 
-Part of the [Pythinker Code](https://github.com/Pythoughts-labs/pythinker-code) monorepo.
+Part of the [Pythinker Code](https://github.com/PyModel/pythinker-code) monorepo.
 
 See the main repository for documentation, issues, and contribution guidelines.
 

--- a/packages/kosong/package.json
+++ b/packages/kosong/package.json
@@ -5,14 +5,14 @@
   "description": "The LLM abstraction layer for modern AI agent applications",
   "license": "MIT",
   "author": "Pythoughts",
-  "homepage": "https://github.com/Pythoughts-labs/pythinker-code/tree/main/packages/kosong#readme",
+  "homepage": "https://github.com/PyModel/pythinker-code/tree/main/packages/kosong#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/kosong"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "keywords": [
     "llm",

--- a/packages/node-sdk/CHANGELOG.md
+++ b/packages/node-sdk/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 ### Minor Changes
 
-- [#51](https://github.com/Pythoughts-labs/pythinker-code/pull/51) [`c8cdcc7`](https://github.com/Pythoughts-labs/pythinker-code/commit/c8cdcc78528f3fd8dedf9111ec0c91f3242e3012) - The saved-workflow write helper now takes the working directory and resolves the repository root itself, saved workflows can carry a size guideline, and the workflow size guideline resolver is exported.
+- [#51](https://github.com/PyModel/pythinker-code/pull/51) [`c8cdcc7`](https://github.com/PyModel/pythinker-code/commit/c8cdcc78528f3fd8dedf9111ec0c91f3242e3012) - The saved-workflow write helper now takes the working directory and resolves the repository root itself, saved workflows can carry a size guideline, and the workflow size guideline resolver is exported.
 
 ## 0.14.0
 
 ### Minor Changes
 
-- [#41](https://github.com/Pythoughts-labs/pythinker-code/pull/41) [`e534040`](https://github.com/Pythoughts-labs/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix `/workflow save` leaving the saved workflow uncallable until the session was reloaded, and add `Session.reloadSkills()` to re-discover skills written while a session is open.
+- [#41](https://github.com/PyModel/pythinker-code/pull/41) [`e534040`](https://github.com/PyModel/pythinker-code/commit/e534040c82d1e3b8c217e6e35ddcf248065ff950) - Fix `/workflow save` leaving the saved workflow uncallable until the session was reloaded, and add `Session.reloadSkills()` to re-discover skills written while a session is open.
 
 ## 0.13.0
 
 ### Minor Changes
 
-- [#35](https://github.com/Pythoughts-labs/pythinker-code/pull/35) [`2ce6b5e`](https://github.com/Pythoughts-labs/pythinker-code/commit/2ce6b5e66935335567a6525413ad8e77b84d852f) - Show the plan before a Dynamic Workflow runs, and let a good one be saved as a command
+- [#35](https://github.com/PyModel/pythinker-code/pull/35) [`2ce6b5e`](https://github.com/PyModel/pythinker-code/commit/2ce6b5e66935335567a6525413ad8e77b84d852f) - Show the plan before a Dynamic Workflow runs, and let a good one be saved as a command
 
   Manual mode used to approve every `DynamicWorkflow` call outright. That approval
   only ever fired in manual mode — auto and yolo approve earlier in the chain — so
@@ -34,7 +34,7 @@
 
 ### Minor Changes
 
-- [#34](https://github.com/Pythoughts-labs/pythinker-code/pull/34) [`42da384`](https://github.com/Pythoughts-labs/pythinker-code/commit/42da384cb36d29ecf0cc147f753790e022e13709) - Make the login platform layer provider-neutral. Model listing, capability derivation and the on-disk config shape are now one set of types shared by every login path, instead of living in a provider-specific module that other providers imported from; the duplicate copies of the capability derivation and the model-info parser are collapsed into one.
+- [#34](https://github.com/PyModel/pythinker-code/pull/34) [`42da384`](https://github.com/PyModel/pythinker-code/commit/42da384cb36d29ecf0cc147f753790e022e13709) - Make the login platform layer provider-neutral. Model listing, capability derivation and the on-disk config shape are now one set of types shared by every login path, instead of living in a provider-specific module that other providers imported from; the duplicate copies of the capability derivation and the model-info parser are collapsed into one.
 
   Logging in is an API key, a models.dev catalog provider, or OpenAI Codex OAuth. "Is the user logged in" is now a single predicate over configured providers with a usable credential, shared by the CLI, the VS Code extension and the ACP adapter. `/feedback` opens the issue tracker.
 
@@ -42,45 +42,45 @@
 
 ### Minor Changes
 
-- [#22](https://github.com/Pythoughts-labs/pythinker-code/pull/22) [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Name the managed OAuth provider after the platform that serves it. It is reached over `auth.kimi.com` and `api.kimi.com`, but it was registered as `managed:pythinker-code`, which read as a first-party service in a client that talks to several providers. The provider id is now `managed:kimi-code`, its models are aliased `kimi-code/*`, and its credentials are stored under `oauth/kimi-code`.
+- [#22](https://github.com/PyModel/pythinker-code/pull/22) [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Name the managed OAuth provider after the platform that serves it. It is reached over `auth.kimi.com` and `api.kimi.com`, but it was registered as `managed:pythinker-code`, which read as a first-party service in a client that talks to several providers. The provider id is now `managed:kimi-code`, its models are aliased `kimi-code/*`, and its credentials are stored under `oauth/kimi-code`.
 
   This is a breaking change for an existing config: the previous entries are not rewritten, so run `pythinker login` once to provision the managed provider under its current name, then remove the stale `managed:pythinker-code` entry.
 
-- [#22](https://github.com/Pythoughts-labs/pythinker-code/pull/22) [`45be822`](https://github.com/Pythoughts-labs/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Add an SDK routine that imports a catalog provider and its models into the persisted config, and use it for the CLI provider import so both entry points preserve existing defaults the same way.
+- [#22](https://github.com/PyModel/pythinker-code/pull/22) [`45be822`](https://github.com/PyModel/pythinker-code/commit/45be8227077847f760fa7b6b09333cf5a8127f32) - Add an SDK routine that imports a catalog provider and its models into the persisted config, and use it for the CLI provider import so both entry points preserve existing defaults the same way.
 
 ## 0.10.0
 
 ### Minor Changes
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add provider-native Fast mode controls for supported OpenAI and Anthropic models.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add provider-native Fast mode controls for supported OpenAI and Anthropic models.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add validated session and persistent workspace directories with SDK, CLI, and TUI management.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add validated session and persistent workspace directories with SDK, CLI, and TUI management.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the precedence-resolved agent profile catalog through the SDK and a searchable TUI command.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the precedence-resolved agent profile catalog through the SDK and a searchable TUI command.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add Anthropic Claude Code marketplace browsing and installation with searchable source selection and install-definition support.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add Anthropic Claude Code marketplace browsing and installation with searchable source selection and install-definition support.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add catalog-backed provider connections with interactive or environment-referenced credentials, live model discovery, provider-aware model selection, and model-specific thinking controls.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add catalog-backed provider connections with interactive or environment-referenced credentials, live model discovery, provider-aware model selection, and model-specific thinking controls.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose files loaded by Read through the SDK and a `/files` TUI command.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose files loaded by Read through the SDK and a `/files` TUI command.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the model-visible context breakdown through the SDK and a `/context` TUI report.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose the model-visible context breakdown through the SDK and a `/context` TUI report.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persisted file checkpoints with preview and recovery-backed code or conversation rewind through the SDK, CLI, and TUI.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add persisted file checkpoints with preview and recovery-backed code or conversation rewind through the SDK, CLI, and TUI.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add live instruction refresh and a `/memory` command for user and project memory files.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add live instruction refresh and a `/memory` command for user and project memory files.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add discoverable built-in, user, project, and plugin output styles with config-backed prompt injection and TUI selection.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add discoverable built-in, user, project, and plugin output styles with config-backed prompt injection and TUI selection.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add validated full configuration replacement to the SDK.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add validated full configuration replacement to the SDK.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose parent tool-call identity on subagent lifecycle events.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose parent tool-call identity on subagent lifecycle events.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add `/cost` to show accumulated session spend and current model token rates, with pricing data available through SDK session status.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add `/cost` to show accumulated session spend and current model token rates, with pricing data available through SDK session status.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose session metadata through the SDK and add searchable session tags with `/tag`.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose session metadata through the SDK and add searchable session tags with `/tag`.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a read-only verification agent and request independent checks when multi-step task lists close without verification.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Add a read-only verification agent and request independent checks when multi-step task lists close without verification.
   Accept TodoWrite-compatible checklist items and show their active labels while tasks are in progress.
   Cache successful local URL fetches for 15 minutes with a 50 MiB bound.
   Preserve binary URL responses and save them through Kaos with MIME-derived filenames.
@@ -165,7 +165,7 @@
   Handle MCP form elicitation through the existing question UI with typed JSON Schema validation and paged fields.
   Run source-compatible `Elicitation` and `ElicitationResult` hooks around MCP forms, including validated hook-supplied responses.
 
-- [`357c850`](https://github.com/Pythoughts-labs/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose bounded working-tree diffs through the SDK and a native `/diff` browser.
+- [`357c850`](https://github.com/PyModel/pythinker-code/commit/357c850cdaf1c8be669566ff7a88af895bcf5c4a) - Expose bounded working-tree diffs through the SDK and a native `/diff` browser.
 
 ## 0.9.4
 

--- a/packages/node-sdk/README.md
+++ b/packages/node-sdk/README.md
@@ -2,7 +2,7 @@
 
 The TypeScript SDK for Pythinker Code
 
-Part of the [Pythinker Code](https://github.com/Pythoughts-labs/pythinker-code) monorepo.
+Part of the [Pythinker Code](https://github.com/PyModel/pythinker-code) monorepo.
 
 See the main repository for documentation, issues, and contribution guidelines.
 

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -5,14 +5,14 @@
   "description": "TypeScript SDK for the Pythinker Code Agent",
   "license": "MIT",
   "author": "Pythoughts",
-  "homepage": "https://github.com/Pythoughts-labs/pythinker-code/tree/main/packages/node-sdk#readme",
+  "homepage": "https://github.com/PyModel/pythinker-code/tree/main/packages/node-sdk#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/node-sdk"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "keywords": [
     "pythinker",

--- a/packages/oauth/README.md
+++ b/packages/oauth/README.md
@@ -2,7 +2,7 @@
 
 OAuth toolkit for Pythinker Code managed authentication.
 
-Part of the [Pythinker Code](https://github.com/Pythoughts-labs/pythinker-code) monorepo.
+Part of the [Pythinker Code](https://github.com/PyModel/pythinker-code) monorepo.
 
 See the main repository for documentation, issues, and contribution guidelines.
 

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -5,14 +5,14 @@
   "description": "Login platform layer: model listing, config provisioning, and OpenAI Codex OAuth",
   "license": "MIT",
   "author": "Pythoughts",
-  "homepage": "https://github.com/Pythoughts-labs/pythinker-code/tree/main/packages/oauth#readme",
+  "homepage": "https://github.com/PyModel/pythinker-code/tree/main/packages/oauth#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/oauth"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "keywords": [
     "pythinker",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -7,11 +7,11 @@
   "author": "Pythoughts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/protocol"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "type": "module",
   "imports": {

--- a/packages/protocol/src/__tests__/rest-fs.test.ts
+++ b/packages/protocol/src/__tests__/rest-fs.test.ts
@@ -402,7 +402,7 @@ describe('fsGitStatusResponseSchema (W11.2)', () => {
       pullRequest: {
         number: 625,
         state: 'open' as const,
-        url: 'https://github.com/Pythoughts-labs/pythinker-code/pull/625',
+        url: 'https://github.com/PyModel/pythinker-code/pull/625',
       },
     };
     expect(fsGitStatusResponseSchema.parse(r)).toEqual(r);

--- a/packages/server-e2e/package.json
+++ b/packages/server-e2e/package.json
@@ -7,11 +7,11 @@
   "author": "Pythoughts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/server-e2e"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "type": "module",
   "imports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,11 +7,11 @@
   "author": "Pythoughts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/server"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "type": "module",
   "imports": {

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -2,7 +2,7 @@
 
 Shared telemetry infrastructure for Pythinker Code.
 
-Part of the [Pythinker Code](https://github.com/Pythoughts-labs/pythinker-code) monorepo.
+Part of the [Pythinker Code](https://github.com/PyModel/pythinker-code) monorepo.
 
 See the main repository for documentation, issues, and contribution guidelines.
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -5,14 +5,14 @@
   "description": "Shared telemetry infrastructure for Pythinker Code",
   "license": "MIT",
   "author": "Pythoughts",
-  "homepage": "https://github.com/Pythoughts-labs/pythinker-code/tree/main/packages/telemetry#readme",
+  "homepage": "https://github.com/PyModel/pythinker-code/tree/main/packages/telemetry#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pythoughts-labs/pythinker-code.git",
+    "url": "git+https://github.com/PyModel/pythinker-code.git",
     "directory": "packages/telemetry"
   },
   "bugs": {
-    "url": "https://github.com/Pythoughts-labs/pythinker-code/issues"
+    "url": "https://github.com/PyModel/pythinker-code/issues"
   },
   "keywords": [
     "pythinker",

--- a/scripts/release/update-brew-formula.mjs
+++ b/scripts/release/update-brew-formula.mjs
@@ -21,7 +21,7 @@ async function main() {
   const tapDir = mkdtempSync(join(tmpdir(), 'tap-'));
   try {
     try {
-      execFileSync('git', ['clone', `https://x-access-token:${token}@github.com/Pythoughts-labs/homebrew-tap.git`, tapDir], {
+      execFileSync('git', ['clone', `https://x-access-token:${token}@github.com/PyModel/homebrew-tap.git`, tapDir], {
         stdio: 'ignore',
       });
     } catch {


### PR DESCRIPTION
## Related Issue

No issue — the problem is explained below.

## Problem

The GitHub org was transferred from `Pythoughts-labs` to `PyModel`. References to the old org are now broken or stale: the old GitHub Pages URLs (`pythoughts-labs.github.io/pythinker-code`) return 404 with no redirect, the Homebrew tap moved to `pymodel/tap`, and `install.sh`/`install.ps1` fetched releases from the old org path.

## What changed

Two literal, case-preserving replacements across all 58 tracked files that referenced the old org (331 lines):

- `Pythoughts-labs` → `PyModel`
- `pythoughts-labs` → `pymodel`

This covers the README, CONTRIBUTING, SECURITY, docs site + VitePress config, `install.sh`/`install.ps1`, workflow `repository_owner` guards, the site Caddyfile Link header, changelogs, `flake.nix`, and the brew-formula release script.

Deliberately untouched: the npm scope `@pythoughts/*` — the packages did not move on npm, only the GitHub org changed.

Verified: zero old-org references remain in tracked files (`git grep -iE 'pythoughts[-_]labs'` is empty), every changed line differs only by the org substitution, all `package.json` files still parse, `install.sh` kept its executable bit, and the new targets were confirmed live (`PyModel/pythinker-code` releases, `Formula/pythinker-code.rb` in `PyModel/homebrew-tap`, `pymodel.github.io/pythinker-code` returns 200).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — no behavior change (URL/metadata sweep); the full suite passed in pre-push (10058 tests).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — no changeset: no runtime behavior change; package.json metadata rides the next release.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — doc URLs updated directly as part of the sweep.