### PR TITLE
fix: stop reporting expired questions as user dismissals

### DIFF
--- a/.changeset/question-lease-and-labels.md
+++ b/.changeset/question-lease-and-labels.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-code': patch
+---
+
+Questions no longer expire after 60 seconds, expired questions are not reported as user dismissals, answers retain question text and option labels, and Escape no longer dismisses a question.

--- a/apps/pythinker-web/AGENTS.md
+++ b/apps/pythinker-web/AGENTS.md
@@ -23,13 +23,13 @@ The browser web UI for Pythinker Code — a peer to the TUI in `apps/pythinker-c
 - Shared components go in `src/components/`; reusable logic goes in `src/composables/` with a `use` prefix.
 - There is **no auto-import plugin** and **no path alias** — `#/` and `@/` are intentionally unused. Write relative imports (`../i18n`, `./config`).
 
-## i18n (normative — keeping locales in sync is manual)
+## i18n (normative — the app is English-only)
 
 - Setup: `src/i18n/index.ts`, vue-i18n in Composition mode (`legacy: false`), fallback `en`. The active locale is persisted in `localStorage` under `pythinker-locale`.
-- Locale files: `src/i18n/locales/{en,zh}/<namespace>.ts`, each `export default { ... } as const`. New namespaces are registered in `src/i18n/locales/index.ts`.
+- **`en` is the only locale.** `src/i18n/locales/` contains exactly one directory, and `locales/index.ts` registers only `en`. Do not add a second locale, and do not "restore parity" with one that does not exist.
+- Locale files: `src/i18n/locales/en/<namespace>.ts`, each `export default { ... } as const`. New namespaces are registered in `src/i18n/locales/index.ts`.
 - Reference with `const { t } = useI18n()` and `t('namespace.key')` (same form in templates).
-- **Adding a key:** add it to **both** `en/<ns>.ts` and `zh/<ns>.ts`. **Adding a namespace:** create the file in both locales **and** register it in `locales/index.ts`.
-- There is **no automated missing-key or en/zh parity check**. Keeping the two locales in sync is a manual responsibility — do not leave a key present in only one locale.
+- **Adding a key:** add it to `en/<ns>.ts`. **Adding a namespace:** create the file under `en/` **and** register it in `locales/index.ts`.
 
 ## Commands
 

--- a/apps/pythinker-web/src/components/QuestionCard.vue
+++ b/apps/pythinker-web/src/components/QuestionCard.vue
@@ -30,6 +30,22 @@ const total = computed(() => props.question.questions.length);
 const hasPreview = computed(() =>
   current.value.options.some((option) => option.preview?.trim()),
 );
+const now = ref(Date.now());
+const remainingMinutes = computed(() => {
+  const expiresAt = Date.parse(props.question.expiresAt);
+  if (Number.isNaN(expiresAt)) return undefined;
+  return Math.ceil((expiresAt - now.value) / 60_000);
+});
+const leaseWarning = computed(() => {
+  const expiresAt = Date.parse(props.question.expiresAt);
+  if (Number.isNaN(expiresAt)) return undefined;
+  const remainingMs = expiresAt - now.value;
+  if (remainingMs <= 0 || remainingMs > 5 * 60_000) return undefined;
+  if (remainingMs < 60_000) return t('question.expiresSoonSeconds');
+  const minutes = remainingMinutes.value;
+  if (minutes === undefined) return undefined;
+  return t('question.expiresSoon', { minutes });
+});
 
 function goBack(): void {
   if (step.value > 0) step.value--;
@@ -207,17 +223,15 @@ function dismiss(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Keyboard: number keys pick options for current question, Enter submit, Esc dismiss
+// Keyboard: number keys pick options for the current question and Enter submits.
 // ---------------------------------------------------------------------------
 
 function handleKeydown(e: KeyboardEvent): void {
   const tag = (document.activeElement?.tagName ?? '').toLowerCase();
   if (tag === 'input' || tag === 'textarea') return;
-  // While minimized the options aren't visible, so don't let number keys pick
-  // an unseen answer; only Escape (dismiss) stays live.
-  if (minimized.value && e.key !== 'Escape') return;
+  // While minimized the options are not visible, so keyboard selection is disabled.
+  if (minimized.value) return;
 
-  if (e.key === 'Escape') { e.preventDefault(); dismiss(); return; }
   if (e.key === 'Enter') { e.preventDefault(); submit(); return; }
 
   const num = parseInt(e.key, 10);
@@ -236,8 +250,19 @@ function handleKeydown(e: KeyboardEvent): void {
   }
 }
 
-onMounted(() => document.addEventListener('keydown', handleKeydown));
-onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
+let leaseTimer: ReturnType<typeof setInterval> | undefined;
+
+onMounted(() => {
+  document.addEventListener('keydown', handleKeydown);
+  leaseTimer = setInterval(() => {
+    now.value = Date.now();
+  }, 30_000);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown);
+  if (leaseTimer !== undefined) clearInterval(leaseTimer);
+});
 </script>
 
 <template>
@@ -245,6 +270,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
     <!-- Step indicator (multi-question) -->
     <div class="qh">
       <span class="qtitle">{{ t('question.title') }}</span>
+      <span v-if="leaseWarning" class="qexpires">{{ leaseWarning }}</span>
       <template v-if="total > 1 && !minimized">
         <span class="qstep">{{ t('question.step', { current: step + 1, total }) }}</span>
         <button class="qnav" :disabled="step === 0" @click="goBack">{{ t('question.prev') }}</button>
@@ -371,6 +397,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
 }
 .qtitle { color: var(--blue2); font-weight: 700; }
 .qstep { color: var(--muted); font-size: calc(var(--ui-font-size) - 3px); margin-left: 4px; }
