### PR TITLE
chore(vscode): move the extension to the pymodel.pythinker Marketplace id

### DIFF
--- a/.changeset/rename-vscode-marketplace-id.md
+++ b/.changeset/rename-vscode-marketplace-id.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Change the VS Code extension Marketplace ID to `pymodel.pythinker`. Existing users must install the extension again under the new ID because Microsoft permanently retired the previous ID.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
       # Packages all six platform targets and runs the VSIX audit on each one.
       # A failure here must stop the job before anything reaches a registry.
       - name: Package and verify VSIX targets
-        run: pnpm --filter pythinker-code run package:platform
+        run: pnpm --filter pythinker run package:platform
 
       - name: Publish to the Visual Studio Marketplace
         env:
@@ -179,7 +179,7 @@ jobs:
             echo "::warning::VSCE_PAT secret not set — skipping Marketplace publish."
             exit 0
           fi
-          pnpm --filter pythinker-code run publish:vsix
+          pnpm --filter pythinker run publish:vsix
 
       # Open VSX serves Cursor / VSCodium / Windsurf. A failure here must not
       # undo an already-successful Marketplace publish, so it only warns.
@@ -192,7 +192,7 @@ jobs:
             echo "::warning::OVSX_PAT secret not set — skipping Open VSX publish."
             exit 0
           fi
-          pnpm --filter pythinker-code run publish:ovsx
+          pnpm --filter pythinker run publish:ovsx
 
       - name: Upload VSIX artifacts
         if: always()

--- a/apps/site/src/App.vue
+++ b/apps/site/src/App.vue
@@ -57,7 +57,7 @@ const terminalDemos = [
   },
 ];
 
-const vscodeInstallCommand = 'code --install-extension pymodel.pythinker-code';
+const vscodeInstallCommand = 'code --install-extension pymodel.pythinker';
 
 const copiedCommand = ref('');
 const mobileMenu = ref(null);
@@ -307,12 +307,12 @@ onUnmounted(() => {
             <li><strong>Thinking controls.</strong> Toggle reasoning or pick a model-supported thinking effort per task.</li>
           </ul>
           <div class="vscode-actions">
-            <a class="button button-primary" href="https://marketplace.visualstudio.com/items?itemName=pymodel.pythinker-code" target="_blank" rel="noopener">
+            <a class="button button-primary" href="https://marketplace.visualstudio.com/items?itemName=pymodel.pythinker" target="_blank" rel="noopener">
               <img src="/brand/visualstudiocode.svg" alt="" width="16" height="16" />
               Get the extension
             </a>
             <div class="vscode-command">
-              <code>code --install-extension pymodel.pythinker-code</code>
+              <code>code --install-extension pymodel.pythinker</code>
               <button class="row-copy" type="button" aria-label="Copy VS Code install command" @click="copyText(vscodeInstallCommand)">
                 <svg v-if="copiedCommand === vscodeInstallCommand" aria-hidden="true" viewBox="0 0 20 20"><path d="m4 10 4 4 8-9" /></svg>
                 <svg v-else aria-hidden="true" viewBox="0 0 20 20"><rect x="7" y="3" width="10" height="11" rx="2" /><rect x="3" y="7" width="10" height="10" rx="2" /></svg>

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -15,7 +15,7 @@ AI coding assistant for VS Code, built for long-context workflows and complex co
 
 Pythinker Code requires VS Code 1.100.0 or later.
 
-1. Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pymodel.pythinker-code)
+1. Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pymodel.pythinker)
 2. Open a folder in VS Code
 3. Click the Pythinker icon in the Activity Bar
 4. Sign in, or use a provider already configured in the shared `config.toml`

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pythinker-code",
+  "name": "pythinker",
   "publisher": "pymodel",
   "displayName": "Pythinker Code",
   "description": "Pythinker Code extension for VS Code",

--- a/apps/vscode/scripts/release-extension.mjs
+++ b/apps/vscode/scripts/release-extension.mjs
@@ -2,8 +2,8 @@
 // Tag and publish the VS Code extension in one pass:
 // preflight -> bump -> commit -> build -> package+verify -> publish -> tag -> push.
 //
