### PR TITLE
feat(desktop): add Windows support with an NSIS installer and release job

### DIFF
--- a/.changeset/desktop-taskkill-timeout.md
+++ b/.changeset/desktop-taskkill-timeout.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': patch
+---
+
+Bound the Windows process-tree kill so a stalled taskkill cannot freeze desktop shutdown

--- a/.changeset/desktop-windows-ci-fixes.md
+++ b/.changeset/desktop-windows-ci-fixes.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': patch
+---
+
+Fix Windows runtime staging and skip empty signing credentials in the desktop release workflow

--- a/.changeset/desktop-windows-deploy-target.md
+++ b/.changeset/desktop-windows-deploy-target.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': patch
+---
+
+Stage the desktop Host closure inside the workspace so pnpm deploy resolves the target on Windows

--- a/.changeset/desktop-windows-packaging.md
+++ b/.changeset/desktop-windows-packaging.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': patch
+---
+
+Add the Windows NSIS installer target, release script, and release workflow job

--- a/.changeset/desktop-windows-runtime.md
+++ b/.changeset/desktop-windows-runtime.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': patch
+---
+
+Fix Windows process-tree shutdown, packaged-runtime guards, and taskbar identity in the desktop app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,5 @@ jobs:
         run: pnpm --filter @pymodel/dashboard-server run typecheck
       - name: Typecheck dashboard-web
         run: pnpm --filter @pymodel/dashboard-web run typecheck
+      - name: Typecheck desktop
+        run: pnpm --filter @pymodel/pythinker-desktop run typecheck

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -51,16 +51,33 @@ jobs:
       # Without Developer ID signing secrets, electron-builder publishes an
       # ad-hoc/self-signed app. macOS auto-update will not accept unsigned updates,
       # but this still proves packaging and the feed shape.
+      # An unset GitHub secret interpolates to an empty string, and
+      # electron-builder resolves an empty CSC_LINK as a certificate path
+      # (path.resolve(appDir, '') === appDir), failing with "not a file".
+      # Export only the variables that carry a value.
+      - name: Resolve macOS signing credentials
+        shell: bash
+        env:
+          IN_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          IN_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          IN_APPLE_ID: ${{ secrets.APPLE_ID }}
+          IN_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          IN_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+            input="IN_${name}"
+            value="${!input:-}"
+            if [ -n "$value" ]; then printf '%s<<__EOF__\n%s\n__EOF__\n' "$name" "$value" >> "$GITHUB_ENV"; fi
+          done
+          if [ -z "${IN_CSC_LINK:-}" ]; then
+            echo 'CSC_IDENTITY_AUTO_DISCOVERY=false' >> "$GITHUB_ENV"
+            echo 'No macOS signing certificate configured; building unsigned.'
+          fi
       - name: Package and publish desktop release
         working-directory: apps/desktop
         run: pnpm exec electron-builder --mac dmg zip --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload macOS artifacts for manual runs
         if: github.event_name == 'workflow_dispatch'
@@ -107,15 +124,25 @@ jobs:
         working-directory: apps/desktop
         run: node --import tsx scripts/stage-runtime.ts
 
