### PR TITLE
fix: persist thinking effort cycled via Ctrl-T/Shift-Tab

### DIFF
--- a/.changeset/persist-cycled-effort.md
+++ b/.changeset/persist-cycled-effort.md
@@ -1,0 +1,5 @@
+---
+"@pythoughts/pythinker-code": patch
+---
+
+Keep the thinking effort chosen with Ctrl-T/Shift-Tab as the default across restarts.

--- a/apps/pythinker-code/src/tui/commands/config.ts
+++ b/apps/pythinker-code/src/tui/commands/config.ts
@@ -35,6 +35,7 @@ import { ThemeSelectorComponent } from '../components/dialogs/theme-selector';
 import { UpdatePreferenceSelectorComponent } from '../components/dialogs/update-preference-selector';
 import { saveTuiConfig } from '../config';
 import { generateKeybindingsTemplate } from '../keybindings';
+import { persistDefaultModelSelection } from '../utils/persist-effort';
 import type { ThemeName } from '#/tui/theme';
 import { currentTheme, isBuiltInTheme, lightColors, loadCustomThemeMerged } from '#/tui/theme';
 import {
@@ -769,21 +770,7 @@ async function performModelSwitch(host: SlashCommandHost, alias: string, effort:
 }
 
 async function persistModelSelection(host: SlashCommandHost, alias: string, effort: string): Promise<boolean> {
-  const defaultThinking = effort !== 'off';
-  const config = await host.harness.getConfig({ reload: true });
-  if (
-    config.defaultModel === alias &&
-    config.defaultThinking === defaultThinking &&
-    config.thinking?.effort === effort
-  ) {
-    return false;
-  }
-  await host.harness.setConfig({
-    defaultModel: alias,
-    defaultThinking,
-    thinking: { effort },
-  });
-  return true;
+  return persistDefaultModelSelection(host.harness, alias, effort);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/pythinker-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/pythinker-code/src/tui/controllers/editor-keyboard.ts
@@ -2,6 +2,7 @@ import { Editor, parseKey } from '@earendil-works/pi-tui';
 import {
   coerceEffortForModel,
   effortLevelsForModel,
+  type PythinkerHarness,
   type Session,
 } from '@pythoughts/pythinker-code-sdk';
 
@@ -28,6 +29,7 @@ import {
   type ParsedKeybinding,
 } from '#/tui/keybindings';
 import { isPrintableChar, printableChar } from '#/tui/utils/printable-key';
+import { persistDefaultModelSelection } from '#/tui/utils/persist-effort';
 
 function effectiveContextBindings(
   bindings: readonly ParsedKeybinding[],
@@ -45,6 +47,7 @@ function effectiveContextBindings(
 export interface EditorKeyboardHost {
   state: TUIState;
   session: Session | undefined;
+  readonly harness: PythinkerHarness;
   cancelInFlight: (() => void) | undefined;
 
   handleUserInput(text: string): void;
@@ -323,6 +326,13 @@ export class EditorKeyboardController {
     host.track('thinking_toggle', { enabled: next !== 'off', effort: next });
     // No transcript notice: the footer already shows the new level live, and
     // rapid cycling would stack a line per keypress in the chat history.
+    try {
+      await persistDefaultModelSelection(host.harness, alias, next);
+    } catch (error) {
+      host.showError(
+        `Thinking effort set to ${next}, but failed to save default: ${formatErrorMessage(error)}`,
+      );
+    }
   }
 
   private cancelCurrentCompaction(): void {

--- a/apps/pythinker-code/src/tui/utils/persist-effort.ts
+++ b/apps/pythinker-code/src/tui/utils/persist-effort.ts
@@ -1,0 +1,27 @@
+import type { PythinkerHarness } from '@pythoughts/pythinker-code-sdk';
+
+/**
+ * Save the model + thinking-effort pair as the startup default.
+ * Returns false when the config already holds the same selection.
+ */
+export async function persistDefaultModelSelection(
+  harness: PythinkerHarness,
+  alias: string,
+  effort: string,
+): Promise<boolean> {
+  const defaultThinking = effort !== 'off';
+  const config = await harness.getConfig({ reload: true });
+  if (
+    config.defaultModel === alias &&
+    config.defaultThinking === defaultThinking &&
+    config.thinking?.effort === effort
+  ) {
+    return false;
+  }
+  await harness.setConfig({
+    defaultModel: alias,
+    defaultThinking,
+    thinking: { effort },
+  });
+  return true;
+}

--- a/apps/pythinker-code/test/tui/controllers/editor-keyboard.test.ts
+++ b/apps/pythinker-code/test/tui/controllers/editor-keyboard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  EditorKeyboardController,
+  type EditorKeyboardHost,
+} from '#/tui/controllers/editor-keyboard';
+import type { ImageAttachmentStore } from '#/tui/utils/image-attachment-store';
+
+function makeHost() {
+  const editor: Record<string, unknown> = {};
+  const setConfig = vi.fn(() => Promise.resolve());
+  const getConfig = vi.fn(() =>
+    Promise.resolve({ defaultModel: undefined, defaultThinking: undefined, thinking: undefined }),
+  );
+  const host = {
+    state: {
+      editor,
+      ui: { addInputListener: vi.fn(() => () => {}), requestRender: vi.fn() },
+      appState: {
+        model: 'test/model',
+        thinkingLevel: 'low',
+        availableModels: {
+          'test/model': {
+            capabilities: ['thinking'],
+            supportEfforts: ['low', 'medium', 'high', 'max'],
+          },
+        },
+      },
+    },
+    session: { setThinking: vi.fn(() => Promise.resolve()) },
+    harness: { getConfig, setConfig },
+    cancelInFlight: undefined,
+    setAppState: vi.fn(),
+    track: vi.fn(),
+    showError: vi.fn(),
+    showNotice: vi.fn(),
+    dispatchFooter: vi.fn(),
+    updateEditorBorderHighlight: vi.fn(),
+    updateQueueDisplay: vi.fn(),
+  } as unknown as EditorKeyboardHost;
+  return { host, editor, setConfig, getConfig };
+}
+
+describe('EditorKeyboardController thinking-effort cycling', () => {
+  it('persists the cycled effort as the startup default', async () => {
+    const { host, editor, setConfig } = makeHost();
+    const controller = new EditorKeyboardController(host, {} as unknown as ImageAttachmentStore);
+    controller.install();
+
+    const onCycleEffort = editor['onCycleEffort'] as () => void;
+    expect(typeof onCycleEffort).toBe('function');
+    onCycleEffort();
+    await vi.waitFor(() => {
+      expect(setConfig).toHaveBeenCalledWith({
+        defaultModel: 'test/model',
+        defaultThinking: true,
+        thinking: { effort: 'medium' },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue

No issue — the problem is explained below.

## Problem

Cycling the thinking effort with Ctrl-T / Shift-Tab updates the live session and the footer, but the choice is never written to `config.toml`. Reopening the CLI then starts with the config default instead of the last selected effort (e.g. a user sets `max`, restarts, and gets the fallback level). The `/effort` and `/model` commands already persist the selection; only the keyboard shortcut path was missing it.

## What changed

- Extracted the existing default-persistence logic from the `/effort`/`/model` handler into a small shared TUI utility.
- The Ctrl-T / Shift-Tab cycling handler now persists the cycled effort with that same utility (best-effort; an error surfaces once without blocking the shortcut).
- Added a controller test that fails without the persistence call.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thinking-effort selections now persist across application restarts.
  * Updated effort settings are saved alongside the currently selected model.
  * Persistence errors are reported without losing the updated in-session setting.

* **Tests**
  * Added coverage for cycling thinking-effort levels and saving the selected value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->