+.qexpires { color: var(--muted); font-size: calc(var(--ui-font-size) - 3px); margin-left: 4px; }
 .qnav {
   font-family: var(--mono);
   font-size: calc(var(--ui-font-size) - 3px);

--- a/apps/pythinker-web/src/components/QuestionCard.vue
+++ b/apps/pythinker-web/src/components/QuestionCard.vue
@@ -40,7 +40,7 @@ const leaseWarning = computed(() => {
   const expiresAt = Date.parse(props.question.expiresAt);
   if (Number.isNaN(expiresAt)) return undefined;
   const remainingMs = expiresAt - now.value;
-  if (remainingMs <= 0 || remainingMs > 5 * 60_000) return undefined;
+  if (remainingMs <= 0 || remainingMs >= 5 * 60_000) return undefined;
   if (remainingMs < 60_000) return t('question.expiresSoonSeconds');
   const minutes = remainingMinutes.value;
   if (minutes === undefined) return undefined;

--- a/apps/pythinker-web/src/composables/usePythinkerWebClient.ts
+++ b/apps/pythinker-web/src/composables/usePythinkerWebClient.ts
@@ -1660,6 +1660,7 @@ function toUiQuestion(q: AppQuestionRequest): UIQuestion {
   return {
     questionId: q.questionId,
     sessionId: q.sessionId,
+    expiresAt: q.expiresAt,
     questions: q.questions.map((qi) => ({
       id: qi.id,
       question: qi.question,

--- a/apps/pythinker-web/src/i18n/locales/en/question.ts
+++ b/apps/pythinker-web/src/i18n/locales/en/question.ts
@@ -10,4 +10,6 @@ export default {
   dismiss: 'Dismiss',
   minimize: 'Minimize',
   expand: 'Expand',
+  expiresSoon: 'Expires in {minutes} min',
+  expiresSoonSeconds: 'Expires in less than a minute',
 } as const;

--- a/apps/pythinker-web/src/types.ts
+++ b/apps/pythinker-web/src/types.ts
@@ -242,6 +242,7 @@ export interface QueuedPromptView {
 export interface UIQuestion {
   questionId: string;
   sessionId: string;
+  expiresAt: string;
   questions: {
     id: string;
     question: string;

--- a/apps/pythinker-web/test/question-card-lifecycle.test.ts
+++ b/apps/pythinker-web/test/question-card-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { createI18n } from 'vue-i18n';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import QuestionCard from '../src/components/QuestionCard.vue';
 import type { UIQuestion } from '../src/types';
@@ -87,5 +87,29 @@ describe('QuestionCard lifecycle', () => {
 
     expect(soon.find('.qexpires').text()).toBe('Expires in 2 min');
     expect(later.find('.qexpires').exists()).toBe(false);
+  });
+
+  it('hides the expiry warning at five minutes and shows it at four minutes fifty-nine seconds', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    try {
+      const boundary = mountCard(question(new Date(Date.now() + 5 * 60_000).toISOString()));
+      const soon = mountCard(question(new Date(Date.now() + 4 * 60_000 + 59_000).toISOString()));
+
+      expect(boundary.find('.qexpires').exists()).toBe(false);
+      expect(soon.find('.qexpires').exists()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores Enter while minimized', async () => {
+    const wrapper = mountCard(question(new Date(Date.now() + 20 * 60_000).toISOString()));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '1', bubbles: true }));
+    await wrapper.find('.qmin').trigger('click');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(wrapper.emitted('answer')).toBeUndefined();
   });
 });

--- a/apps/pythinker-web/test/question-card-lifecycle.test.ts
+++ b/apps/pythinker-web/test/question-card-lifecycle.test.ts
@@ -1,0 +1,91 @@
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import QuestionCard from '../src/components/QuestionCard.vue';
+import type { UIQuestion } from '../src/types';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      question: {
+        title: 'Question',
+        step: '{current}/{total}',
+        prev: 'Prev',
+        next: 'Next',
+        expand: 'Expand',
+        minimize: 'Minimize',
+        otherDefault: 'Other',
+        submit: 'Submit',
+        dismiss: 'Dismiss',
+        notes: 'Notes',
+        notesPlaceholder: 'Add notes on this option',
+        expiresSoon: 'Expires in {minutes} min',
+        expiresSoonSeconds: 'Expires in less than a minute',
+      },
+    },
+  },
+  missingWarn: false,
+  fallbackWarn: false,
+});
+
+const mounted: ReturnType<typeof mount>[] = [];
+
+function question(expiresAt: string): UIQuestion {
+  return {
+    questionId: 'qreq_1',
+    sessionId: 'sess_1',
+    expiresAt,
+    questions: [
+      {
+        id: 'q1',
+        question: 'Pick one',
+        options: [
+          { id: 'a', label: 'A' },
+          { id: 'b', label: 'B' },
+        ],
+      },
+    ],
+  };
+}
+
+function mountCard(input: UIQuestion) {
+  const wrapper = mount(QuestionCard, {
+    props: { question: input },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Markdown: {
+          props: ['text'],
+          template: '<pre class="markdown-stub">{{ text }}</pre>',
+        },
+      },
+    },
+  });
+  mounted.push(wrapper);
+  return wrapper;
+}
+
+afterEach(() => {
+  for (const wrapper of mounted.splice(0)) wrapper.unmount();
+});
+
+describe('QuestionCard lifecycle', () => {
+  it('does not dismiss when Escape is pressed', () => {
+    const wrapper = mountCard(question(new Date(Date.now() + 20 * 60_000).toISOString()));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(wrapper.emitted('dismiss')).toBeUndefined();
+  });
+
+  it('shows an expiry warning within five minutes and hides it at twenty minutes', () => {
+    const soon = mountCard(question(new Date(Date.now() + 2 * 60_000).toISOString()));
+    const later = mountCard(question(new Date(Date.now() + 20 * 60_000).toISOString()));
+
+    expect(soon.find('.qexpires').text()).toBe('Expires in 2 min');
+    expect(later.find('.qexpires').exists()).toBe(false);
+  });
+});

--- a/apps/pythinker-web/test/question-card-lifecycle.test.ts
+++ b/apps/pythinker-web/test/question-card-lifecycle.test.ts
@@ -107,9 +107,16 @@ describe('QuestionCard lifecycle', () => {
     const wrapper = mountCard(question(new Date(Date.now() + 20 * 60_000).toISOString()));
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: '1', bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    const answerCount = wrapper.emitted('answer')?.length ?? 0;
+
+    expect(answerCount).toBe(1);
+
     await wrapper.find('.qmin').trigger('click');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '1', bubbles: true }));
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 
-    expect(wrapper.emitted('answer')).toBeUndefined();
+    expect(wrapper.emitted('answer')).toHaveLength(answerCount);
   });
 });