-      # Without WIN_CSC_* signing secrets, Windows artifacts are unsigned and
-      # installers trigger a SmartScreen warning on first run.
+      # Only non-empty WIN_CSC_* signing secrets are exported. Without them,
+      # Windows artifacts are unsigned and installers trigger a SmartScreen
+      # warning on first run.
+      - name: Resolve Windows signing credentials
+        shell: bash
+        env:
+          IN_WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          IN_WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+        run: |
+          for name in WIN_CSC_LINK WIN_CSC_KEY_PASSWORD; do
+            input="IN_${name}"
+            value="${!input:-}"
+            if [ -n "$value" ]; then printf '%s<<__EOF__\n%s\n__EOF__\n' "$name" "$value" >> "$GITHUB_ENV"; fi
+          done
       - name: Package and publish desktop release
         working-directory: apps/desktop
         run: pnpm exec electron-builder --win nsis --x64 --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
       - name: Upload Windows artifacts for manual runs
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -72,3 +72,57 @@ jobs:
             apps/desktop/dist/*.zip
             apps/desktop/dist/latest-mac.yml
           if-no-files-found: error
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pinned from v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # pinned from v6
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # pinned from v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Stamp desktop version for tag builds
+        if: startsWith(github.ref, 'refs/tags/desktop-v')
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          export DESKTOP_VERSION="${TAG_NAME#desktop-v}"
+          node -e 'const fs = require("node:fs"); const path = "apps/desktop/package.json"; const packageJson = JSON.parse(fs.readFileSync(path, "utf8")); packageJson.version = process.env.DESKTOP_VERSION; fs.writeFileSync(path, `${JSON.stringify(packageJson, null, 2)}\n`);'
+
+      - name: Build workspace
+        run: pnpm --workspace-root run build
+
+      - name: Stage desktop runtime
+        working-directory: apps/desktop
+        run: node --import tsx scripts/stage-runtime.ts
+
+      # Without WIN_CSC_* signing secrets, Windows artifacts are unsigned and
+      # installers trigger a SmartScreen warning on first run.
+      - name: Package and publish desktop release
+        working-directory: apps/desktop
+        run: pnpm exec electron-builder --win nsis --x64 --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+
+      - name: Upload Windows artifacts for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned from v7
+        with:
+          name: desktop-windows
+          path: |
+            apps/desktop/dist/*.exe
+            apps/desktop/dist/latest.yml
+          if-no-files-found: error

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -66,7 +66,7 @@ rmdir "$MOUNT_POINT"
 
 ### Windows
 
-Run `pnpm run dist:win` on a native Windows x64 host; cross-building from macOS is not possible because the staged Host closure contains platform-gated native packages. The output is `dist/Pythinker-<version>-x64-Setup.exe`, a per-user NSIS installer with no elevation required and a selectable installation directory. Artifacts are unsigned unless `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` are set.
+Run `pnpm run dist:win` on a native Windows x64 host; cross-building from macOS is not possible because the staged Host closure contains platform-gated native packages. The output is `dist/Pythinker-<version>-x64-Setup.exe`, an assisted NSIS installer that defaults to a per-user install, offers a per-machine option that requires elevation, and lets you select the installation directory. Artifacts are unsigned unless `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` are set.
 
 ## Known limitations
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -64,11 +64,15 @@ hdiutil detach "$MOUNT_POINT"
 rmdir "$MOUNT_POINT"
 ```
 
+### Windows
+
+Run `pnpm run dist:win` on a native Windows x64 host; cross-building from macOS is not possible because the staged Host closure contains platform-gated native packages. The output is `dist/Pythinker-<version>-x64-Setup.exe`, a per-user NSIS installer with no elevation required and a selectable installation directory. Artifacts are unsigned unless `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` are set.
+
 ## Known limitations
 
 The first desktop assembly uses a loopback HTTP Host. The renderer and Host protocol remain unchanged so the application can replace the transport with the IPC carrier reserved by the GUI architecture without changing product features.
 
-The signed installer path currently targets macOS. Windows and Linux packaging creates unpacked applications; their installer formats and distribution signing remain release work.
+The signed installer path currently targets macOS. Linux packaging creates an unpacked application; its installer format and distribution signing remain release work.
 
 ## Model Experience
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,8 @@
     "dev": "pnpm -C ../pythinker-code run build && tsc -p tsconfig.json && tsdown && electron .",
     "package": "pnpm --workspace-root run build && node --import tsx scripts/stage-runtime.ts && electron-builder --dir",
     "dist": "pnpm --workspace-root run build && node --import tsx scripts/stage-runtime.ts && electron-builder",
-    "dist:mac": "node --import tsx scripts/release-mac.ts"
+    "dist:mac": "node --import tsx scripts/release-mac.ts",
+    "dist:win": "node --import tsx scripts/release-win.ts"
   },
   "license": "MIT",
   "devDependencies": {
@@ -67,8 +68,23 @@
     "win": {
       "icon": "build/icon.png",
       "target": [
-        "dir"
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
       ]
+    },
+    "nsis": {
+      "allowElevation": true,
+      "allowToChangeInstallationDirectory": true,
+      "artifactName": "Pythinker-${version}-${arch}-Setup.${ext}",
+      "createDesktopShortcut": true,
+      "createStartMenuShortcut": true,
+      "oneClick": false,
+      "perMachine": false,
+      "shortcutName": "Pythinker"
     },
     "linux": {
       "category": "Development",

--- a/apps/desktop/scripts/release-win.ts
+++ b/apps/desktop/scripts/release-win.ts
@@ -1,0 +1,37 @@
+/** Build the Windows NSIS installer from a native Windows host. */
+
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { verifyWindowsInstaller } from './verify-win-installer'
+
+function run(command: string, args: readonly string[], cwd: string): void {
+  const result = spawnSync(command, args, { cwd, stdio: 'inherit', shell: process.platform === 'win32' })
+  if (result.error !== undefined) throw result.error
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} exited with ${String(result.status)}`)
+}
+
+/** Build and verify the unsigned Windows installer. */
+export function releaseWin(): void {
+  if (process.platform !== 'win32') {
+    throw new Error('The Windows installer must be built on Windows: the staged Host closure contains platform-specific native packages')
+  }
+  if (process.arch !== 'x64') {
+    throw new Error(`The Windows installer targets x64; this host is ${process.arch}`)
+  }
+  const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  run('pnpm', ['--workspace-root', 'run', 'build'], desktopRoot)
+  run('node', ['--import', 'tsx', 'scripts/stage-runtime.ts'], desktopRoot)
+  run('pnpm', ['exec', 'electron-builder', '--win', 'nsis', '--x64', '--publish', 'never'], desktopRoot)
+  verifyWindowsInstaller(desktopRoot)
+}
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  try {
+    releaseWin()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/apps/desktop/scripts/stage-runtime.ts
+++ b/apps/desktop/scripts/stage-runtime.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs'
 import { cp, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const desktopRoot = resolve(import.meta.dirname, '..')
 const repositoryRoot = resolve(desktopRoot, '../..')
@@ -14,9 +15,42 @@ const entry = join(staging, 'node_modules/@pymodel/pythinker-code/dist/launcher.
 const frontend = join(staging, 'node_modules/@pymodel/pythinker-code/dist-web/index.html')
 const workspaceState = join(repositoryRoot, 'node_modules/.pnpm-workspace-state-v1.json')
 
+/** Windows characters that make an argument unsafe to hand to `cmd.exe` unquoted. */
+const WINDOWS_UNSAFE_ARGUMENT = /[\s"&()<>^|]/u
+
+/**
+ * Decide how to invoke a package manager on one platform.
+ *
+ * Node refuses to spawn a `.cmd` or `.bat` shim without a shell, so Windows
+ * needs `shell: true`. With a shell, Node does not quote arguments, so any
+ * argument carrying whitespace or a `cmd.exe` metacharacter is quoted here.
+ * @param platform - The value of `process.platform`.
+ * @param command - The package-manager binary name.
+ * @param args - Arguments in their unquoted form.
+ * @returns The command, arguments and shell flag to pass to `spawn`.
+ */
+export function packageManagerInvocation(platform: string, command: string, args: readonly string[]): {
+  readonly command: string
+  readonly args: readonly string[]
+  readonly shell: boolean
+} {
+  if (platform !== 'win32') return { command, args, shell: false }
+  return {
+    command,
+    args: args.map(argument => (WINDOWS_UNSAFE_ARGUMENT.test(argument) ? `"${argument}"` : argument)),
+    shell: true,
+  }
+}
+
 async function run(command: string, args: readonly string[]): Promise<void> {
+  const invocation = packageManagerInvocation(process.platform, command, args)
   await new Promise<void>((accept, reject) => {
-    const child = spawn(command, args, { cwd: repositoryRoot, env: { ...process.env, CI: 'true' }, stdio: 'inherit' })
+    const child = spawn(invocation.command, [...invocation.args], {
+      cwd: repositoryRoot,
+      env: { ...process.env, CI: 'true' },
+      stdio: 'inherit',
+      shell: invocation.shell,
+    })
     child.once('error', reject)
     child.once('exit', (code, signal) => {
       if (code === 0) accept()
@@ -60,7 +94,7 @@ async function materializeLinks(): Promise<void> {
 async function deploy(target: string): Promise<void> {
   const savedWorkspaceState = existsSync(workspaceState) ? await readFile(workspaceState) : undefined
   try {
-    await run(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', [
+    await run('pnpm', [
       '--config.verify-deps-before-run=false', '--filter', deployPackage, 'deploy', '--legacy', '--prod',
       '--config.node-linker=hoisted', '--config.auto-install-peers=false', '--config.link-workspace-packages=true', target,
     ])
@@ -96,4 +130,7 @@ async function main(): Promise<void> {
   console.log(`desktop runtime staged at ${staging}`)
 }
 
-await main()
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/apps/desktop/scripts/stage-runtime.ts
+++ b/apps/desktop/scripts/stage-runtime.ts
@@ -3,8 +3,7 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { cp, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join, resolve, sep } from 'node:path'
+import { join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const desktopRoot = resolve(import.meta.dirname, '..')
@@ -14,6 +13,7 @@ const deployPackage = '@pymodel/pythinker-code'
 const entry = join(staging, 'node_modules/@pymodel/pythinker-code/dist/launcher.mjs')
 const frontend = join(staging, 'node_modules/@pymodel/pythinker-code/dist-web/index.html')
 const workspaceState = join(repositoryRoot, 'node_modules/.pnpm-workspace-state-v1.json')
+const stagingParent = join(repositoryRoot, 'node_modules', '.pythinker-desktop-staging')
 
 /** Windows characters that make an argument unsafe to hand to `cmd.exe` unquoted. */
 const WINDOWS_UNSAFE_ARGUMENT = /[\s"&()<>^|]/u
@@ -40,6 +40,21 @@ export function packageManagerInvocation(platform: string, command: string, args
     args: args.map(argument => (WINDOWS_UNSAFE_ARGUMENT.test(argument) ? `"${argument}"` : argument)),
     shell: true,
   }
+}
+
+/**
+ * Express a deploy target the way pnpm accepts it.
+ *
+ * pnpm joins its workspace root with the deploy target rather than resolving
+ * it, so an absolute path on another volume produces a concatenated,
+ * non-existent directory such as `D:\repo\C:\Users\…`. A workspace-relative
+ * target is correct whether pnpm joins or resolves.
+ * @param workspaceRoot - The pnpm workspace root, and the child process's cwd.
+ * @param target - The absolute staging directory.
+ * @returns The target expressed relative to the workspace root.
+ */
+export function deployTargetArgument(workspaceRoot: string, target: string): string {
+  return relative(workspaceRoot, target)
 }
 
 async function run(command: string, args: readonly string[]): Promise<void> {
@@ -96,7 +111,8 @@ async function deploy(target: string): Promise<void> {
   try {
     await run('pnpm', [
       '--config.verify-deps-before-run=false', '--filter', deployPackage, 'deploy', '--legacy', '--prod',
-      '--config.node-linker=hoisted', '--config.auto-install-peers=false', '--config.link-workspace-packages=true', target,
+      '--config.node-linker=hoisted', '--config.auto-install-peers=false', '--config.link-workspace-packages=true',
+      deployTargetArgument(repositoryRoot, target),
     ])
   } finally {
     if (savedWorkspaceState === undefined) await rm(workspaceState, { force: true })
@@ -105,7 +121,8 @@ async function deploy(target: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  const deployed = await mkdtemp(join(tmpdir(), 'pythinker-desktop-runtime-'))
+  await mkdir(stagingParent, { recursive: true })
+  const deployed = await mkdtemp(join(stagingParent, 'runtime-'))
   try {
     await deploy(deployed)
     await rm(join(staging, 'node_modules'), { recursive: true, force: true })

--- a/apps/desktop/scripts/verify-packaged-runtime.ts
+++ b/apps/desktop/scripts/verify-packaged-runtime.ts
@@ -9,6 +9,12 @@ const REQUIRED_HOST_FILES = [
   ['@pymodel', 'pythinker-code', 'dist-web', 'index.html'],
 ] as const
 
+const REQUIRED_WINDOWS_NODE_PTY_ENTRIES = [
+  ['node-pty', 'prebuilds', 'win32-x64', 'pty.node'],
+  ['node-pty', 'prebuilds', 'win32-x64', 'conpty.node'],
+  ['node-pty', 'prebuilds', 'win32-x64', 'conpty_console_list.node'],
+] as const
+
 /**
  * Verify the Host files required before the signed application can start.
  * @param context - Electron Builder's completed application directory.
@@ -19,6 +25,10 @@ export async function afterPack(context: AfterPackContext): Promise<void> {
     ? join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`, 'Contents', 'Resources')
     : join(context.appOutDir, 'resources')
   for (const segments of REQUIRED_HOST_FILES) {
+    await access(join(resources, 'host', 'node_modules', ...segments))
+  }
+  if (context.electronPlatformName !== 'win32') return
+  for (const segments of REQUIRED_WINDOWS_NODE_PTY_ENTRIES) {
     await access(join(resources, 'host', 'node_modules', ...segments))
   }
 }

