### PR TITLE
feat(desktop): publish releases to a dedicated update channel

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -46,8 +46,8 @@ jobs:
         working-directory: apps/desktop
         run: node --import tsx scripts/stage-runtime.ts
 
-      # On a desktop-v* tag, --publish always creates or updates the draft-or-release
-      # for that tag; contents: write makes GITHUB_TOKEN sufficient.
+      # On a desktop-v* tag, --publish always creates or updates the release
+      # in pythinker-desktop-releases with the GitHub App token below.
       # Without Developer ID signing secrets, electron-builder publishes an
       # ad-hoc/self-signed app. macOS auto-update will not accept unsigned updates,
       # but this still proves packaging and the feed shape.
@@ -73,11 +73,29 @@ jobs:
             echo 'CSC_IDENTITY_AUTO_DISCOVERY=false' >> "$GITHUB_ENV"
             echo 'No macOS signing certificate configured; building unsigned.'
           fi
+      - name: Mint releases-repo token
+        id: releases_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # pinned from v3.2.0
+        with:
+          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+          owner: PyModel
+          repositories: pythinker-desktop-releases
       - name: Package and publish desktop release
         working-directory: apps/desktop
         run: pnpm exec electron-builder --mac dmg zip --publish always
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.releases_token.outputs.token }}
+
+      - name: Verify macOS packaged update configuration
+        shell: bash
+        run: |
+          app_bundle="$(find apps/desktop/dist -maxdepth 2 -type d -name '*.app' -print -quit)"
+          if [ -z "$app_bundle" ]; then
+            echo 'macOS application bundle not found' >&2
+            exit 1
+          fi
+          test -f "$app_bundle/Contents/Resources/app-update.yml"
 
       - name: Upload macOS artifacts for manual runs
         if: github.event_name == 'workflow_dispatch'
@@ -154,11 +172,23 @@ jobs:
             value="${!input:-}"
             if [ -n "$value" ]; then printf '%s<<__EOF__\n%s\n__EOF__\n' "$name" "$value" >> "$GITHUB_ENV"; fi
           done
+      - name: Mint releases-repo token
+        id: releases_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # pinned from v3.2.0
+        with:
+          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+          owner: PyModel
+          repositories: pythinker-desktop-releases
       - name: Package and publish desktop release
         working-directory: apps/desktop
         run: node --import tsx scripts/package-win.ts --publish always
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.releases_token.outputs.token }}
+
+      - name: Verify Windows packaged update configuration
+        shell: bash
+        run: test -f apps/desktop/dist/win-unpacked/resources/app-update.yml
 
       - name: Upload Windows artifacts for manual runs
         if: github.event_name == 'workflow_dispatch'

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,7 +32,8 @@
       {
         "provider": "github",
         "owner": "PyModel",
-        "repo": "pythinker-code"
+        "repo": "pythinker-desktop-releases",
+        "releaseType": "release"
       }
     ],
     "afterPack": "./scripts/verify-packaged-runtime.ts",

--- a/apps/desktop/tests/packaging-config.spec.ts
+++ b/apps/desktop/tests/packaging-config.spec.ts
@@ -28,6 +28,12 @@ interface DesktopPackage {
       readonly perMachine: boolean
       readonly shortcutName: string
     }
+    readonly publish: readonly {
+      readonly owner: string
+      readonly provider: string
+      readonly releaseType: string
+      readonly repo: string
+    }[]
     readonly productName: string
     readonly win: {
       readonly icon: string
@@ -56,6 +62,15 @@ describe('desktop packaging configuration', () => {
   it('packages the application with expected metadata', () => {
     expect(desktopPackage.build.appId).toBe('com.pythinker.desktop')
     expect(desktopPackage.build.productName).toBe('Pythinker')
+  })
+
+  it('publishes updates to the dedicated desktop release repository', () => {
+    expect(desktopPackage.build.publish).toContainEqual({
+      owner: 'PyModel',
+      provider: 'github',
+      releaseType: 'release',
+      repo: 'pythinker-desktop-releases',
+    })
   })
 
   it('keeps desktop download URLs derived from their published release version', () => {


### PR DESCRIPTION
## Related Issue

Follow-up to #87, which fixed the desktop update *client*. This fixes the update *channel*.

## Problem

Auto-update is broken in shipped desktop builds, independently of the client-side bugs fixed in #87.

`electron-updater`'s public GitHub provider resolves the repository's newest release. This repository
publishes CLI releases continuously, so `https://github.com/PyModel/pythinker-code/releases/latest`
resolves to a CLI release — currently `@pymodel/pythinker-code@0.19.0` — which contains no desktop
assets and no `latest-mac.yml`. Every desktop update check therefore 404s.

One repository was publishing two unrelated release streams into one "latest" channel.

## What changed

- **Desktop releases now publish to `PyModel/pythinker-desktop-releases`**, a repository that holds
  desktop artifacts and update metadata only, so "latest release" unambiguously means the desktop app.
- **`releaseType: "release"`** is set explicitly. `electron-publish`'s GitHub publisher otherwise
  creates a **draft**, and a draft is invisible to the updater — this would have failed quietly.
- **Both release jobs mint a GitHub App installation token** for the publish step. `GITHUB_TOKEN` is
  scoped to the repository running the workflow and cannot publish into another one.
- **Both jobs now assert `app-update.yml` exists inside the packaged application.** A build without it
  cannot self-update, and after #87 the app reports itself as non-updatable rather than erroring — so
  shipping such a build would be a silent regression. The check is the last command in its step, so a
  missing file fails the job.

### Required before the next desktop release

Two repository secrets, from a GitHub App installed on `PyModel/pythinker-desktop-releases` with
**Contents: write**:

- `DESKTOP_RELEASES_APP_ID`
- `DESKTOP_RELEASES_APP_PRIVATE_KEY`

There is deliberately **no fallback** to `GITHUB_TOKEN`. A fallback would publish to the wrong
repository and silently recreate this bug; a missing secret must fail the release loudly instead.
Nothing breaks before then — this workflow only runs on `desktop-v*` tags.

### Alternatives considered and rejected

- **Generic provider against the `code.pythinker.com` CDN.** Needs its own credential *and* atomic
  publishing, cache-control correctness, and availability monitoring that the GitHub path gets free.
- **One repository with `allowPrerelease` and a `desktop` channel.** This can be made to work with
  semver-valid tags, since the provider scans the Atom feed and skips invalid tags. Rejected because
  Atom retention is not a channel contract: enough CLI releases can push every desktop entry out of
  the feed, and the failure returns silently.

### Migration note

Clients on the existing `v0.1.0` pre-release cannot learn about the new repository and will need one
manual reinstall. That cost is already sunk — their update path is broken today regardless — and it
only grows with the installed base, which is why this moves now rather than later.

## Verification

- `pnpm --filter @pymodel/pythinker-desktop exec vitest run` — **80 passed**, including a new
  assertion that the publish target is the releases repo with `releaseType: release`. Recorded red
  against the old config first.
- `pnpm run lint` — exit 0.
- Workflow shape asserted mechanically: the app-token step present in both jobs, no publish step left
  on `GITHUB_TOKEN`, and a packaged-feed guard in both jobs.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — `@pymodel/pythinker-desktop` is private and changeset-ignored.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
