### PR TITLE
fix(desktop): sign the Windows installer and clean up the Windows window chrome

### DIFF
--- a/.changeset/desktop-windows-azure-signing.md
+++ b/.changeset/desktop-windows-azure-signing.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': patch
+---
+
+Sign the Windows installer through Azure Artifact Signing when the signing environment is configured

--- a/.changeset/site-windows-download.md
+++ b/.changeset/site-windows-download.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Add a Windows download button to the site and point both desktop download buttons directly at the published installer assets.

--- a/.changeset/windows-opaque-window.md
+++ b/.changeset/windows-opaque-window.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': patch
+---
+
+Render the Windows desktop window opaquely so the theme colours are not blended with the desktop wallpaper

--- a/.changeset/windows-titlebar-and-display-name.md
+++ b/.changeset/windows-titlebar-and-display-name.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Reserve the Windows title-bar area so the window controls no longer overlap the chat header, paint the Windows sidebar solid, and change the VS Code extension display name to `Pythinker` because the previous name is reserved on the Marketplace.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -138,9 +138,25 @@ jobs:
             value="${!input:-}"
             if [ -n "$value" ]; then printf '%s<<__EOF__\n%s\n__EOF__\n' "$name" "$value" >> "$GITHUB_ENV"; fi
           done
+      - name: Resolve Azure signing configuration
+        shell: bash
+        env:
+          IN_AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          IN_AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          IN_AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          IN_AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          IN_AZURE_SIGNING_ACCOUNT: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          IN_AZURE_SIGNING_CERT_PROFILE: ${{ secrets.AZURE_SIGNING_CERT_PROFILE }}
+          IN_AZURE_SIGNING_PUBLISHER_NAME: ${{ secrets.AZURE_SIGNING_PUBLISHER_NAME }}
+        run: |
+          for name in AZURE_TENANT_ID AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_SIGNING_ENDPOINT AZURE_SIGNING_ACCOUNT AZURE_SIGNING_CERT_PROFILE AZURE_SIGNING_PUBLISHER_NAME; do
+            input="IN_${name}"
+            value="${!input:-}"
+            if [ -n "$value" ]; then printf '%s<<__EOF__\n%s\n__EOF__\n' "$name" "$value" >> "$GITHUB_ENV"; fi
+          done
       - name: Package and publish desktop release
         working-directory: apps/desktop
-        run: pnpm exec electron-builder --win nsis --x64 --publish always
+        run: node --import tsx scripts/package-win.ts --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -66,7 +66,11 @@ rmdir "$MOUNT_POINT"
 
 ### Windows
 
-Run `pnpm run dist:win` on a native Windows x64 host; cross-building from macOS is not possible because the staged Host closure contains platform-gated native packages. The output is `dist/Pythinker-<version>-x64-Setup.exe`, an assisted NSIS installer that defaults to a per-user install, offers a per-machine option that requires elevation, and lets you select the installation directory. Artifacts are unsigned unless `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` are set.
+Run `pnpm run dist:win` on a native Windows x64 host; cross-building from macOS is not possible because the staged Host closure contains platform-gated native packages. The output is `dist/Pythinker-<version>-x64-Setup.exe`, an assisted NSIS installer that defaults to a per-user install, offers a per-machine option that requires elevation, and lets you select the installation directory. The existing certificate-file signing path uses `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD`.
+
+#### Azure Artifact Signing
+
+Windows artifacts are signed through Azure Artifact Signing when `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SIGNING_ENDPOINT`, `AZURE_SIGNING_ACCOUNT`, `AZURE_SIGNING_CERT_PROFILE`, and `AZURE_SIGNING_PUBLISHER_NAME` are all set; they are unsigned when none are set. The credential variables are read from the environment; the four `AZURE_SIGNING_*` variables map to `azureSignOptions.endpoint`, `azureSignOptions.codeSigningAccountName`, `azureSignOptions.certificateProfileName`, and `azureSignOptions.publisherName`, respectively. Setting only some of the seven variables is a hard error by design.
 
 ## Known limitations
 