--- a/apps/desktop/scripts/verify-win-installer.ts
+++ b/apps/desktop/scripts/verify-win-installer.ts
@@ -1,0 +1,36 @@
+/** Reject a Windows release whose installer or unpacked shell is not a real PE binary. */
+
+import { openSync, readSync, closeSync, statSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MINIMUM_PE_BYTES = 0x40 + 4
+
+function assertPortableExecutable(path: string): void {
+  const stats = statSync(path)
+  if (!stats.isFile()) throw new Error(`Windows release artifact is not a regular file: ${path}`)
+  if (stats.size < MINIMUM_PE_BYTES) throw new Error(`Windows release artifact is too small to be a PE image: ${path}`)
+  const handle = openSync(path, 'r')
+  try {
+    const header = Buffer.alloc(0x40)
+    readSync(handle, header, 0, header.length, 0)
+    if (header.toString('latin1', 0, 2) !== 'MZ') throw new Error(`Windows release artifact has no DOS header: ${path}`)
+    const peOffset = header.readUInt32LE(0x3c)
+    if (peOffset + 4 > stats.size) throw new Error(`Windows release artifact has an out-of-range PE offset: ${path}`)
+    const signature = Buffer.alloc(4)
+    readSync(handle, signature, 0, 4, peOffset)
+    if (signature.toString('latin1') !== 'PE\0\0') throw new Error(`Windows release artifact has no PE signature: ${path}`)
+  } finally {
+    closeSync(handle)
+  }
+}
+
+/**
+ * Verify the Windows artifacts electron-builder must have produced.
+ * @param desktopRoot - The apps/desktop directory containing dist/.
+ */
+export function verifyWindowsInstaller(desktopRoot: string): void {
+  const { version } = JSON.parse(readFileSync(join(desktopRoot, 'package.json'), 'utf8')) as { version: string }
+  assertPortableExecutable(join(desktopRoot, 'dist', `Pythinker-${version}-x64-Setup.exe`))
+  assertPortableExecutable(join(desktopRoot, 'dist', 'win-unpacked', 'Pythinker.exe'))
+  console.log(`Windows release verified: Pythinker-${version}-x64-Setup.exe`)
+}

--- a/apps/desktop/src/host-supervisor.ts
+++ b/apps/desktop/src/host-supervisor.ts
@@ -1,6 +1,6 @@
 /** Supervise the loopback Web Host used by the first desktop application. */
 
-import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import { spawn, spawnSync, type ChildProcessByStdio } from 'node:child_process'
 import type { Readable } from 'node:stream'
 
 const READINESS_PREFIX = 'Pythinker server: '
@@ -297,6 +297,26 @@ export function spawnPythinkerServer(options: SpawnPythinkerServerOptions): Host
   return nodeChildAdapter(process)
 }
 