--- a/apps/pythinker-web/test/question-card-recommended.test.ts
+++ b/apps/pythinker-web/test/question-card-recommended.test.ts
@@ -35,6 +35,7 @@ function question(overrides: Partial<UIQuestion['questions'][number]> = {}): UIQ
   return {
     questionId: 'qreq_1',
     sessionId: 'sess_1',
+    expiresAt: new Date(Date.now() + 20 * 60_000).toISOString(),
     questions: [
       {
         id: 'q1',

--- a/packages/agent-core/src/errors/codes.ts
+++ b/packages/agent-core/src/errors/codes.ts
@@ -33,6 +33,7 @@ export const ErrorCodes = {
 
   AGENT_NOT_FOUND: 'agent.not_found',
   TURN_AGENT_BUSY: 'turn.agent_busy',
+  QUESTION_EXPIRED: 'question.expired',
 
   GOAL_ALREADY_EXISTS: 'goal.already_exists',
   GOAL_NOT_FOUND: 'goal.not_found',
@@ -228,6 +229,12 @@ export const PYTHINKER_ERROR_INFO = {
     retryable: true,
     public: true,
     action: 'Wait for the current turn to finish or steer it.',
+  },
+  'question.expired': {
+    title: 'Question expired',
+    retryable: false,
+    public: true,
+    action: 'Ask the user again if you still need the answer.',
   },
 
   'goal.already_exists': {

--- a/packages/agent-core/src/services/question/question.ts
+++ b/packages/agent-core/src/services/question/question.ts
@@ -3,9 +3,7 @@
  *
  * **Service interface** (`IQuestionService`): Reverse-RPC one-shot broker
  * role — routes `QuestionRequest`s coming out of `PythinkerCore` to a waiter
- * (web client over WS, mock handler in tests) and resolves the
- * promise when the response arrives — or `dismiss()`-es it if the user
- * closes the panel (SCHEMAS.md §6.3).
+ * and resolves the promise when the response arrives or the user dismisses it.
  *
  * Role: one-shot broker — see `packages/services/AGENTS.md`. Kept under the
  * `Service` suffix per the package-wide convention; the broker semantics
@@ -13,36 +11,29 @@
  * docstring, not in the type name.
  *
  * **Shape note:** the service returns the in-process
- * `QuestionResult = null | QuestionAnswers | QuestionResponse` (see
- * `packages/agent-core/src/rpc/sdk-api.ts:48`). SCHEMAS.md §6.2/§6.4 defines
- * a protocol-level `QuestionResponse` with a 5-kind discriminated union
- * (`single` / `multi` / `other` / `multi_with_other` / `skipped`); the
- * protocol↔in-process adapter lives at the daemon boundary, NOT inside the
- * service interface. This keeps the SDK side of the adapter untouched and
- * confines protocol shape decisions to one place.
+ * `QuestionResult = null | QuestionAnswers | QuestionResponse`. The
+ * protocol↔in-process adapter lives at the daemon boundary, not inside the
+ * service interface.
  *
  * **Adapter** (`toBrokerRequest` / `toAgentCoreResponse` / `dismissedResult`):
- * Bridges two representations of the same question interaction:
+ * Bridges two representations of the same question interaction. Protocol ids
+ * go in; question text and option labels that the user saw come out. This is
+ * the only protocol↔SDK translation site for questions:
  *
  *   1. **In-process SDK shape** (agent-core, camelCase) — what
- *      `BridgeClientAPI` sees from `PythinkerCore.requestQuestion(...)`. See
- *      `packages/agent-core/src/rpc/sdk-api.ts:50-54`:
+ *      `BridgeClientAPI` sees from `PythinkerCore.requestQuestion(...)`:
  *        `QuestionRequest { turnId?, toolCallId?, questions: QuestionItem[] }`
  *      where `QuestionItem` has `question, header?, body?, options[],
  *      multiSelect?, allowOther?, otherLabel?, otherDescription?`.
  *      `QuestionResult = null | QuestionAnswers | QuestionResponse`,
  *      `QuestionAnswers = Record<string, string | true>`.
  *
- *   2. **Protocol wire shape** (snake_case, with daemon-allocated metadata) —
- *      defined in `packages/protocol/src/question.ts`. 5-kind discriminated
- *      union for answers: `single | multi | other | multi_with_other | skipped`.
+ *   2. **Protocol wire shape** (snake_case, with daemon-allocated metadata).
  *
  * **Synthesizing stable ids** (SDK has no per-item / per-option `id`):
  *   - `QuestionItem.id`     ← `q_<index>` (e.g. `q_0`, `q_1`, ...)
  *   - `QuestionOption.id`   ← `opt_<parent_idx>_<option_idx>` (e.g. `opt_0_0`)
  *
- * **Anti-corruption**: this is the ONLY place protocol↔SDK shape translation
- * happens for question.
  */
 
 import { createDecorator } from '../../di';
@@ -104,14 +95,14 @@ export interface QuestionToBrokerRequestParams {
   readonly sessionId: string;
   /** `createdAt` ISO string; broker passes `new Date().toISOString()`. */
   readonly createdAt: string;
-  /** `expiresAt` ISO string; broker computes `createdAt + 60s`. */
+  /** `expiresAt` ISO string; broker computes the lease deadline. */
   readonly expiresAt: string;
 }
 
 /**
  * Build a protocol option from an SDK option. SDK has only `label?:string` +
  * `description?:string`; we synthesize `id` from parent and child indices so
- * `toAgentCoreAnswers` can map back through `Record<qid, string>`.
+ * the response adapter can map answers back to the question text and labels.
  */
 function buildOption(
   opt: {
@@ -134,7 +125,7 @@ function buildOption(
 
 /**
  * Build a protocol question item from an SDK item + its position. The
- * synthesized `id` (`q_<parentIdx>`) is the key the SDK answers Record uses.
+ * synthesized `id` (`q_<parentIdx>`) identifies the matching response item.
  */
 function buildItem(
   item: InProcessQuestionItem,
@@ -178,36 +169,42 @@ export function toBrokerRequest(
 }
 
 /**
- * Protocol REST response body → in-process SDK `QuestionResponse` (with
- * `answers` flattened to `Record<string, string | true>`).
+ * Protocol response ids + the original request → in-process SDK
+ * `QuestionResponse` with answers flattened to `Record<string, string | true>`.
  *
- * Normalization rules from SCHEMAS §6.4:
- *   - single            → option_id
- *   - multi             → option_ids.join(',')
+ * The original request is the lookup for the text and labels displayed to the
+ * user:
+ *   - single            → option label
+ *   - multi             → option labels joined with `, `
  *   - other             → text
- *   - multi_with_other  → [...option_ids, other_text].join(',')
+ *   - multi_with_other  → option labels and text joined with `, `
  *   - skipped           → OMIT entry
  */
 export function toAgentCoreResponse(
   resp: ProtocolQuestionResponse,
+  request: ProtocolQuestionRequest,
 ): InProcessQuestionResponse {
   const flattened: InProcessQuestionAnswers = {};
   for (const [qid, ans] of Object.entries(resp.answers)) {
+    const item = request.questions.find((question) => question.id === qid);
+    const question = item?.question ?? qid;
+    const optionLabel = (id: string): string =>
+      item?.options.find((option) => option.id === id)?.label ?? id;
     switch (ans.kind) {
       case 'single':
-        flattened[qid] = ans.option_id;
+        flattened[question] = optionLabel(ans.option_id);
         break;
       case 'multi':
-        flattened[qid] = ans.option_ids.join(',');
+        flattened[question] = ans.option_ids.map(optionLabel).join(', ');
         break;
       case 'other':
-        flattened[qid] = ans.text;
+        flattened[question] = ans.text;
         break;
       case 'multi_with_other':
-        flattened[qid] = [...ans.option_ids, ans.other_text].join(',');
+        flattened[question] = [...ans.option_ids.map(optionLabel), ans.other_text].join(', ');
         break;
       case 'skipped':
-        // Omitted from the record — matches SCHEMAS §6.4 ("if skipped continue").
+        // Omitted from the record.
         break;
       default: {
         // Defensive: never-reached if Zod schema is the SOT, but TS narrowing
@@ -219,7 +216,7 @@ export function toAgentCoreResponse(
   }
   const out: InProcessQuestionResponse = { answers: flattened };
   if (resp.method !== undefined) {
-    // SCHEMAS §6.2 protocol allows 'click' as a method; agent-core's in-process
+    // Protocol allows 'click' as a method; agent-core's in-process
     // `QuestionAnswerMethod` is `'enter' | 'space' | 'number_key'` (NO 'click').
     // Drop 'click' on the in-process side to preserve type safety; the wire
     // form keeps it for clients that want to surface the affordance used.

--- a/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
@@ -102,6 +102,8 @@ export const AskUserQuestionInputSchema: z.ZodType<AskUserQuestionInput> =
   AskUserQuestionInputBaseSchema;
 
 const QUESTION_DISMISSED_MESSAGE = 'User dismissed the question without answering.';
+const QUESTION_EXPIRED_MESSAGE =
+  'The question expired before the user answered it. The user did NOT dismiss it — ask again in your text response if you still need the answer.';
 
 const QUESTION_UNSUPPORTED_FAILURE_MESSAGE =
   'The connected client does not support interactive questions. Do NOT call this tool again. Ask the user directly in your text response instead.';
@@ -216,7 +218,23 @@ export class AskUserQuestionTool implements BuiltinTool<AskUserQuestionInput> {
         };
       }
 
-      return dismissedQuestionResult();
+      if (error instanceof PythinkerError && error.code === ErrorCodes.QUESTION_EXPIRED) {
+        const source = args.metadata?.source;
+        if (source === undefined) {
+          this.agent.telemetry.track('question_expired');
+        } else {
+          this.agent.telemetry.track('question_expired', { source });
+        }
+        return {
+          isError: false,
+          output: JSON.stringify({ answers: {}, note: QUESTION_EXPIRED_MESSAGE }),
+        };
+      }
+
+      return {
+        isError: true,
+        output: `The question could not be delivered or answered: ${errorMessage(error)}`,
+      };
     }
   }
 

--- a/packages/agent-core/test/services/question-adapter.test.ts
+++ b/packages/agent-core/test/services/question-adapter.test.ts
@@ -1,8 +1,7 @@
 /**
  * Question adapter unit tests (W8.2 / Chain 6).
  *
- * Covers SCHEMAS §6.4 5-kind ↔ Record<string, string | true> normalization
- * verbatim.
+ * Covers protocol answer normalization into the text the user sees.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -103,74 +102,101 @@ describe('question-adapter · toBrokerRequest (in-process → protocol)', () => 
   });
 });
 
-describe('question-adapter · toAgentCoreResponse · SCHEMAS §6.4 verbatim', () => {
-  it("'single' → answers[qid] = option_id", () => {
+describe('question-adapter · toAgentCoreResponse (protocol ids → user-facing text)', () => {
+  const request = {
+    question_id: '01J_QUESTION',
+    session_id: 'sess_x',
+    questions: [
+      {
+        id: 'q_0',
+        question: 'Which animal?',
+        options: [
+          { id: 'opt_0_0', label: 'Cat' },
+          { id: 'opt_0_1', label: 'Dog' },
+        ],
+      },
+      {
+        id: 'q_1',
+        question: 'Which colors?',
+        options: [
+          { id: 'opt_1_0', label: 'Red' },
+          { id: 'opt_1_1', label: 'Green' },
+          { id: 'opt_1_2', label: 'Blue' },
+        ],
+      },
+    ],
+    created_at: '2026-06-04T10:30:00.000Z',
+    expires_at: '2026-06-04T11:00:00.000Z',
+  };
+
+  it("'single' maps the question text to the option label", () => {
     const inProc = toAgentCoreResponse({
       answers: { q_0: { kind: 'single', option_id: 'opt_0_1' } },
-    });
-    expect(inProc.answers).toEqual({ q_0: 'opt_0_1' });
+    }, request);
+    expect(inProc.answers).toEqual({ 'Which animal?': 'Dog' });
   });
 
-  it("'multi' → answers[qid] = option_ids.join(',')  (lossy)", () => {
+  it("'multi' maps option ids to labels", () => {
     const inProc = toAgentCoreResponse({
       answers: {
-        q_0: { kind: 'multi', option_ids: ['opt_0_0', 'opt_0_2'] },
+        q_1: { kind: 'multi', option_ids: ['opt_1_0', 'opt_1_2'] },
       },
-    });
-    expect(inProc.answers).toEqual({ q_0: 'opt_0_0,opt_0_2' });
+    }, request);
+    expect(inProc.answers).toEqual({ 'Which colors?': 'Red, Blue' });
   });
 
-  it("'other' → answers[qid] = text", () => {
+  it("'other' keeps the entered text", () => {
     const inProc = toAgentCoreResponse({
       answers: { q_0: { kind: 'other', text: 'Hippopotamus' } },
-    });
-    expect(inProc.answers).toEqual({ q_0: 'Hippopotamus' });
+    }, request);
+    expect(inProc.answers).toEqual({ 'Which animal?': 'Hippopotamus' });
   });
 
-  it("'multi_with_other' → [...option_ids, other_text].join(',')", () => {
+  it("'multi_with_other' maps labels and keeps the entered text", () => {
     const inProc = toAgentCoreResponse({
       answers: {
-        q_0: {
+        q_1: {
           kind: 'multi_with_other',
-          option_ids: ['opt_0_0', 'opt_0_1'],
+          option_ids: ['opt_1_0', 'opt_1_1'],
           other_text: 'Custom',
         },
       },
-    });
-    expect(inProc.answers).toEqual({ q_0: 'opt_0_0,opt_0_1,Custom' });
+    }, request);
+    expect(inProc.answers).toEqual({ 'Which colors?': 'Red, Green, Custom' });
   });
 
-  it("'skipped' → entry OMITTED entirely from the record", () => {
+  it("'skipped' omits the answer", () => {
     const inProc = toAgentCoreResponse({
       answers: {
         q_0: { kind: 'single', option_id: 'opt_0_0' },
         q_1: { kind: 'skipped' },
-        q_2: { kind: 'other', text: 'Custom' },
       },
-    });
+    }, request);
     expect(inProc.answers).toEqual({
-      q_0: 'opt_0_0',
-      q_2: 'Custom',
+      'Which animal?': 'Cat',
     });
-    expect(Object.keys(inProc.answers)).not.toContain('q_1');
+    expect(Object.keys(inProc.answers)).not.toContain('Which colors?');
   });
 
-  it('handles a mixed 4-item response with one skipped (e2e prompt acceptance)', () => {
+  it('falls back to raw ids for unknown questions and options', () => {
     const inProc = toAgentCoreResponse({
       answers: {
-        q_0: { kind: 'single', option_id: 'opt_0_0' },
-        q_1: { kind: 'multi', option_ids: ['opt_1_0', 'opt_1_1'] },
-        q_2: { kind: 'other', text: 'Hippopotamus' },
-        q_3: { kind: 'skipped' },
+        q_0: { kind: 'single', option_id: 'opt_0_unknown' },
+        q_unknown: { kind: 'single', option_id: 'opt_unknown' },
       },
-      method: 'click',
-    });
+    }, request);
     expect(inProc.answers).toEqual({
-      q_0: 'opt_0_0',
-      q_1: 'opt_1_0,opt_1_1',
-      q_2: 'Hippopotamus',
+      'Which animal?': 'opt_0_unknown',
+      q_unknown: 'opt_unknown',
     });
-    // method 'click' is NOT in agent-core's in-process method union — dropped.
+  });
+
+  it("drops the protocol-only 'click' method", () => {
+    const inProc = toAgentCoreResponse({
+      answers: { q_0: { kind: 'single', option_id: 'opt_0_0' } },
+      method: 'click',
+    }, request);
+    expect(inProc.answers).toEqual({ 'Which animal?': 'Cat' });
     expect((inProc as { method?: string }).method).toBeUndefined();
   });
 
@@ -178,7 +204,7 @@ describe('question-adapter · toAgentCoreResponse · SCHEMAS §6.4 verbatim', ()
     const inProc = toAgentCoreResponse({
       answers: { q_0: { kind: 'skipped' } },
       method: 'enter',
-    });
+    }, request);
     expect((inProc as { method?: string }).method).toBe('enter');
   });
 
@@ -191,7 +217,7 @@ describe('question-adapter · toAgentCoreResponse · SCHEMAS §6.4 verbatim', ()
           notes: 'Use the calmer option.',
         },
       },
-    });
+    }, request);
 
     expect(inProc.annotations).toEqual({
       'Which animal?': {
@@ -207,7 +233,7 @@ describe('question-adapter · toAgentCoreResponse · SCHEMAS §6.4 verbatim', ()
         q_0: { kind: 'skipped' },
         q_1: { kind: 'skipped' },
       },
-    });
+    }, request);
     expect(inProc.answers).toEqual({});
     // Distinct from dismissedResult() which returns null.
     expect(inProc).not.toBeNull();

--- a/packages/agent-core/test/tools/ask-user.test.ts
+++ b/packages/agent-core/test/tools/ask-user.test.ts
@@ -390,7 +390,7 @@ describe('AskUserQuestionTool', () => {
     expect(telemetryTrack).toHaveBeenCalledWith('question_dismissed');
   });
 
-  it('resolves question rpc error responses as dismissed answers', async () => {
+  it('returns an error when question rpc delivery fails', async () => {
     const { tool } = makeTool({
       requestQuestion: async () => {
         throw new PythinkerError(ErrorCodes.INTERNAL, 'JSON-RPC question error response');
@@ -404,15 +404,31 @@ describe('AskUserQuestionTool', () => {
       signal,
     });
 
-    expect(result).toMatchObject({ isError: false });
-    expect(result.output).toContain('dismissed');
-    expect(typeof result.output).toBe('string');
-    const output = typeof result.output === 'string' ? result.output : '';
-    expect(JSON.parse(output)).toEqual({
-      answers: {},
-      note: 'User dismissed the question without answering.',
-    });
+    expect(result).toMatchObject({ isError: true });
+    expect(result.output).toContain('could not be delivered or answered');
+    expect(result.output).toContain('JSON-RPC question error response');
+    expect(result.output).not.toContain('dismissed');
     expect(result.output).not.toContain('Do NOT call this tool again');
+  });
+
+  it('returns an expired question note without marking it dismissed', async () => {
+    const { tool, telemetryTrack } = makeTool({
+      requestQuestion: async () => {
+        throw new PythinkerError(ErrorCodes.QUESTION_EXPIRED, 'question expired');
+      },
+    });
+
+    const result = await executeTool(tool, {
+      turnId: '0',
+      toolCallId: 'call_question',
+      args: { ...input(), metadata: { source: 'test' } },
+      signal,
+    });
+
+    expect(result).toMatchObject({ isError: false });
+    expect(result.output).toContain('expired');
+    expect(result.output).not.toContain('dismissed');
+    expect(telemetryTrack).toHaveBeenCalledWith('question_expired', { source: 'test' });
   });
 
   it('propagates aborts while waiting for question rpc', async () => {

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -207,6 +207,7 @@ export type PythinkerErrorCode =
   | 'session.init_failed'
   | 'agent.not_found'
   | 'turn.agent_busy'
+  | 'question.expired'
   | 'goal.already_exists'
   | 'goal.not_found'
   | 'goal.objective_empty'

--- a/packages/server/src/routes/questions.ts
+++ b/packages/server/src/routes/questions.ts
@@ -39,7 +39,7 @@ import {
   questionResolveRequestSchema,
   questionResolveResultSchema,
 } from '@pymodel/protocol';
-import { IQuestionService, questionToAgentCoreResponse, type IInstantiationService } from '@pymodel/agent-core';
+import { IQuestionService, type IInstantiationService } from '@pymodel/agent-core';
 import { z } from 'zod';
 
 
@@ -226,9 +226,16 @@ export function registerQuestionsRoutes(
       }
 
       const body = bodyParse.data;
-      const inProc = questionToAgentCoreResponse(body);
-      broker.resolve(questionId, inProc);
-      broker.markResolved(questionId);
+      if (!broker.resolveProtocolResponse(questionId, body)) {
+        reply.send(
+          errEnvelope(
+            ErrorCode.QUESTION_NOT_FOUND,
+            `question ${questionId} not found`,
+            req.id,
+          ),
+        );
+        return;
+      }
 
       const result = {
         resolved: true,

--- a/packages/server/src/services/question/questionService.ts
+++ b/packages/server/src/services/question/questionService.ts
@@ -2,23 +2,29 @@
 
 import { ulid } from 'ulid';
 
-import { Disposable, DisposableMap, IEventService, IQuestionService, questionDismissedResult, questionToBrokerRequest, ILogService, type IDisposable, type QuestionRequest, type QuestionResult } from '@pymodel/agent-core';
+import { Disposable, DisposableMap, ErrorCodes, IEventService, IQuestionService, PythinkerError, questionDismissedResult, questionToAgentCoreResponse, questionToBrokerRequest, ILogService, type IDisposable, type QuestionRequest, type QuestionResult } from '@pymodel/agent-core';
 import type {
   Event,
   QuestionRequest as ProtocolQuestionRequest,
+  QuestionResponse as ProtocolQuestionResponse,
 } from '@pymodel/protocol';
 
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _typeAnchor: typeof IQuestionService = IQuestionService;
 
-export const QUESTION_DEFAULT_TIMEOUT_MS = 60_000;
+/**
+ * A pending question waits on a human, so the timer is a leak guard, not a
+ * network timeout. Keep it long enough that a person can read the options,
+ * think, and answer without losing the turn.
+ */
+export const QUESTION_DEFAULT_TIMEOUT_MS = 30 * 60_000;
 
 export const QUESTION_RECENTLY_RESOLVED_CAP = 1024;
 
-export class QuestionExpiredError extends Error {
+export class QuestionExpiredError extends PythinkerError {
   constructor(public readonly questionId: string, timeoutMs: number) {
-    super(`question ${questionId} expired after ${timeoutMs}ms`);
+    super(ErrorCodes.QUESTION_EXPIRED, `question ${questionId} expired after ${timeoutMs}ms`);
     this.name = 'QuestionExpiredError';
   }
 }
@@ -158,6 +164,19 @@ export class QuestionService extends Disposable implements IQuestionService {
     this.eventService.publish(answeredEvent);
 
     p.resolve(response);
+  }
+
+  /**
+   * Resolve a pending question from its protocol response. The adapter needs
+   * the original request to turn ids back into the question text and option
+   * labels the user saw, and the pending entry is the only holder of it.
+   * Returns false when the question is not pending.
+   */
+  resolveProtocolResponse(id: string, response: ProtocolQuestionResponse): boolean {
+    const p = this._pending.get(id);
+    if (!p) return false;
+    this.resolve(id, questionToAgentCoreResponse(response, p.protocolRequest));
+    return true;
   }
 
   dismiss(id: string): void {

--- a/packages/server/test/question.e2e.test.ts
+++ b/packages/server/test/question.e2e.test.ts
@@ -239,7 +239,7 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
     expect(env.code).toBe(0);
     expect(env.data?.resolved).toBe(true);
 
-    // Promise resolves with the SCHEMAS §6.4 flattened shape.
+    // Promise resolves with the text and labels that the user saw.
     const result = await pending;
     expect(result).not.toBeNull();
     const inProcResp = result as {
@@ -247,14 +247,43 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
       method?: string;
     };
     expect(inProcResp.answers).toEqual({
-      q_0: 'opt_0_0',
-      q_1: 'opt_1_0,opt_1_2',
-      q_2: 'Hippopotamus',
-      // q_3 omitted entirely (kind: skipped)
+      'Animal?': 'Cat',
+      'Colors?': 'R, B',
+      'Custom?': 'Hippopotamus',
+      // 'Skip me' omitted entirely (kind: skipped)
     });
     expect(inProcResp.method).toBe('enter');
 
     ws.close();
+  });
+
+  it('REST resolve gives the awaiting caller question text and option labels', async () => {
+    const r = await bootDaemon();
+    const sid = await createSession(r);
+    const broker = r.services.invokeFunction(
+      (a) => a.get(IQuestionService) as QuestionService,
+    );
+    const pending = broker.request({
+      sessionId: sid,
+      agentId: 'main',
+      questions: [
+        { question: 'Which animal?', options: [{ label: 'Cat' }, { label: 'Dog' }] },
+      ],
+    });
+    const questionId = firstPendingQuestionId(broker);
+    expect(questionId).toBeDefined();
+    if (questionId === undefined) throw new Error('pending question id is missing');
+
+    const res = await appOf(r).inject({
+      method: 'POST',
+      url: `/api/v1/sessions/${sid}/questions/${questionId}`,
+      payload: { answers: { q_0: { kind: 'single', option_id: 'opt_0_1' } } },
+    });
+
+    expect(envelopeOf<{ resolved: boolean }>(res.json()).code).toBe(0);
+    await expect(pending).resolves.toEqual({
+      answers: { 'Which animal?': 'Dog' },
+    });
   });
 
   it('GET pending questions lists recoverable requests and omits dismissed ones', async () => {
@@ -364,19 +393,19 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
       'single kind',
       [{ question: '?', options: [{ label: 'A' }, { label: 'B' }] }],
       { q_0: { kind: 'single', option_id: 'opt_0_1' } },
-      { q_0: 'opt_0_1' },
+      { '?': 'B' },
     ],
     [
       'multi kind',
       [{ question: '?', options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }], multiSelect: true }],
       { q_0: { kind: 'multi', option_ids: ['opt_0_0', 'opt_0_2'] } },
-      { q_0: 'opt_0_0,opt_0_2' },
+      { '?': 'A, C' },
     ],
     [
       'other kind',
       [{ question: '?', options: [{ label: 'X' }, { label: 'Y' }], otherLabel: 'Other' }],
       { q_0: { kind: 'other', text: 'free' } },
-      { q_0: 'free' },
+      { '?': 'free' },
     ],
     [
       'multi_with_other kind',
@@ -388,7 +417,7 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
           other_text: 'X',
         },
       },
-      { q_0: 'opt_0_0,X' },
+      { '?': 'A, X' },
     ],
     [
       'skipped kind (record entry omitted)',
@@ -397,7 +426,7 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
       {},
     ],
   ] as const)(
-    'normalizes %s per SCHEMAS §6.4',
+    'normalizes %s to the text and labels shown to the user',
     async (_label, questions, answers, expectedRecord) => {
       const r = await bootDaemon();
       const sid = await createSession(r);
@@ -588,7 +617,7 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
     broker.dismiss(questionId!);
   });
 
-  it('60s timeout broadcasts event.question.expired + rejects with QuestionExpiredError', async () => {
+  it('lease expiry broadcasts event.question.expired + rejects with QuestionExpiredError', async () => {
     const r = await bootDaemon();
     const sid = await createSession(r);
     const { ws, received } = await openSubscriber(r, sid);

--- a/packages/server/test/services.test.ts
+++ b/packages/server/test/services.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { InstantiationService, ServiceCollection, EventService, FsWatcherService, IApprovalService, IEventService, ILogService, IQuestionService, type ApprovalResponse, type QuestionResult, type FsWatcherServiceOptions, type IEnvironmentService, type ILogService as ILoggerT, type ISessionService } from '@pymodel/agent-core';
+import { InstantiationService, ServiceCollection, EventService, ErrorCodes, FsWatcherService, IApprovalService, IEventService, ILogService, IQuestionService, type ApprovalResponse, type QuestionResult, type FsWatcherServiceOptions, type IEnvironmentService, type ILogService as ILoggerT, type ISessionService } from '@pymodel/agent-core';
 import { WS_PROTOCOL_VERSION, type Event } from '@pymodel/protocol';
 
 import { ApprovalService } from '#/services/approval/approvalService';
@@ -1172,7 +1172,7 @@ describe('QuestionService (broadcasts + dismiss)', () => {
     bus.dispose();
   });
 
-  it('60s timeout broadcasts event.question.expired + rejects QuestionExpiredError', async () => {
+  it('lease expiry broadcasts event.question.expired + rejects QuestionExpiredError', async () => {
     const { broker, bus, broadcast, conn } = makeQuestionBroker();
     broker._setTimeoutMsForTests(30);
     const pending = broker.request({
@@ -1184,6 +1184,7 @@ describe('QuestionService (broadcasts + dismiss)', () => {
     } as Parameters<typeof broker.request>[0]);
 
     await expect(pending).rejects.toMatchObject({ name: 'QuestionExpiredError' });
+    await expect(pending).rejects.toHaveProperty('code', ErrorCodes.QUESTION_EXPIRED);
     await broadcast._drainForTest('s');
     const expiredFrame = conn.sent.find(
       (f) => (f as { type: string }).type === 'event.question.expired',


### PR DESCRIPTION
## Related Issue

No issue — reported by a Windows desktop user: the agent asked a question, the user answered, and the agent replied that the question was dismissed. The problem is described below.

## Problem

A question asked through the daemon path (`AskUserQuestion` → `packages/server` `QuestionService` → REST/WS → `apps/pythinker-web` `QuestionCard`) expired after **60 seconds**. On expiry the tool caught the rejection and told the model:

> User dismissed the question without answering.

So the agent reported a dismissal for a question the user was still reading. The desktop app (Electron → loopback server → web UI) is where users meet it: the card disappears at 60 s, a late answer POST returns `40902`, and the user sees only a toast. Transport failures and server shutdown produced the same false message, because `ask-user.ts` mapped **every** throw to a dismissal.

Two further defects sit in the same path:

- The answers that reach the model were synthesized ids — `{"answers":{"q_0":"opt_0_1"}}` — with no question text and no option label. The terminal and ACP surfaces both send `{ question text: option label }`, and `mcp/elicitation.ts` reads answers by question text, so MCP elicitation was broken over this path too.
- A stray `Escape` anywhere in the page silently destroyed a pending question, through a document-level key handler.

## What changed

- **The timer is a 30-minute lease, not a network timeout.** A pending question waits on a human, so the timer only guards against a leak. Removing it entirely was considered and rejected: the daemon bridge drops the `AbortSignal` and `loop/tool-call.ts` ends an aborted tool with a grace sentinel while the broker entry stays pending, so a timer-free question would become an unbounded orphan.
- **Causes are preserved at the tool boundary.** Expiry carries the new `question.expired` error code — class identity does not survive the RPC JSON round-trip, so the code is the only reliable discriminator — and returns a neutral "not answered" result. Other failures return real tool errors. Only a null or empty answer still means "dismissed".
- **Answers keep the words the user saw**: question text keys, option label values, joined with `, ` for multi-select. `toAgentCoreResponse` now takes the originating request, and `QuestionService.resolveProtocolResponse` supplies it, since the pending entry is the only holder.
- **`Escape` no longer dismisses.** The visible Dismiss button is unchanged.
- **The web card warns** when less than five minutes of the lease remain, using the `expires_at` the protocol already delivered and nothing consumed.

## Verification

Run locally on this branch:

- `pnpm --filter @pymodel/agent-core exec vitest run` — 3577 passed, 1 skipped
- `pnpm --filter @pymodel/server exec vitest run` — 503 passed
- `pnpm --filter @pymodel/pythinker-web exec vitest run` — 263 passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — clean

The rewritten adapter tests were confirmed RED against the old behaviour first (`expected { q_0: 'opt_0_1' } to deeply equal { 'Which animal?': 'Dog' }`), so they can fail.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Question response leases now last up to 30 minutes.
  * Added live expiration warnings during the final five minutes, including under one minute.
  * Responses now retain question text and selected option labels.
* **Bug Fixes**
  * Expired questions now show a clear expiration message instead of a generic error.
  * Dismissal and delivery failures are handled separately for more accurate feedback.
  * Minimized question cards no longer respond to keyboard input, including Escape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->