### PR TITLE
chore(server): drop the unused question service type anchor

### DIFF
--- a/packages/server/src/services/question/questionService.ts
+++ b/packages/server/src/services/question/questionService.ts
@@ -2,16 +2,12 @@
 
 import { ulid } from 'ulid';
 
-import { Disposable, DisposableMap, ErrorCodes, IEventService, IQuestionService, PythinkerError, questionDismissedResult, questionToAgentCoreResponse, questionToBrokerRequest, ILogService, type IDisposable, type QuestionRequest, type QuestionResult } from '@pymodel/agent-core';
+import { Disposable, DisposableMap, ErrorCodes, IEventService, PythinkerError, questionDismissedResult, questionToAgentCoreResponse, questionToBrokerRequest, ILogService, type IDisposable, type IQuestionService, type QuestionRequest, type QuestionResult } from '@pymodel/agent-core';
 import type {
   Event,
   QuestionRequest as ProtocolQuestionRequest,
   QuestionResponse as ProtocolQuestionResponse,
 } from '@pymodel/protocol';
-
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const _typeAnchor: typeof IQuestionService = IQuestionService;
 
 /**
  * A pending question waits on a human, so the timer is a leak guard, not a


### PR DESCRIPTION
## Related Issue

Follow-up to a review finding on #85, deliberately deferred there to keep that bug-fix PR free of
drive-by edits.

## Problem

`packages/server/src/services/question/questionService.ts` carried:

```ts
// eslint-disable-next-line @typescript-eslint/no-unused-vars
const _typeAnchor: typeof IQuestionService = IQuestionService;
```

The const existed only to keep the `IQuestionService` import referenced at runtime, and it needed a
lint suppression to survive. Oxlint still reported `no-underscore-dangle` on it.

## What changed

`IQuestionService` moves to a type-only import and the anchor plus its suppression are deleted. The
class already names the interface in a type position (`implements IQuestionService`), which is the
only reference this file needs.

## Verification

Because the identifier is a DI decorator, a green typecheck alone would not prove the runtime
registration still works — so the full server suite was the gate:

- `pnpm --filter @pymodel/server exec vitest run` — **503 passed** (43 files).
- `pnpm --filter @pymodel/server exec tsc -p tsconfig.json --noEmit` — exit 0.
- `pnpm run lint` — exit 0.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — No new behaviour; the existing server suite covers the DI wiring this touches.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — `@pymodel/server` is changeset-ignored.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal type imports and removed unused declarations.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->