+/**
+ * Terminate a child and its descendants.
+ *
+ * Windows has no signal delivery: `child.kill` calls TerminateProcess on one
+ * PID, so the Host's own children (node-pty shells, subagent hosts) survive and
+ * keep holding the loopback port. `taskkill /T` walks the tree instead.
+ *
+ * ponytail: /F makes every Windows stop a forced stop — Node cannot deliver a
+ * graceful SIGTERM to a Windows child at all. Add a stdin or IPC shutdown
+ * channel to the Host if graceful Windows teardown is ever needed.
+ */
+function killProcessTree(child: ChildProcessByStdio<null, Readable, Readable>, signal: 'SIGTERM' | 'SIGKILL'): void {
+  if (process.platform !== 'win32' || child.pid === undefined) {
+    child.kill(signal)
+    return
+  }
+  const result = spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { windowsHide: true })
+  if (result.error !== undefined || result.status !== 0) child.kill(signal)
+}
+
 /** Adapt Node's event overloads to the supervisor's explicit ownership API. */
 function nodeChildAdapter(child: ChildProcessByStdio<null, Readable, Readable>): HostChild {
   return {
@@ -312,7 +332,7 @@ function nodeChildAdapter(child: ChildProcessByStdio<null, Readable, Readable>):
       return () => { child.off('error', listener) }
     },
     kill(signal) {
-      child.kill(signal)
+      killProcessTree(child, signal)
     },
   }
 }

--- a/apps/desktop/src/host-supervisor.ts
+++ b/apps/desktop/src/host-supervisor.ts
@@ -6,6 +6,7 @@ import type { Readable } from 'node:stream'
 const READINESS_PREFIX = 'Pythinker server: '
 const DEFAULT_READINESS_TIMEOUT_MS = 90_000
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000
+const TASKKILL_TIMEOUT_MS = 5_000
 const MAX_STARTUP_OUTPUT_CHARS = 32_768
 
 /** Incremental parser for the Web Host's canonical readiness line. */
@@ -303,6 +304,8 @@ export function spawnPythinkerServer(options: SpawnPythinkerServerOptions): Host
  * Windows has no signal delivery: `child.kill` calls TerminateProcess on one
  * PID, so the Host's own children (node-pty shells, subagent hosts) survive and
  * keep holding the loopback port. `taskkill /T` walks the tree instead.
+ * Because this call is synchronous, keep it bounded so a stalled taskkill falls
+ * back to a single-process kill instead of blocking the Electron main loop indefinitely.
  *
  * ponytail: /F makes every Windows stop a forced stop — Node cannot deliver a
  * graceful SIGTERM to a Windows child at all. Add a stdin or IPC shutdown
@@ -313,7 +316,10 @@ function killProcessTree(child: ChildProcessByStdio<null, Readable, Readable>, s
     child.kill(signal)
     return
   }
