### PR TITLE
chore: move the VS Code extension to the pymodel publisher

### DIFF
--- a/.changeset/vscode-publisher-pymodel.md
+++ b/.changeset/vscode-publisher-pymodel.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Publish the VS Code extension under the pymodel Marketplace publisher and Open VSX namespace.

--- a/apps/site/src/App.vue
+++ b/apps/site/src/App.vue
@@ -57,7 +57,7 @@ const terminalDemos = [
   },
 ];
 
-const vscodeInstallCommand = 'code --install-extension pythoughts.pythinker-code';
+const vscodeInstallCommand = 'code --install-extension pymodel.pythinker-code';
 
 const copiedCommand = ref('');
 const mobileMenu = ref(null);
@@ -307,12 +307,12 @@ onUnmounted(() => {
             <li><strong>Thinking controls.</strong> Toggle reasoning or pick a model-supported thinking effort per task.</li>
           </ul>
           <div class="vscode-actions">
-            <a class="button button-primary" href="https://marketplace.visualstudio.com/items?itemName=pythoughts.pythinker-code" target="_blank" rel="noopener">
+            <a class="button button-primary" href="https://marketplace.visualstudio.com/items?itemName=pymodel.pythinker-code" target="_blank" rel="noopener">
               <img src="/brand/visualstudiocode.svg" alt="" width="16" height="16" />
               Get the extension
             </a>
             <div class="vscode-command">
-              <code>code --install-extension pythoughts.pythinker-code</code>
+              <code>code --install-extension pymodel.pythinker-code</code>
               <button class="row-copy" type="button" aria-label="Copy VS Code install command" @click="copyText(vscodeInstallCommand)">
                 <svg v-if="copiedCommand === vscodeInstallCommand" aria-hidden="true" viewBox="0 0 20 20"><path d="m4 10 4 4 8-9" /></svg>
                 <svg v-else aria-hidden="true" viewBox="0 0 20 20"><rect x="7" y="3" width="10" height="11" rx="2" /><rect x="3" y="7" width="10" height="10" rx="2" /></svg>

--- a/apps/site/src/App.vue
+++ b/apps/site/src/App.vue
@@ -494,7 +494,7 @@ onUnmounted(() => {
 
   <footer class="site-footer">
     <div class="container footer-inner">
-      <div><div class="footer-brand"><PythinkerMascot :width="16" :height="20" /><p class="wordmark">Pythinker Code</p><span class="footer-version">v{{ version }}</span></div><p class="footer-caption">Built by Pythoughts. MIT License.</p></div>
+      <div><div class="footer-brand"><PythinkerMascot :width="16" :height="20" /><p class="wordmark">Pythinker Code</p><span class="footer-version">v{{ version }}</span></div><p class="footer-caption">Built by Pymodel. MIT License.</p></div>
       <div class="footer-links">
         <a href="https://github.com/PyModel/pythinker-code" target="_blank" rel="noopener">GitHub</a>
         <a href="https://www.npmjs.com/package/@pymodel/pythinker-code" target="_blank" rel="noopener">npm</a>

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -15,7 +15,7 @@ AI coding assistant for VS Code, built for long-context workflows and complex co
 
 Pythinker Code requires VS Code 1.100.0 or later.
 
-1. Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pythoughts.pythinker-code)
+1. Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pymodel.pythinker-code)
 2. Open a folder in VS Code
 3. Click the Pythinker icon in the Activity Bar
 4. Sign in, or use a provider already configured in the shared `config.toml`

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pythinker-code",
-  "publisher": "pythoughts",
+  "publisher": "pymodel",
   "displayName": "Pythinker Code",
   "description": "Pythinker Code extension for VS Code",
   "version": "0.9.0",
@@ -40,7 +40,7 @@
     "json",
     "autocomplete",
     "pythinker",
-    "pythoughts"
+    "pymodel"
   ],
   "pricing": "Free",
   "activationEvents": [],

--- a/apps/vscode/scripts/release-extension.mjs
+++ b/apps/vscode/scripts/release-extension.mjs
@@ -70,7 +70,7 @@ async function assertUnpublished(version) {
   const response = await fetch('https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json;api-version=7.1-preview.1' },
-    body: JSON.stringify({ filters: [{ criteria: [{ filterType: 7, value: 'pythoughts.pythinker-code' }] }], flags: 914 }),
+    body: JSON.stringify({ filters: [{ criteria: [{ filterType: 7, value: 'pymodel.pythinker-code' }] }], flags: 914 }),
   });
   if (!response.ok) {
     console.warn(`Could not reach the Marketplace to check for ${version}; continuing.`);

--- a/apps/vscode/test/extension-host/index.cjs
+++ b/apps/vscode/test/extension-host/index.cjs
@@ -4,7 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const vscode = require("vscode");
 
-const EXTENSION_ID = "pythoughts.pythinker-code";
+const EXTENSION_ID = "pymodel.pythinker-code";
 const EXPECTED_COMMANDS = [
   "pythinker.clearAllState",
   "pythinker.focusInput",

--- a/apps/vscode/test/ovsx-namespace.test.ts
+++ b/apps/vscode/test/ovsx-namespace.test.ts
@@ -13,20 +13,20 @@ describe('ensureNamespace', () => {
   it('creates the namespace before any publish is attempted', () => {
     const run = vi.fn();
 
-    ensureNamespace('pythoughts', run);
+    ensureNamespace('pymodel', run);
 
     expect(run).toHaveBeenCalledTimes(1);
     const [pkg, bin, args] = run.mock.calls[0] as [string, string, string[]];
     expect([pkg, bin]).toEqual(['ovsx', 'ovsx']);
-    expect(args).toEqual(['create-namespace', 'pythoughts']);
+    expect(args).toEqual(['create-namespace', 'pymodel']);
   });
 
   it('treats an existing namespace as success, so a re-run is safe', () => {
     const run = vi.fn(() => {
-      throw new Error('Local ovsx exited with code 1:\nERROR  Namespace already exists: pythoughts');
+      throw new Error('Local ovsx exited with code 1:\nERROR  Namespace already exists: pymodel');
     });
 
-    expect(() => ensureNamespace('pythoughts', run)).not.toThrow();
+    expect(() => ensureNamespace('pymodel', run)).not.toThrow();
   });
 
   it('propagates a real failure instead of publishing into a broken namespace', () => {
@@ -34,6 +34,6 @@ describe('ensureNamespace', () => {
       throw new Error('Local ovsx exited with code 1:\nERROR  Response code 401 (Unauthorized)');
     });
 
-    expect(() => ensureNamespace('pythoughts', run)).toThrow(/401/u);
+    expect(() => ensureNamespace('pymodel', run)).toThrow(/401/u);
   });
 });

--- a/apps/vscode/test/ovsx-namespace.test.ts
+++ b/apps/vscode/test/ovsx-namespace.test.ts
@@ -27,6 +27,9 @@ describe('ensureNamespace', () => {
     });
 
     expect(() => ensureNamespace('pymodel', run)).not.toThrow();
+    expect(run).toHaveBeenCalledTimes(1);
+    const [, , args] = run.mock.calls[0] as unknown as [string, string, string[]];
+    expect(args).toEqual(['create-namespace', 'pymodel']);
   });
 
   it('propagates a real failure instead of publishing into a broken namespace', () => {

--- a/apps/vscode/test/publish-retry.test.ts
+++ b/apps/vscode/test/publish-retry.test.ts
@@ -58,12 +58,12 @@ describe('summaryLine', () => {
    */
   it('keeps the registry error that follows the CLI wrapper line', () => {
     const error = new Error(
-      'Local ovsx exited with code 1:\nERROR  Unknown namespace: pythoughts\n',
+      'Local ovsx exited with code 1:\nERROR  Unknown namespace: pymodel\n',
     );
 
     const line = summaryLine(error);
 
-    expect(line).toContain('Unknown namespace: pythoughts');
+    expect(line).toContain('Unknown namespace: pymodel');
     expect(line).toContain('exited with code 1');
   });
 
@@ -85,7 +85,7 @@ describe('summaryLine', () => {
 describe('publishEachTarget', () => {
   it('reports the underlying cause for a failed target, not just the wrapper', async () => {
     const publishOne = vi.fn().mockRejectedValue(
-      new Error('Local ovsx exited with code 1:\nERROR  Unknown namespace: pythoughts'),
+      new Error('Local ovsx exited with code 1:\nERROR  Unknown namespace: pymodel'),
     );
     const logged: string[] = [];
     const log = vi.spyOn(console, 'log').mockImplementation((...args) => {
@@ -103,7 +103,7 @@ describe('publishEachTarget', () => {
     const failures = logged.filter((line) => line.includes('FAILED'));
     expect(failures).toHaveLength(3);
     for (const failure of failures) {
-      expect(failure).toContain('Unknown namespace: pythoughts');
+      expect(failure).toContain('Unknown namespace: pymodel');
     }
   });
 


### PR DESCRIPTION
## Summary

- Move the VS Code extension from the `pythoughts` Marketplace publisher to `pymodel`, matching the npm scope and GitHub org migration.
- Update the publisher field, extension keyword, Marketplace links, site install snippets, and the release script Marketplace query.
- Rename the Open VSX namespace fixtures in tests; the real namespace derives from the manifest publisher at publish time.

## Notes

- CI workflows need no change: the publisher flows from `apps/vscode/package.json`; the publish jobs read `VSCE_PAT` / `OVSX_PAT` secrets, which must be rotated to the new `pymodel` accounts before the next extension release.
- The publisher change creates a new Marketplace listing; the old `pythoughts.pythinker-code` listing does not migrate automatically.

## Testing

- `pnpm --filter pythinker-code test` — 338 tests pass.
- `tsgo -p apps/vscode/tsconfig.json --noEmit` — clean.
- Full pre-push gate passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The VS Code extension is now published under the `pymodel` publisher and Open VSX namespace.
  * Updated installation commands, marketplace links, and displayed extension identifiers.

* **Documentation**
  * Updated extension installation guidance to reference the new publisher.

* **Bug Fixes**
  * Release and validation workflows now use the updated extension identity consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->