--- a/apps/desktop/scripts/package-win.ts
+++ b/apps/desktop/scripts/package-win.ts
@@ -1,0 +1,87 @@
+/** Package the Windows NSIS installer with optional Azure Artifact Signing. */
+
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { packageManagerInvocation } from './stage-runtime'
+
+function trimmedValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed === '' ? undefined : trimmed
+}
+
+/** Return Electron Builder overrides when all Azure signing settings are configured. */
+export function windowsSigningArgs(env: NodeJS.ProcessEnv): readonly string[] {
+  const values: readonly (readonly [string, string | undefined])[] = [
+    ['AZURE_TENANT_ID', trimmedValue(env['AZURE_TENANT_ID'])],
+    ['AZURE_CLIENT_ID', trimmedValue(env['AZURE_CLIENT_ID'])],
+    ['AZURE_CLIENT_SECRET', trimmedValue(env['AZURE_CLIENT_SECRET'])],
+    ['AZURE_SIGNING_ENDPOINT', trimmedValue(env['AZURE_SIGNING_ENDPOINT'])],
+    ['AZURE_SIGNING_ACCOUNT', trimmedValue(env['AZURE_SIGNING_ACCOUNT'])],
+    ['AZURE_SIGNING_CERT_PROFILE', trimmedValue(env['AZURE_SIGNING_CERT_PROFILE'])],
+    ['AZURE_SIGNING_PUBLISHER_NAME', trimmedValue(env['AZURE_SIGNING_PUBLISHER_NAME'])],
+  ]
+  const missing: string[] = []
+  const args: string[] = []
+  for (const [name, value] of values) {
+    if (value === undefined) {
+      missing.push(name)
+      continue
+    }
+
+    switch (name) {
+      case 'AZURE_SIGNING_ENDPOINT':
+        args.push('--config.win.azureSignOptions.endpoint', value)
+        break
+      case 'AZURE_SIGNING_ACCOUNT':
+        args.push('--config.win.azureSignOptions.codeSigningAccountName', value)
+        break
+      case 'AZURE_SIGNING_CERT_PROFILE':
+        args.push('--config.win.azureSignOptions.certificateProfileName', value)
+        break
+      case 'AZURE_SIGNING_PUBLISHER_NAME':
+        args.push('--config.win.azureSignOptions.publisherName', value)
+        break
+    }
+  }
+  missing.sort()
+
+  if (missing.length === values.length) return []
+  if (missing.length > 0) {
+    throw new Error(
+      `Windows signing is partially configured; missing: ${missing.join(', ')}. Set all seven signing variables or none.`,
+    )
+  }
+
+  return args
+}
+
+/** Return the package-manager invocation for a Windows installer build. */
+export function windowsPackageInvocation(platform: string, env: NodeJS.ProcessEnv, publish: string): {
+  readonly command: string
+  readonly args: readonly string[]
+  readonly shell: boolean
+} {
+  const args = ['exec', 'electron-builder', '--win', 'nsis', '--x64', '--publish', publish, ...windowsSigningArgs(env)]
+  return packageManagerInvocation(platform, 'pnpm', args)
+}
+
+/** Package the Windows installer and optionally sign it through Azure Artifact Signing. */
+export function packageWin(options: { readonly publish: string }): void {
+  const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const invocation = windowsPackageInvocation(process.platform, process.env, options.publish)
+  const result = spawnSync(invocation.command, invocation.args, { cwd: desktopRoot, stdio: 'inherit', shell: invocation.shell })
+  if (result.error !== undefined) throw result.error
+  if (result.status !== 0) throw new Error(`electron-builder exited with ${String(result.status)}`)
+}
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  try {
+    const publishIndex = process.argv.indexOf('--publish')
+    packageWin({ publish: publishIndex === -1 ? 'never' : (process.argv[publishIndex + 1] ?? 'never') })
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/apps/desktop/scripts/release-win.ts
+++ b/apps/desktop/scripts/release-win.ts
@@ -3,6 +3,7 @@
 import { spawnSync } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { packageWin } from './package-win'
 import { verifyWindowsInstaller } from './verify-win-installer'
 
 function run(command: string, args: readonly string[], cwd: string): void {
@@ -11,7 +12,7 @@ function run(command: string, args: readonly string[], cwd: string): void {
   if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} exited with ${String(result.status)}`)
 }
 
-/** Build and verify the unsigned Windows installer. */
+/** Build and verify the Windows installer. */
 export function releaseWin(): void {
   if (process.platform !== 'win32') {
     throw new Error('The Windows installer must be built on Windows: the staged Host closure contains platform-specific native packages')
@@ -22,7 +23,7 @@ export function releaseWin(): void {
   const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
   run('pnpm', ['--workspace-root', 'run', 'build'], desktopRoot)
   run('node', ['--import', 'tsx', 'scripts/stage-runtime.ts'], desktopRoot)
-  run('pnpm', ['exec', 'electron-builder', '--win', 'nsis', '--x64', '--publish', 'never'], desktopRoot)
+  packageWin({ publish: 'never' })
   verifyWindowsInstaller(desktopRoot)
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -201,8 +201,9 @@ async function createMainWindow(): Promise<BrowserWindow> {
       vibrancy: 'sidebar' as const,
       visualEffectState: 'followWindow' as const,
     } : {}),
+    // Windows uses an opaque window so theme colors do not blend with desktop wallpaper.
     ...(process.platform === 'win32' ? {
-      backgroundMaterial: 'acrylic' as const,
+      backgroundColor: '#0d1117',
       hasShadow: true,
       roundedCorners: true,
       thickFrame: true,

--- a/apps/desktop/tests/package-win.spec.ts
+++ b/apps/desktop/tests/package-win.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { windowsPackageInvocation, windowsSigningArgs } from '../scripts/package-win'
+
+const signingEnvironment: NodeJS.ProcessEnv = {
+  AZURE_TENANT_ID: 'tenant-id',
+  AZURE_CLIENT_ID: 'client-id',
+  AZURE_CLIENT_SECRET: 'client-secret',
+  AZURE_SIGNING_ENDPOINT: 'https://example.test',
+  AZURE_SIGNING_ACCOUNT: 'signing-account',
+  AZURE_SIGNING_CERT_PROFILE: 'certificate-profile',
+  AZURE_SIGNING_PUBLISHER_NAME: 'CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US',
+}
+
+describe('Windows Azure signing configuration', () => {
+  it('leaves the build unsigned when no signing variables are set', () => {
+    expect(windowsSigningArgs({})).toEqual([])
+  })
+
+  it('passes Azure signing settings as separate Electron Builder arguments', () => {
+    expect(windowsSigningArgs(signingEnvironment)).toEqual([
+      '--config.win.azureSignOptions.endpoint', 'https://example.test',
+      '--config.win.azureSignOptions.codeSigningAccountName', 'signing-account',
+      '--config.win.azureSignOptions.certificateProfileName', 'certificate-profile',
+      '--config.win.azureSignOptions.publisherName', 'CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US',
+    ])
+  })
+
+  it('rejects a missing Azure credential', () => {
+    expect(() => windowsSigningArgs({
+      ...signingEnvironment,
+      AZURE_CLIENT_SECRET: undefined,
+    })).toThrow(
+      'Windows signing is partially configured; missing: AZURE_CLIENT_SECRET. Set all seven signing variables or none.',
+    )
+  })
+
+  it('rejects a missing Azure signing setting', () => {
+    expect(() => windowsSigningArgs({
+      ...signingEnvironment,
+      AZURE_SIGNING_ACCOUNT: undefined,
+    })).toThrow(
+      'Windows signing is partially configured; missing: AZURE_SIGNING_ACCOUNT. Set all seven signing variables or none.',
+    )
+  })
+
+  it('treats whitespace-only signing values as absent', () => {
+    expect(() => windowsSigningArgs({
+      ...signingEnvironment,
+      AZURE_SIGNING_PUBLISHER_NAME: '   ',
+    })).toThrow('AZURE_SIGNING_PUBLISHER_NAME')
+  })
+})
+
+describe('Windows package invocation', () => {
+  it('quotes the publisher name on Windows', () => {
+    const invocation = windowsPackageInvocation('win32', signingEnvironment, 'never')
+
+    expect(invocation.args).toContain('"CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US"')
+    expect(invocation.shell).toBe(true)
+  })
+
+  it('leaves the publisher name unquoted outside Windows', () => {
+    const invocation = windowsPackageInvocation('darwin', signingEnvironment, 'never')
+
+    expect(invocation.args).toContain('CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US')
+    expect(invocation.shell).toBe(false)
+  })
+
+  it('preserves argument order and content outside Windows', () => {
+    expect(windowsPackageInvocation('darwin', signingEnvironment, 'never').args).toEqual([
+      'exec', 'electron-builder', '--win', 'nsis', '--x64', '--publish', 'never',
+      '--config.win.azureSignOptions.endpoint', 'https://example.test',
+      '--config.win.azureSignOptions.codeSigningAccountName', 'signing-account',
+      '--config.win.azureSignOptions.certificateProfileName', 'certificate-profile',
+      '--config.win.azureSignOptions.publisherName', 'CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US',
+    ])
+  })
+
+  it('omits signing arguments when signing is not configured', () => {
+    const expectedArgs = ['exec', 'electron-builder', '--win', 'nsis', '--x64', '--publish', 'never']
+    const darwin = windowsPackageInvocation('darwin', {}, 'never')
+    const win32 = windowsPackageInvocation('win32', {}, 'never')
+
+    expect(darwin.args).toEqual(expectedArgs)
+    expect(win32.args).toEqual(expectedArgs)
+    expect(darwin.args.some(argument => argument.startsWith('--config.win.'))).toBe(false)
+    expect(win32.args.some(argument => argument.startsWith('--config.win.'))).toBe(false)
+  })
+
+  it('uses pnpm on both platforms', () => {
+    expect(windowsPackageInvocation('darwin', signingEnvironment, 'never').command).toBe('pnpm')
+    expect(windowsPackageInvocation('win32', signingEnvironment, 'never').command).toBe('pnpm')
+  })
+})

--- a/apps/desktop/tests/packaging-config.spec.ts
+++ b/apps/desktop/tests/packaging-config.spec.ts
@@ -58,6 +58,24 @@ describe('desktop packaging configuration', () => {
     expect(desktopPackage.build.productName).toBe('Pythinker')
   })
 
+  it('keeps desktop download URLs derived from their published release version', () => {
+    const siteSource = readFileSync(resolve(repositoryRoot, 'apps/site/src/App.vue'), 'utf8')
+    const desktopVersionMatch = siteSource.match(/const DESKTOP_VERSION = '([^']+)'/)
+
+    expect(desktopVersionMatch).not.toBeNull()
+    expect(desktopVersionMatch![1]).not.toBe('')
+    expect(siteSource).not.toContain('Pythinker-0.1.0-arm64.dmg')
+    expect(siteSource).not.toContain('Pythinker-0.1.0-x64-Setup.exe')
+    expect(siteSource).toContain('Pythinker-${DESKTOP_VERSION}-arm64.dmg')
+    expect(siteSource).toContain('Pythinker-${DESKTOP_VERSION}-x64-Setup.exe')
+    expect(siteSource).toContain('releases/download/v${DESKTOP_VERSION}')
+    expect(siteSource).not.toContain('releases/download/v0.1.0')
+
+    const desktopShowcaseMatch = siteSource.match(/<section id="desktop"[\s\S]*?<\/section>/)
+    expect(desktopShowcaseMatch).not.toBeNull()
+    expect(desktopShowcaseMatch![0]).toContain('/brand/windows11.svg')
+  })
+
   it('maps the staged Host node_modules directory as the copy root', () => {
     expect(desktopPackage.build.extraResources).toEqual(expect.arrayContaining([
       { from: 'resources', to: 'desktop-resources' },

--- a/apps/desktop/tests/window-appearance.spec.ts
+++ b/apps/desktop/tests/window-appearance.spec.ts
@@ -9,12 +9,12 @@ const mainSource = readFileSync(resolve(desktopRoot, 'src', 'main.ts'), 'utf8')
 
 describe('desktop window appearance configuration', () => {
   it('keeps Windows opaque and non-Windows windows transparent', () => {
-    const backgroundMaterialMatches = [...mainSource.matchAll(/backgroundMaterial/g)]
+    const backgroundMaterialMatches = [...mainSource.matchAll(/backgroundMaterial/gu)]
     const win32BranchMatches = [...mainSource.matchAll(
-      /\.\.\.\(process\.platform === 'win32' \? \{([\s\S]*?)\} : \{\s*transparent: true,/g,
+      /\.\.\.\(process\.platform === 'win32' \? \{([\s\S]*?)\} : \{\s*transparent: true,/gu,
     )]
     const nonWin32BranchMatches = [...mainSource.matchAll(
-      /\} : \{\s*transparent: true,[\s\S]*?\}\),\s*title:/g,
+      /\} : \{\s*transparent: true,[\s\S]*?\}\),\s*title:/gu,
     )]
 
     expect(backgroundMaterialMatches).toHaveLength(0)
@@ -22,11 +22,11 @@ describe('desktop window appearance configuration', () => {
     expect(nonWin32BranchMatches).toHaveLength(1)
 
     const win32Branch = win32BranchMatches[0]![1]!
-    const opaqueColorMatches = [...win32Branch.matchAll(/backgroundColor:\s*'#[0-9a-fA-F]{6}'/g)]
-    const alphaColorMatches = [...win32Branch.matchAll(/#[0-9a-fA-F]{8}/g)]
-    const hasShadowMatches = [...win32Branch.matchAll(/hasShadow:\s*true/g)]
-    const roundedCornersMatches = [...win32Branch.matchAll(/roundedCorners:\s*true/g)]
-    const thickFrameMatches = [...win32Branch.matchAll(/thickFrame:\s*true/g)]
+    const opaqueColorMatches = [...win32Branch.matchAll(/backgroundColor:\s*'#[0-9a-fA-F]{6}'/gu)]
+    const alphaColorMatches = [...win32Branch.matchAll(/#[0-9a-fA-F]{8}/gu)]
+    const hasShadowMatches = [...win32Branch.matchAll(/hasShadow:\s*true/gu)]
+    const roundedCornersMatches = [...win32Branch.matchAll(/roundedCorners:\s*true/gu)]
+    const thickFrameMatches = [...win32Branch.matchAll(/thickFrame:\s*true/gu)]
 
     expect(opaqueColorMatches).toHaveLength(1)
     expect(alphaColorMatches).toHaveLength(0)

--- a/apps/desktop/tests/window-appearance.spec.ts
+++ b/apps/desktop/tests/window-appearance.spec.ts
@@ -1,0 +1,43 @@
+// Static check: no Windows host exists in CI or locally, so this test guards the
+// window configuration rather than the rendered result.
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const desktopRoot = resolve(import.meta.dirname, '..')
+const mainSource = readFileSync(resolve(desktopRoot, 'src', 'main.ts'), 'utf8')
+
+describe('desktop window appearance configuration', () => {
+  it('keeps Windows opaque and non-Windows windows transparent', () => {
+    const backgroundMaterialMatches = [...mainSource.matchAll(/backgroundMaterial/g)]
+    const win32BranchMatches = [...mainSource.matchAll(
+      /\.\.\.\(process\.platform === 'win32' \? \{([\s\S]*?)\} : \{\s*transparent: true,/g,
+    )]
+    const nonWin32BranchMatches = [...mainSource.matchAll(
+      /\} : \{\s*transparent: true,[\s\S]*?\}\),\s*title:/g,
+    )]
+
+    expect(backgroundMaterialMatches).toHaveLength(0)
+    expect(win32BranchMatches).toHaveLength(1)
+    expect(nonWin32BranchMatches).toHaveLength(1)
+
+    const win32Branch = win32BranchMatches[0]![1]!
+    const opaqueColorMatches = [...win32Branch.matchAll(/backgroundColor:\s*'#[0-9a-fA-F]{6}'/g)]
+    const alphaColorMatches = [...win32Branch.matchAll(/#[0-9a-fA-F]{8}/g)]
+    const hasShadowMatches = [...win32Branch.matchAll(/hasShadow:\s*true/g)]
+    const roundedCornersMatches = [...win32Branch.matchAll(/roundedCorners:\s*true/g)]
+    const thickFrameMatches = [...win32Branch.matchAll(/thickFrame:\s*true/g)]
+
+    expect(opaqueColorMatches).toHaveLength(1)
+    expect(alphaColorMatches).toHaveLength(0)
+    expect(hasShadowMatches).toHaveLength(1)
+    expect(roundedCornersMatches).toHaveLength(1)
+    expect(thickFrameMatches).toHaveLength(1)
+
+    expect(win32Branch).toContain('backgroundColor')
+    expect(nonWin32BranchMatches[0]![0]).toContain('transparent: true')
+    expect(win32Branch).toContain('hasShadow')
+    expect(win32Branch).toContain('roundedCorners')
+    expect(win32Branch).toContain('thickFrame')
+  })
+})

--- a/apps/pythinker-web/src/App.vue
+++ b/apps/pythinker-web/src/App.vue
@@ -871,6 +871,7 @@ function openPr(url: string): void {
 
 <template>
   <div class="app-shell">
+    <div class="windows-titlebar" aria-hidden="true"></div>
     <section v-if="showAuthGate" class="auth-page">
       <div class="auth-page-inner">
         <PythinkerLogo size="lg" interactive class="auth-page-logo" />
@@ -1337,6 +1338,21 @@ function openPr(url: string): void {
   overflow: hidden;
   box-sizing: border-box;
 }
+.windows-titlebar { display: none; }
+:global(html[data-desktop-platform='win32'] .app-shell) {
+  padding-top: env(titlebar-area-height, 44px);
+  background: var(--panel);
+}
+:global(html[data-desktop-platform='win32'] .windows-titlebar) {
+  display: block;
+  position: fixed;
+  top: env(titlebar-area-y, 0px);
+  left: env(titlebar-area-x, 0px);
+  width: env(titlebar-area-width, 100%);
+  height: env(titlebar-area-height, 44px);
+  -webkit-app-region: drag;
+  user-select: none;
+}
 .auth-page {
   flex: 1;
   min-height: 0;
@@ -1420,19 +1436,25 @@ function openPr(url: string): void {
   overflow: hidden;
   box-sizing: border-box;
 }
-:global(html[data-desktop-platform='darwin'] .app),
-:global(html[data-desktop-platform='win32'] .app) {
+:global(html[data-desktop-platform='darwin'] .app) {
   background: transparent;
 }
+:global(html[data-desktop-platform='win32'] .app) {
+  background: var(--bg);
+}
 :global(html[data-desktop-platform='darwin'] .side),
-:global(html[data-desktop-platform='win32'] .side),
-:global(html[data-desktop-platform='darwin'] .sidebar-rail),
-:global(html[data-desktop-platform='win32'] .sidebar-rail) {
+:global(html[data-desktop-platform='darwin'] .sidebar-rail) {
   background: color-mix(in srgb, var(--panel) 55%, transparent);
 }
+:global(html[data-desktop-platform='win32'] .side),
+:global(html[data-desktop-platform='win32'] .sidebar-rail) {
+  background: var(--panel);
+}
 :global(html[data-desktop-platform='darwin'] .con),
+:global(html[data-desktop-platform='darwin'] .global-preview) {
+  background: var(--bg);
+}
 :global(html[data-desktop-platform='win32'] .con),
-:global(html[data-desktop-platform='darwin'] .global-preview),
 :global(html[data-desktop-platform='win32'] .global-preview) {
   background: var(--bg);
 }

--- a/apps/pythinker-web/test/windows-titlebar.test.ts
+++ b/apps/pythinker-web/test/windows-titlebar.test.ts
@@ -1,0 +1,58 @@
+// Static contract check: CI and local development do not have a Windows host,
+// so this checks the CSS contract rather than rendered geometry.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const appPath = ['src/App.vue', 'apps/pythinker-web/src/App.vue'].find(existsSync);
+if (!appPath) throw new Error('App.vue source was not found');
+
+const appSource = readFileSync(appPath, 'utf8');
+const styleMatch = appSource.match(/<style scoped>([\s\S]*?)<\/style>/);
+
+if (!styleMatch?.[1]) throw new Error('App.vue must have a scoped style block');
+
+const cssRules = [...styleMatch[1].matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(([, selector, declarations]) => ({
+  selector: selector!,
+  declarations: declarations!,
+}));
+const win32 = "data-desktop-platform='win32'";
+const darwin = "data-desktop-platform='darwin'";
+
+function rulesFor(platform: string, ...selectors: string[]) {
+  return cssRules.filter((rule) => (
+    rule.selector.includes(platform) && selectors.every((selector) => rule.selector.includes(selector))
+  ));
+}
+
+describe('Windows titlebar CSS contract', () => {
+  it('keeps the titlebar safe area and sidebar platform-specific', () => {
+    expect(appSource).toContain('class="windows-titlebar"');
+    expect(appSource).toContain('aria-hidden="true"');
+
+    const win32DragRules = cssRules.filter((rule) => (
+      rule.selector.includes(win32) && rule.declarations.includes('-webkit-app-region: drag')
+    ));
+    expect(win32DragRules).toHaveLength(1);
+    expect(win32DragRules[0]!.selector).toContain('.windows-titlebar');
+
+    const win32TitlebarRules = rulesFor(win32, '.windows-titlebar');
+    expect(win32TitlebarRules).toHaveLength(1);
+    expect(win32TitlebarRules[0]!.declarations).toContain('titlebar-area-x');
+    expect(win32TitlebarRules[0]!.declarations).toContain('titlebar-area-width');
+
+    const win32ShellRules = rulesFor(win32, '.app-shell');
+    expect(win32ShellRules).toHaveLength(1);
+    expect(win32ShellRules[0]!.declarations).toContain('titlebar-area-height');
+
+    const win32SidebarRules = rulesFor(win32, ' .side)', '.sidebar-rail');
+    expect(win32SidebarRules).toHaveLength(1);
+    expect(win32SidebarRules[0]!.declarations).not.toMatch(/transparent|color-mix/);
+
+    const darwinSidebarRules = rulesFor(darwin, ' .side)', '.sidebar-rail');
+    expect(darwinSidebarRules).toHaveLength(1);
+    expect(darwinSidebarRules[0]!.declarations).toContain(
+      'color-mix(in srgb, var(--panel) 55%, transparent)',
+    );
+  });
+});

--- a/apps/pythinker-web/test/windows-titlebar.test.ts
+++ b/apps/pythinker-web/test/windows-titlebar.test.ts
@@ -8,11 +8,11 @@ const appPath = ['src/App.vue', 'apps/pythinker-web/src/App.vue'].find(existsSyn
 if (!appPath) throw new Error('App.vue source was not found');
 
 const appSource = readFileSync(appPath, 'utf8');
-const styleMatch = appSource.match(/<style scoped>([\s\S]*?)<\/style>/);
+const styleMatch = appSource.match(/<style scoped>([\s\S]*?)<\/style>/u);
 
 if (!styleMatch?.[1]) throw new Error('App.vue must have a scoped style block');
 
-const cssRules = [...styleMatch[1].matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(([, selector, declarations]) => ({
+const cssRules = [...styleMatch[1].matchAll(/([^{}]+)\{([^{}]*)\}/gu)].map(([, selector, declarations]) => ({
   selector: selector!,
   declarations: declarations!,
 }));
@@ -30,9 +30,9 @@ describe('Windows titlebar CSS contract', () => {
     expect(appSource).toContain('class="windows-titlebar"');
     expect(appSource).toContain('aria-hidden="true"');
 
-    const win32DragRules = cssRules.filter((rule) => (
-      rule.selector.includes(win32) && rule.declarations.includes('-webkit-app-region: drag')
-    ));
+    const win32DragRules = cssRules
+      .filter((rule) => rule.selector.includes(win32))
+      .filter((rule) => rule.declarations.includes('-webkit-app-region: drag'));
     expect(win32DragRules).toHaveLength(1);
     expect(win32DragRules[0]!.selector).toContain('.windows-titlebar');
 
@@ -47,7 +47,7 @@ describe('Windows titlebar CSS contract', () => {
 
     const win32SidebarRules = rulesFor(win32, ' .side)', '.sidebar-rail');
     expect(win32SidebarRules).toHaveLength(1);
-    expect(win32SidebarRules[0]!.declarations).not.toMatch(/transparent|color-mix/);
+    expect(win32SidebarRules[0]!.declarations).not.toMatch(/transparent|color-mix/u);
 
     const darwinSidebarRules = rulesFor(darwin, ' .side)', '.sidebar-rail');
     expect(darwinSidebarRules).toHaveLength(1);

--- a/apps/site/src/App.vue
+++ b/apps/site/src/App.vue
@@ -7,6 +7,19 @@ import PythinkerMascot from './components/PythinkerMascot.vue';
 
 const version = __PYTHINKER_VERSION__;
 
+/**
+ * Desktop release currently published on GitHub. This tracks the published
+ * release, not apps/desktop/package.json — the manifest is bumped by changesets
+ * ahead of the build that produces these assets. Bump this only after the
+ * matching desktop release is public.
+ */
+const DESKTOP_VERSION = '0.1.0';
+const DESKTOP_RELEASE_BASE = `https://github.com/PyModel/pythinker-code/releases/download/v${DESKTOP_VERSION}`;
+const desktopDownloads = {
+  mac: `${DESKTOP_RELEASE_BASE}/Pythinker-${DESKTOP_VERSION}-arm64.dmg`,
+  windows: `${DESKTOP_RELEASE_BASE}/Pythinker-${DESKTOP_VERSION}-x64-Setup.exe`,
+};
+
 const installRows = [
   ['macOS / Linux', 'curl -fsSL https://code.pythinker.com/pythinker-code/install.sh | bash', '/brand/apple.svg'],
   ['Windows (PowerShell)', 'irm https://code.pythinker.com/pythinker-code/install.ps1 | iex', '/brand/windows11.svg'],
@@ -268,10 +281,17 @@ onUnmounted(() => {
       <div class="desktop-showcase-copy reveal">
         <p class="eyebrow">Desktop app</p>
         <h2 id="desktop-title" class="display-md">Pythinker Desktop</h2>
-        <p class="desktop-showcase-lead">The agent in a native macOS app, with sidebar sessions, live activity, and auto-updates.</p>
+        <p class="desktop-showcase-lead">The agent in native macOS and Windows apps, with sidebar sessions, live activity, and auto-updates.</p>
         <div class="desktop-showcase-actions">
-          <a class="button button-primary" href="https://github.com/PyModel/pythinker-code/releases/latest" target="_blank" rel="noopener">Download for macOS</a>
-          <span class="desktop-showcase-note">Auto-updates included · Apple Silicon</span>
+          <a class="button button-primary" :href="desktopDownloads.mac" rel="noopener">
+            <img src="/brand/apple.svg" alt="" aria-hidden="true" class="button-platform-icon" />
+            Download for macOS
+          </a>
+          <a class="button button-secondary" :href="desktopDownloads.windows" rel="noopener">
+            <img src="/brand/windows11.svg" alt="" aria-hidden="true" class="button-platform-icon" />
+            Download for Windows
+          </a>
+          <span class="desktop-showcase-note">Auto-updates included · Apple Silicon and Windows x64</span>
         </div>
       </div>
     </section>
@@ -803,6 +823,19 @@ onUnmounted(() => {
   flex-wrap: wrap;
   align-items: center;
   gap: 16px;
+}
+
+.button-platform-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.desktop-showcase-actions .button {
+  gap: 8px;
+}
+
+.desktop-showcase-actions .button-primary .button-platform-icon {
+  filter: brightness(0) invert(1);
 }
 
 .desktop-showcase-note {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pythinker",
   "publisher": "pymodel",
-  "displayName": "Pythinker Code",
+  "displayName": "Pythinker",
   "description": "Pythinker Code extension for VS Code",
   "version": "0.9.2",
   "private": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['packages/*', 'apps/pythinker-code', 'apps/desktop'],
+    projects: ['packages/*', 'apps/pythinker-code', 'apps/desktop', 'apps/pythinker-web'],
     coverage: {
       provider: 'v8',
       include: ['packages/*/src/**/*.ts', 'apps/*/src/**/*.ts'],


### PR DESCRIPTION
## Related Issue

No prior issue — these are follow-ups to the Windows desktop release. The problems are described below.

## Problem

Four separate defects, all surfaced by the first Windows desktop build:

1. **The Windows installer is unsigned.** SmartScreen warns on every download.
2. **The window controls overlap the app chrome.** With `titleBarStyle: 'hidden'`, the minimise/maximise/close buttons sit on top of the branch name and diff counters, and the title-bar strip is not draggable.
3. **The Windows colours look washed out** compared with macOS. `backgroundMaterial: 'acrylic'` makes Windows composite the desktop wallpaper behind the window, and the sidebar's `color-mix(..., 55%, transparent)` blended 45% of that wallpaper into its colour.
4. **The site offers only a macOS download**, and it points at the releases page rather than the asset.

## What changed

**Windows code signing** (`apps/desktop/scripts/package-win.ts`, `.github/workflows/desktop-release.yml`)
Signs the NSIS installer through Azure Artifact Signing. The seven signing variables are all-or-nothing: none set means an unsigned local build, all set means a signed one, and any partial configuration throws rather than silently shipping unsigned. Arguments route through the existing `packageManagerInvocation` helper because Node's `spawnSync` with `shell: true` concatenates argv without escaping, which would split an X.500 `publisherName` on its spaces.

**Title bar and sidebar** (`apps/pythinker-web/src/App.vue`)
A dedicated `.windows-titlebar` element occupies the Window Controls Overlay safe area (`env(titlebar-area-*)`) and carries `-webkit-app-region: drag`, so the strip is draggable and the app content starts below the controls. The sidebar and rail are painted opaque on `win32` only; macOS keeps its `color-mix` translucency.

**Opaque Windows window** (`apps/desktop/src/main.ts`)
Drops `backgroundMaterial: 'acrylic'` for `backgroundColor: '#0d1117'`, removing the wallpaper source itself. `hasShadow`, `roundedCorners`, and `thickFrame` are unchanged, as is the macOS `vibrancy` path.

**Site download buttons** (`apps/site/src/App.vue`)
Both buttons link directly to the published release assets so they download without an intermediate page, each with its platform glyph. `DESKTOP_VERSION` deliberately tracks the *published* release rather than `apps/desktop/package.json` — changesets bumps the manifest ahead of the build that produces the assets, so following the manifest would link to a release that does not exist yet.

## Verification

- `pnpm --filter @pymodel/pythinker-desktop run typecheck` — pass
- `pnpm vitest run --project @pymodel/pythinker-desktop` — 79 tests, 10 files
- `pnpm vitest run --project @pymodel/pythinker-web` — pass
- `pnpm --filter @pymodel/site run build` — pass
- `pnpm run lint` — pass
- Every new assertion was run against a deliberate mutation first and observed to fail: restoring `backgroundMaterial` (`length 1 ≠ 0`), an 8-digit alpha `backgroundColor` (`[] to have length 1`), a second `-webkit-app-region: drag` rule, and the missing icon filter (`got 0`).

**Not verified:** there is no Windows host and no visual-regression test here, so the title-bar, colour, and button-icon changes are checked as configuration and CSS contracts, not as rendered pixels.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows installers can optionally use Azure Artifact Signing.
  * Added platform-specific macOS and Windows desktop download options.
  * Renamed the VS Code extension display name to **Pythinker**.
* **Bug Fixes**
  * Improved Windows title-bar spacing, dragging, sidebar appearance, and opaque window rendering.
  * Improved platform-specific background rendering across Windows and macOS.
* **Documentation**
  * Added guidance for configuring Azure signing credentials.
* **Release Improvements**
  * Updated Windows packaging and publishing for signed installers when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->