-  const result = spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { windowsHide: true })
+  const result = spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+    windowsHide: true,
+    timeout: TASKKILL_TIMEOUT_MS,
+  })
   if (result.error !== undefined || result.status !== 0) child.kill(signal)
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2,7 +2,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { isAbsolute, join, resolve } from 'node:path'
 import {
   app,
   BrowserWindow,
@@ -109,7 +109,7 @@ function hostPaths(): { nodeExecutable: string; cliEntry: string; cwd: string; e
 }
 
 function assertHostArtifacts(paths: ReturnType<typeof hostPaths>): void {
-  if (paths.nodeExecutable.includes('/') && !existsSync(paths.nodeExecutable)) {
+  if (isAbsolute(paths.nodeExecutable) && !existsSync(paths.nodeExecutable)) {
     throw new Error(`desktop Node runtime is missing: ${paths.nodeExecutable}`)
   }
   if (!existsSync(paths.cliEntry)) {
@@ -298,6 +298,7 @@ function requestAppQuit(): Promise<void> {
 }
 
 async function boot(): Promise<void> {
+  if (process.platform === 'win32') app.setAppUserModelId('com.pythinker.desktop')
   if (bootQuitPromise !== undefined) return
   initializeDesktopTelemetry()
   const paths = hostPaths()

--- a/apps/desktop/tests/host-supervisor.spec.ts
+++ b/apps/desktop/tests/host-supervisor.spec.ts
@@ -331,7 +331,7 @@ describe('desktop Host process', () => {
       stdout: Buffer.alloc(0),
       stderr: Buffer.alloc(0),
       status: 0,
-      signal: null,
+      signal: 'SIGTERM',
     })
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
 
@@ -347,9 +347,42 @@ describe('desktop Host process', () => {
     expect(spawnSync).toHaveBeenCalledWith(
       'taskkill',
       ['/pid', '4242', '/T', '/F'],
-      { windowsHide: true },
+      { windowsHide: true, timeout: 5_000 },
     )
     expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('falls back to killing the Windows Host when taskkill times out', async () => {
+    const child = {
+      pid: 4242,
+      stdout: { on: vi.fn(), off: vi.fn() },
+      stderr: { on: vi.fn(), off: vi.fn() },
+      on: vi.fn(),
+      off: vi.fn(),
+      kill: vi.fn(),
+    }
+    vi.mocked(spawn).mockReturnValue(child as never)
+    vi.mocked(spawnSync).mockReturnValue({
+      pid: 4242,
+      output: [],
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      status: null,
+      signal: null,
+      error: Object.assign(new Error('spawnSync taskkill ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+    })
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    const { spawnPythinkerServer } = await import('../src/host-supervisor')
+    const host = spawnPythinkerServer({
+      nodeExecutable: 'node',
+      cliEntry: '/tmp/launcher.mjs',
+      cwd: '/tmp',
+      env: {},
+    })
+    host.kill('SIGTERM')
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
 
   it('uses child.kill unchanged on non-Windows', async () => {

--- a/apps/desktop/tests/host-supervisor.spec.ts
+++ b/apps/desktop/tests/host-supervisor.spec.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   createHostSupervisor,
@@ -313,5 +313,68 @@ describe('desktop Host process', () => {
       ],
       expect.objectContaining({ env: { PYTHINKER_DESKTOP: '1', ELECTRON_RUN_AS_NODE: '1' } }),
     )
+  })
+
+  it('kills the Windows Host process tree', async () => {
+    const child = {
+      pid: 4242,
+      stdout: { on: vi.fn(), off: vi.fn() },
+      stderr: { on: vi.fn(), off: vi.fn() },
+      on: vi.fn(),
+      off: vi.fn(),
+      kill: vi.fn(),
+    }
+    vi.mocked(spawn).mockReturnValue(child as never)
+    vi.mocked(spawnSync).mockReturnValue({
+      pid: 4242,
+      output: [],
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      status: 0,
+      signal: null,
+    })
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    const { spawnPythinkerServer } = await import('../src/host-supervisor')
+    const host = spawnPythinkerServer({
+      nodeExecutable: 'node',
+      cliEntry: '/tmp/launcher.mjs',
+      cwd: '/tmp',
+      env: {},
+    })
+    host.kill('SIGTERM')
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '4242', '/T', '/F'],
+      { windowsHide: true },
+    )
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('uses child.kill unchanged on non-Windows', async () => {
+    const child = {
+      pid: 4242,
+      stdout: { on: vi.fn(), off: vi.fn() },
+      stderr: { on: vi.fn(), off: vi.fn() },
+      on: vi.fn(),
+      off: vi.fn(),
+      kill: vi.fn(),
+    }
+    vi.mocked(spawn).mockReturnValue(child as never)
+    vi.mocked(spawnSync).mockClear()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    const { spawnPythinkerServer } = await import('../src/host-supervisor')
+    const host = spawnPythinkerServer({
+      nodeExecutable: 'node',
+      cliEntry: '/tmp/launcher.mjs',
+      cwd: '/tmp',
+      env: {},
+    })
+    host.kill('SIGTERM')
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(spawnSync).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/tests/packaging-config.spec.ts
+++ b/apps/desktop/tests/packaging-config.spec.ts
@@ -18,8 +18,24 @@ interface DesktopPackage {
       readonly icon: string
       readonly notarize: boolean
     }
+    readonly nsis: {
+      readonly allowElevation: boolean
+      readonly allowToChangeInstallationDirectory: boolean
+      readonly artifactName: string
+      readonly createDesktopShortcut: boolean
+      readonly createStartMenuShortcut: boolean
+      readonly oneClick: boolean
+      readonly perMachine: boolean
+      readonly shortcutName: string
+    }
     readonly productName: string
-    readonly win: { readonly icon: string }
+    readonly win: {
+      readonly icon: string
+      readonly target: readonly {
+        readonly target: string
+        readonly arch: readonly string[]
+      }[]
+    }
   }
 }
 
@@ -79,9 +95,27 @@ describe('desktop packaging configuration', () => {
     expect(desktopPackage.build.mac.notarize).toBe(true)
   })
 
+  it('configures the Windows x64 NSIS installer', () => {
+    expect(desktopPackage.build.win.target).toEqual([{ target: 'nsis', arch: ['x64'] }])
+    expect(desktopPackage.build.nsis).toEqual({
+      allowElevation: true,
+      allowToChangeInstallationDirectory: true,
+      artifactName: 'Pythinker-${version}-${arch}-Setup.${ext}',
+      createDesktopShortcut: true,
+      createStartMenuShortcut: true,
+      oneClick: false,
+      perMachine: false,
+      shortcutName: 'Pythinker',
+    })
+    expect(desktopPackage.build.nsis.artifactName).toBe('Pythinker-${version}-${arch}-Setup.${ext}')
+    expect(desktopPackage.build.productName).toBe('Pythinker')
+    expect(desktopPackage.scripts['dist:win']).toBe('node --import tsx scripts/release-win.ts')
+  })
+
   it('exposes desktop commands at the repository root', () => {
     expect(rootPackage.scripts['dev:desktop']).toBe('pnpm -C apps/desktop run dev')
     expect(rootPackage.scripts['package:desktop']).toBe('pnpm -C apps/desktop run package')
     expect(rootPackage.scripts['dist:mac:desktop']).toBe('pnpm -C apps/desktop run dist:mac')
+    expect(rootPackage.scripts['dist:win:desktop']).toBe('pnpm -C apps/desktop run dist:win')
   })
 })

--- a/apps/desktop/tests/packaging-config.spec.ts
+++ b/apps/desktop/tests/packaging-config.spec.ts
@@ -112,6 +112,12 @@ describe('desktop packaging configuration', () => {
     expect(desktopPackage.scripts['dist:win']).toBe('node --import tsx scripts/release-win.ts')
   })
 
+  it('offers an assisted installer that defaults to a per-user install', () => {
+    expect(desktopPackage.build.nsis.oneClick).toBe(false)
+    expect(desktopPackage.build.nsis.perMachine).toBe(false)
+    expect(desktopPackage.build.nsis.allowElevation).toBe(true)
+  })
+
   it('exposes desktop commands at the repository root', () => {
     expect(rootPackage.scripts['dev:desktop']).toBe('pnpm -C apps/desktop run dev')
     expect(rootPackage.scripts['package:desktop']).toBe('pnpm -C apps/desktop run package')

--- a/apps/desktop/tests/stage-runtime.spec.ts
+++ b/apps/desktop/tests/stage-runtime.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { packageManagerInvocation } from '../scripts/stage-runtime'
+
+describe('package manager invocation', () => {
+  it('leaves non-Windows invocations untouched', () => {
+    const args = ['--filter', 'x', '/tmp/a b']
+
+    expect(packageManagerInvocation('darwin', 'pnpm', args)).toEqual({
+      command: 'pnpm',
+      args,
+      shell: false,
+    })
+  })
+
+  it('uses a shell on Windows', () => {
+    expect(packageManagerInvocation('win32', 'pnpm', ['deploy']).shell).toBe(true)
+  })
+
+  it('quotes a Windows path containing a space', () => {
+    expect(packageManagerInvocation('win32', 'pnpm', ['deploy', 'C:\\Users\\John Doe\\tmp']).args)
+      .toEqual(['deploy', '"C:\\Users\\John Doe\\tmp"'])
+  })
+
+  it('leaves a safe Windows argument alone', () => {
+    expect(packageManagerInvocation('win32', 'pnpm', ['--config.node-linker=hoisted']).args)
+      .toEqual(['--config.node-linker=hoisted'])
+  })
+
+  it('quotes a Windows cmd metacharacter', () => {
+    expect(packageManagerInvocation('win32', 'pnpm', ['deploy&verify']).args)
+      .toEqual(['"deploy&verify"'])
+  })
+})

--- a/apps/desktop/tests/stage-runtime.spec.ts
+++ b/apps/desktop/tests/stage-runtime.spec.ts
@@ -1,5 +1,6 @@
+import { isAbsolute, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { packageManagerInvocation } from '../scripts/stage-runtime'
+import { deployTargetArgument, packageManagerInvocation } from '../scripts/stage-runtime'
 
 describe('package manager invocation', () => {
   it('leaves non-Windows invocations untouched', () => {
@@ -29,5 +30,23 @@ describe('package manager invocation', () => {
   it('quotes a Windows cmd metacharacter', () => {
     expect(packageManagerInvocation('win32', 'pnpm', ['deploy&verify']).args)
       .toEqual(['"deploy&verify"'])
+  })
+})
+
+describe('deploy target argument', () => {
+  it('is relative to the workspace root', () => {
+    expect(deployTargetArgument('/repo', '/repo/node_modules/.pythinker-desktop-staging/runtime-abc123'))
+      .toBe(join('node_modules', '.pythinker-desktop-staging', 'runtime-abc123'))
+  })
+
+  it('is never absolute', () => {
+    expect(isAbsolute(deployTargetArgument('/repo', '/repo/node_modules/.pythinker-desktop-staging/runtime-abc123')))
+      .toBe(false)
+  })
+
+  it('never returns the target unchanged', () => {
+    const target = '/repo/node_modules/.pythinker-desktop-staging/runtime-abc123'
+
+    expect(deployTargetArgument('/repo', target)).not.toBe(target)
   })
 })

--- a/apps/desktop/tests/verify-packaged-runtime.spec.ts
+++ b/apps/desktop/tests/verify-packaged-runtime.spec.ts
@@ -38,4 +38,38 @@ describe('packaged desktop runtime verification', () => {
       await rm(appOutDir, { recursive: true, force: true })
     }
   })
+
+  it('rejects a Windows shell whose node-pty native closure was filtered out', async () => {
+    const appOutDir = await mkdtemp(join(tmpdir(), 'pythinker-packaged-runtime-'))
+    try {
+      const resources = join(appOutDir, 'resources', 'host', 'node_modules')
+      const cli = join(resources, '@pymodel', 'pythinker-code', 'dist', 'launcher.mjs')
+      const web = join(resources, '@pymodel', 'pythinker-code', 'dist-web', 'index.html')
+      await mkdir(join(cli, '..'), { recursive: true })
+      await mkdir(join(web, '..'), { recursive: true })
+      await writeFile(cli, '')
+      await writeFile(web, '')
+
+      await expect(afterPack(context(appOutDir, 'win32'))).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      await rm(appOutDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not require Windows node-pty entries for a Darwin shell', async () => {
+    const appOutDir = await mkdtemp(join(tmpdir(), 'pythinker-packaged-runtime-'))
+    try {
+      const resources = join(appOutDir, 'Pythinker.app', 'Contents', 'Resources', 'host', 'node_modules')
+      const cli = join(resources, '@pymodel', 'pythinker-code', 'dist', 'launcher.mjs')
+      const web = join(resources, '@pymodel', 'pythinker-code', 'dist-web', 'index.html')
+      await mkdir(join(cli, '..'), { recursive: true })
+      await mkdir(join(web, '..'), { recursive: true })
+      await writeFile(cli, '')
+      await writeFile(web, '')
+
+      await expect(afterPack(context(appOutDir))).resolves.toBeUndefined()
+    } finally {
+      await rm(appOutDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/apps/desktop/tests/verify-win-installer.spec.ts
+++ b/apps/desktop/tests/verify-win-installer.spec.ts
@@ -1,0 +1,74 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { verifyWindowsInstaller } from '../scripts/verify-win-installer'
+
+const VERSION = '9.9.9'
+
+function portableExecutable(magic = 'MZ', signature = 'PE\0\0', offset = 0x80): Buffer {
+  const image = Buffer.alloc(offset + signature.length)
+  image.write(magic, 0, magic.length, 'latin1')
+  image.writeUInt32LE(offset, 0x3c)
+  image.write(signature, offset, signature.length, 'latin1')
+  return image
+}
+
+async function withFixture(callback: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'pythinker-win-installer-'))
+  try {
+    await callback(root)
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
+}
+
+async function createFixture(root: string, installer?: Buffer): Promise<void> {
+  const dist = join(root, 'dist')
+  await mkdir(join(dist, 'win-unpacked'), { recursive: true })
+  await writeFile(join(root, 'package.json'), JSON.stringify({ version: VERSION }))
+  if (installer !== undefined) {
+    await writeFile(join(dist, `Pythinker-${VERSION}-x64-Setup.exe`), installer)
+  }
+  await writeFile(join(dist, 'win-unpacked', 'Pythinker.exe'), portableExecutable())
+}
+
+describe('Windows installer verification', () => {
+  it('accepts the installer and unpacked shell when both are PE binaries', async () => {
+    await withFixture(async (root) => {
+      await createFixture(root, portableExecutable())
+      expect(() => verifyWindowsInstaller(root)).not.toThrow()
+    })
+  })
+
+  it('rejects a missing installer', async () => {
+    await withFixture(async (root) => {
+      await createFixture(root)
+      expect(() => verifyWindowsInstaller(root)).toThrow('ENOENT')
+    })
+  })
+
+  it('rejects an artifact without a DOS header', async () => {
+    await withFixture(async (root) => {
+      await createFixture(root, portableExecutable('ZZ'))
+      expect(() => verifyWindowsInstaller(root)).toThrow(/no DOS header/)
+    })
+  })
+
+  it('rejects an artifact with a truncated PE offset', async () => {
+    await withFixture(async (root) => {
+      const truncated = Buffer.alloc(0x44)
+      truncated.write('MZ', 0, 2, 'latin1')
+      truncated.writeUInt32LE(0x80, 0x3c)
+      await createFixture(root, truncated)
+      expect(() => verifyWindowsInstaller(root)).toThrow(/out-of-range PE offset/)
+    })
+  })
+
+  it('rejects an artifact without a PE signature', async () => {
+    await withFixture(async (root) => {
+      await createFixture(root, portableExecutable('MZ', 'NE\0\0'))
+      expect(() => verifyWindowsInstaller(root)).toThrow(/no PE signature/)
+    })
+  })
+})

--- a/apps/desktop/tests/verify-win-installer.spec.ts
+++ b/apps/desktop/tests/verify-win-installer.spec.ts
@@ -37,21 +37,21 @@ describe('Windows installer verification', () => {
   it('accepts the installer and unpacked shell when both are PE binaries', async () => {
     await withFixture(async (root) => {
       await createFixture(root, portableExecutable())
-      expect(() => verifyWindowsInstaller(root)).not.toThrow()
+      expect(() => { verifyWindowsInstaller(root) }).not.toThrow()
     })
   })
 
   it('rejects a missing installer', async () => {
     await withFixture(async (root) => {
       await createFixture(root)
-      expect(() => verifyWindowsInstaller(root)).toThrow('ENOENT')
+      expect(() => { verifyWindowsInstaller(root) }).toThrow('ENOENT')
     })
   })
 
   it('rejects an artifact without a DOS header', async () => {
     await withFixture(async (root) => {
       await createFixture(root, portableExecutable('ZZ'))
-      expect(() => verifyWindowsInstaller(root)).toThrow(/no DOS header/)
+      expect(() => { verifyWindowsInstaller(root) }).toThrow(/no DOS header/u)
     })
   })
 
@@ -61,14 +61,14 @@ describe('Windows installer verification', () => {
       truncated.write('MZ', 0, 2, 'latin1')
       truncated.writeUInt32LE(0x80, 0x3c)
       await createFixture(root, truncated)
-      expect(() => verifyWindowsInstaller(root)).toThrow(/out-of-range PE offset/)
+      expect(() => { verifyWindowsInstaller(root) }).toThrow(/out-of-range PE offset/u)
     })
   })
 
   it('rejects an artifact without a PE signature', async () => {
     await withFixture(async (root) => {
       await createFixture(root, portableExecutable('MZ', 'NE\0\0'))
-      expect(() => verifyWindowsInstaller(root)).toThrow(/no PE signature/)
+      expect(() => { verifyWindowsInstaller(root) }).toThrow(/no PE signature/u)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:plugin-marketplace": "pnpm -C apps/pythinker-code run build:plugin-marketplace",
     "dashboard": "pnpm -C apps/dashboard run dev",
     "dev:docs": "pnpm -C docs install --ignore-workspace && pnpm -C docs run dev",
-    "typecheck": "pnpm run build:packages && pnpm -r --filter './packages/*' run typecheck && pnpm --filter @pymodel/pythinker-code run typecheck && pnpm --filter @pymodel/pythinker-web run typecheck && pnpm --filter @pymodel/dashboard-server run typecheck && pnpm --filter @pymodel/dashboard-web run typecheck",
+    "typecheck": "pnpm run build:packages && pnpm -r --filter './packages/*' run typecheck && pnpm --filter @pymodel/pythinker-code run typecheck && pnpm --filter @pymodel/pythinker-web run typecheck && pnpm --filter @pymodel/dashboard-server run typecheck && pnpm --filter @pymodel/dashboard-web run typecheck && pnpm --filter @pymodel/pythinker-desktop run typecheck",
     "lint": "oxlint --type-aware",
     "lint:fix": "pnpm run lint --fix",
     "lint:pkg": "pnpm --filter @pymodel/pythinker-code exec publint && npm_config_cache=${TMPDIR:-/tmp}/pythinker-code-npm-cache pnpm --filter @pymodel/pythinker-code exec attw --pack . --profile node16",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:web": "pnpm -C apps/pythinker-web run dev",
     "package:desktop": "pnpm -C apps/desktop run package",
     "dist:mac:desktop": "pnpm -C apps/desktop run dist:mac",
+    "dist:win:desktop": "pnpm -C apps/desktop run dist:win",
     "dev:server": "pnpm -C apps/pythinker-code run dev:server",
     "build:plugin-marketplace": "pnpm -C apps/pythinker-code run build:plugin-marketplace",
     "dashboard": "pnpm -C apps/dashboard run dev",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['packages/*', 'apps/pythinker-code'],
+    projects: ['packages/*', 'apps/pythinker-code', 'apps/desktop'],
     coverage: {
       provider: 'v8',
       include: ['packages/*/src/**/*.ts', 'apps/*/src/**/*.ts'],


### PR DESCRIPTION
## Related Issue

No prior issue. The problem is described below.

## Problem

`apps/desktop` shipped a macOS-only application. `build.win` used the `dir`
target, which emits an unpacked directory and no installer, so Windows had
nothing to distribute and `electron-updater` had no `latest.yml` feed to read.

Three Windows defects also lived in the shell itself, each dead or wrong code
rather than a missing feature:

- `host-supervisor.ts` terminated the Host with `child.kill()`. Windows has no
  signal delivery, so that is `TerminateProcess` on one PID and the Host's own
  children — node-pty shells, subagent hosts — survived and kept holding the
  loopback port.
- The packaged-runtime guard tested `nodeExecutable.includes('/')`, which is
  never true for `C:\...\Pythinker.exe`. The check could not fire on Windows.
- No `app.setAppUserModelId`, so taskbar pinning did not survive an installer
  upgrade and toasts were attributed to a generated identity.

Separately, `apps/desktop`'s 65 vitest cases and its typecheck script ran in no
required check, so a desktop regression merged green.

## What changed

**Windows packaging** — per-user NSIS installer (`oneClick: false`,
`perMachine: false`, elevation allowed, installation directory selectable,
desktop and Start Menu shortcuts), `dist:win`, and a `windows-latest` release
job running in parallel with `mac`. `verify-win-installer.ts` sniffs the DOS and
PE headers of both artifacts rather than trusting the file extension.

`dist:win` refuses to run anywhere but native Windows x64. This is not caution:
`stage-runtime.ts` runs `pnpm deploy` on the build machine, and the closure
resolves platform-gated natives — a macOS-staged tree carries
`@opentui/core-darwin-arm64` and cannot produce a working Windows build.

**Windows runtime** — tree kill via `taskkill /T /F`, `isAbsolute()` for the
artifact guard, `setAppUserModelId`, and an `afterPack` check for the win32
`node-pty` prebuilds.

**Release workflow** — an unset GitHub secret interpolates to an empty string,
not to an absent variable, and electron-builder resolves an empty `CSC_LINK` as
a certificate path: `path.resolve(appDir, '')` is the app directory, so the
macOS job died on `not a file`. Credentials are now exported only when they
carry a value, which also fixed the pre-existing macOS failure. Windows
artifacts are unsigned until `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` are
configured; the job passes them through, so enabling signing needs no code
change.

**Staging** — Node refuses to spawn a `.cmd` shim without a shell, so `pnpm.cmd`
raised `EINVAL`. And pnpm joins its workspace root with the deploy target rather
than resolving it, so an absolute path on another volume became
`D:\repo\C:\Users\...`. The target is now workspace-relative, which is correct
whether pnpm joins or resolves, and the staging directory moved onto the
repository's own volume.

**CI gates** — `apps/desktop` registered in the root vitest projects, plus a
per-package typecheck step. Deliberately not added to the `tsgo` loop, which
covers the source tsconfig and would silently skip `tests/tsconfig.json`.

Out of scope, and left alone: the reference implementation's Windows ACL runner
and pwsh sandbox trampoline (`packages/kaos` and `agent-core` carry their own
win32 handling), Windows arm64, Linux packaging, and signing certificates.
`apps/vscode` has the same CI-gate omission; that is pre-existing and belongs in
its own change.

## How this was verified

Windows packaging cannot be validated on a macOS workstation, so the proof is a
green CI run, not a local claim.

Run [31914773126](https://github.com/PyModel/pythinker-code/actions/runs/31914773126)
— `mac: success`, `windows: success`:

```
• building  target=nsis file=dist\Pythinker-0.1.0-x64-Setup.exe archs=x64 oneClick=false perMachine=false
• building block map  blockMapFile=dist\Pythinker-0.1.0-x64-Setup.exe.blockmap
• uploading  file=Pythinker-0.1.0-x64-Setup.exe provider=github
```

Artifacts: `desktop-windows` 134 MB, `desktop-macos` 329 MB, with `latest.yml`
and a `.blockmap` so Windows auto-update downloads differentially.

Three earlier runs failed and each fix is a separate commit, so the sequence is
reviewable: `EINVAL` on `.cmd`, then empty signing credentials, then the pnpm
deploy target.

Locally, every added test was mutation-proved — the guard was reverted, the test
was watched go red, then restored and watched go green. That includes the new CI
gate itself: breaking a desktop test now fails root `pnpm run test` with
`FAIL |@pymodel/pythinker-desktop| tests/stage-runtime.spec.ts`, which it could
not do before this change.

Full root suite: 682 files, 10184 passed, 71 skipped. Desktop typecheck and
`pnpm run lint` both exit 0.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows x64 NSIS installer packaging with customizable installation location, shortcuts, and optional signing.
  * Added a Windows desktop release workflow and distribution command.
* **Bug Fixes**
  * Improved Windows process-tree shutdown and packaged runtime validation.
  * Fixed Windows application identity and runtime staging behavior.
  * Added installer validation to catch invalid or incomplete release artifacts.
* **Documentation**
  * Documented Windows packaging requirements, installer output, signing options, and current platform limitations.
* **Tests**
  * Expanded automated coverage for Windows packaging, staging, runtime checks, and process termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->