-//   pnpm --filter pythinker-code run release 0.8.3
-//   pnpm --filter pythinker-code run release 0.8.3 --dry-run
+//   pnpm --filter pythinker run release 0.8.3
+//   pnpm --filter pythinker run release 0.8.3 --dry-run
 //
 // The Marketplace token is read from the macOS keychain, so it never reaches a
 // shell history or a file. Store it once with:
@@ -70,7 +70,7 @@ async function assertUnpublished(version) {
   const response = await fetch('https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json;api-version=7.1-preview.1' },
-    body: JSON.stringify({ filters: [{ criteria: [{ filterType: 7, value: 'pymodel.pythinker-code' }] }], flags: 914 }),
+    body: JSON.stringify({ filters: [{ criteria: [{ filterType: 7, value: 'pymodel.pythinker' }] }], flags: 914 }),
   });
   if (!response.ok) {
     console.warn(`Could not reach the Marketplace to check for ${version}; continuing.`);
@@ -119,7 +119,7 @@ async function main() {
     // failed build — otherwise the next real run trips its own clean-tree check.
     try {
       run('pnpm', ['build']);
-      run('pnpm', ['--filter', 'pythinker-code', 'run', 'package:platform']);
+      run('pnpm', ['--filter', 'pythinker', 'run', 'package:platform']);
       console.log(`\nDry run: built and verified ${version}. Nothing published, nothing tagged.`);
     } finally {
       writeFileSync(MANIFEST, originalManifest);
@@ -128,7 +128,7 @@ async function main() {
   }
 
   run('pnpm', ['build']);
-  run('pnpm', ['--filter', 'pythinker-code', 'run', 'package:platform']);
+  run('pnpm', ['--filter', 'pythinker', 'run', 'package:platform']);
 
   // Commit before publishing so the shipped bits always correspond to a commit,
   // and tag only once the Marketplace has actually accepted them.
@@ -136,7 +136,7 @@ async function main() {
   run('git', ['commit', '-m', `chore(vscode): release ${version}`]);
 
   try {
-    run('pnpm', ['--filter', 'pythinker-code', 'run', 'publish:vsix'], { env: { ...process.env, VSCE_PAT: vscePat } });
+    run('pnpm', ['--filter', 'pythinker', 'run', 'publish:vsix'], { env: { ...process.env, VSCE_PAT: vscePat } });
   } catch (error) {
     // The version bump is already committed and some targets may already be
     // live, so say exactly how to finish rather than leaving it to be worked out.
@@ -144,7 +144,7 @@ async function main() {
       `${error instanceof Error ? error.message : String(error)}\n\n` +
         `${version} is partly published and NOT tagged. The publish summary above lists which\n` +
         `targets are live; published ones are skipped on a re-run. Finish with:\n` +
-        `  pnpm --filter pythinker-code run publish:vsix\n` +
+        `  pnpm --filter pythinker run publish:vsix\n` +
         `  git tag -a ${tag} -m "Pythinker Code VS Code extension ${version}"\n` +
         `Do not bump the version again — ${version} is already consumed.`,
     );
@@ -155,7 +155,7 @@ async function main() {
     // Open VSX serves Cursor / VSCodium / Windsurf, but it must never undo a
     // successful Marketplace publish.
     try {
-      run('pnpm', ['--filter', 'pythinker-code', 'run', 'publish:ovsx'], { env: { ...process.env, OVSX_PAT: ovsxPat } });
+      run('pnpm', ['--filter', 'pythinker', 'run', 'publish:ovsx'], { env: { ...process.env, OVSX_PAT: ovsxPat } });
     } catch (error) {
       console.warn(`Open VSX publish failed, Marketplace is live: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/apps/vscode/test/baseline.manager.test.ts
+++ b/apps/vscode/test/baseline.manager.test.ts
@@ -2,7 +2,7 @@
  * Scenario: VSCode-owned file baselines for new and forked sessions.
  * Responsibilities: capture originals, show changes, keep/undo, and reject unsafe paths.
  * Wiring: real temporary workspace/global-storage files; no stubbed collaborators.
- * Run: pnpm --filter pythinker-code test -- baseline.manager.test.ts
+ * Run: pnpm --filter pythinker test -- baseline.manager.test.ts
  */
 import { existsSync, writeFileSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, rm, symlink, unlink, writeFile } from 'node:fs/promises';

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -2,7 +2,7 @@
  * Scenario: untrusted Webview RPC messages cross into the VS Code extension host.
  * Responsibilities: validate requests, preserve public model metadata, omit private paths, and recover visibly from persisted state errors.
  * Wiring: the real BridgeHandler and handlers; VS Code and the public Node SDK harness boundary are replaced.
- * Run: pnpm --filter pythinker-code exec vitest run --config vitest.config.ts test/bridge-handler.test.ts
+ * Run: pnpm --filter pythinker exec vitest run --config vitest.config.ts test/bridge-handler.test.ts
  */
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/apps/vscode/test/extension-host-smoke.test.ts
+++ b/apps/vscode/test/extension-host-smoke.test.ts
@@ -4,7 +4,7 @@
  * Host cannot discover the developer's real home directory.
  * Wiring: real smoke orchestration and filesystem; @vscode/test-electron is the
  * external process/download boundary.
- * Run: pnpm --filter pythinker-code exec vitest run --config vitest.config.ts test/extension-host-smoke.test.ts
+ * Run: pnpm --filter pythinker exec vitest run --config vitest.config.ts test/extension-host-smoke.test.ts
  */
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/apps/vscode/test/extension-host/index.cjs
+++ b/apps/vscode/test/extension-host/index.cjs
@@ -4,7 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const vscode = require("vscode");
 
-const EXTENSION_ID = "pymodel.pythinker-code";
+const EXTENSION_ID = "pymodel.pythinker";
 const EXPECTED_COMMANDS = [
   "pythinker.clearAllState",
   "pythinker.focusInput",

--- a/apps/vscode/test/pythinker-harness.integration.test.ts
+++ b/apps/vscode/test/pythinker-harness.integration.test.ts
@@ -2,7 +2,7 @@
  * Scenario: the VS Code host and another Node SDK client share one in-process Pythinker home.
  * Responsibilities: outbound host identity, config/session interoperability, MCP credential/edit compatibility, and terminal provider failures.
  * Wiring: PythinkerRuntime, PythinkerHarness, core, storage, and HTTP provider adapter are real; only the remote provider is local.
- * Run: pnpm --filter pythinker-code exec vitest run test/pythinker-harness.integration.test.ts
+ * Run: pnpm --filter pythinker exec vitest run test/pythinker-harness.integration.test.ts
  */
 
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";

--- a/apps/vscode/test/replay-resume.integration.test.ts
+++ b/apps/vscode/test/replay-resume.integration.test.ts
@@ -2,7 +2,7 @@
  * Scenario: persisted Node SDK sessions are reopened and rendered by the VS Code replay adapter.
  * Responsibilities: restored tool displays and child-agent steps through the public resume state.
  * Wiring: Node SDK, core, storage, and HTTP provider adapter are real; only the remote provider is local.
- * Run: pnpm --filter pythinker-code exec vitest run --config vitest.config.ts test/replay-resume.integration.test.ts
+ * Run: pnpm --filter pythinker exec vitest run --config vitest.config.ts test/replay-resume.integration.test.ts
  */
 
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";

--- a/apps/vscode/test/vsix-package.test.ts
+++ b/apps/vscode/test/vsix-package.test.ts
@@ -4,7 +4,7 @@
  * dev state, manifest/resource hygiene, unresolved imports, and entry loading.
  * Wiring: real Node packaging/verifier CLIs and filesystem; VSIX directory
  * fixtures replace only the external Marketplace archive producer.
- * Run: pnpm --filter pythinker-code exec vitest run --config vitest.config.ts test/vsix-package.test.ts
+ * Run: pnpm --filter pythinker exec vitest run --config vitest.config.ts test/vsix-package.test.ts
  */
 import { spawnSync } from 'node:child_process';
 import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -4,7 +4,7 @@
  * editor mentions use relative paths inside the working directory and absolute paths outside.
  * Wiring: real temporary local files plus the public handler/bridge surfaces;
  * VS Code host APIs are the only stubbed boundary.
- * Run: pnpm --filter pythinker-code exec vitest run --config vitest.config.ts test/workspace-paths.test.ts
+ * Run: pnpm --filter pythinker exec vitest run --config vitest.config.ts test/workspace-paths.test.ts
  */
 import { mkdtemp, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";


### PR DESCRIPTION
## Related Issue

No issue — the problem is described below.

## Problem

The 0.18.0 release failed all six VS Code targets with:

```
The extension 'pythinker-code' already exists in the Marketplace.
Please use a different 'name' in the package.json file
```

`pythoughts.pythinker-code@0.8.8` was published to both the Visual Studio Marketplace and Open VSX
on 2026-08-08 (visible in the release run for #44) and has since been **deleted**. Evidence:

- Both `marketplace.visualstudio.com/publishers/pythoughts` and `/pymodel` return 200 and list
  **zero** extensions.
- `vsce show pythoughts.pythinker-code` and `vsce show pymodel.pythinker-code` → not found.
- The gallery API (`filterType: 7`, and a text search for `pythinker`) → no results.
- The Open VSX API → `Extension not found` for both namespaces.
- `marketplace.visualstudio.com/items?itemName=…` → 404 for both (a known-good control,
  `ms-python.python`, returns 200, so the probe is calibrated).

The Marketplace permanently reserves the name of a removed extension, **even against its original
publisher**. The old id is unrecoverable, so the extension needs a new one. This blocked 0.17.1 as
well — the extension has not shipped to either registry since the org migration.

## What changed

`apps/vscode/package.json` `name`: `pythinker-code` → `pythinker`. The Marketplace id becomes
**`pymodel.pythinker`**, matching the CLI binary name.

Unchanged on purpose: `publisher` (`pymodel`), `displayName` ("Pythinker Code"), the npm scope, the
CLI, and all ten `pythinker.*` contributed command ids — Marketplace identity and runtime command
ids are different namespaces and only the former moves. Renaming the command ids would break every
keybinding and menu contribution.

The manifest `name` is **also the pnpm workspace package name**, so the rename mechanically forces:

- `.github/workflows/release.yml` — three `pnpm --filter pythinker-code run …` calls (package,
  publish:vsix, publish:ovsx) would fail with "no projects matched".
- `apps/vscode/scripts/release-extension.mjs` — seven filter references plus the hardcoded
  Marketplace query identifier.
- Seven `Run:` header comments under `apps/vscode/test/` that print a command that no longer works.

Install links and snippets updated in `apps/vscode/README.md` and `apps/site/src/App.vue`.

`flake.nix` needs no change — `apps/vscode` is in neither `workspacePaths` nor `workspaceNames`.

## Verification

Every check confirmed red on the unchanged tree before being trusted:

- `MANIFEST_OK 10` — name, publisher and displayName correct, and all ten command ids still start
  with `pythinker.` (asserts a non-zero command count first, so an empty list cannot satisfy it).
- No `pymodel.pythinker-code` / `pythoughts.pythinker-code` anywhere in the repo.
- No `--filter pythinker-code` in `apps/vscode`, `.github`, or `package.json`.
- `pnpm --filter pythinker exec … | grep -q FILTER_RESOLVES` — the new workspace name resolves.
  (Piped through `grep -q` on purpose: bare `pnpm --filter` prints "No projects matched" and still
  exits 0, so the obvious form of this check cannot fail.)
- `pnpm --filter pythinker run typecheck` (both the extension and webview-ui tsconfigs) → exit 0.
- `pnpm run lint` → exit 0.

**Note for the next release:** a reserved-because-deleted name is invisible to every public query,
so `pythinker` being free can only be proven by the publish itself. If it collides too, the publish
script skips already-published targets, so a re-run after a second rename is safe.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Update**
  * Renamed the VS Code extension to **Pythinker** with the new Marketplace ID `pymodel.pythinker`.
  * Updated installation commands, Marketplace links, and publishing destinations to reflect the new identifier.
  * Existing installations must be reinstalled using the new extension listing.

* **Documentation**
  * Updated extension documentation and setup references with the new package and Marketplace details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->