### PR TITLE
ci: mirror apps/site to PyModel/pythinker-site

### DIFF
--- a/.github/workflows/site-mirror.yml
+++ b/.github/workflows/site-mirror.yml
@@ -1,0 +1,56 @@
+# Mirrors apps/site to PyModel/pythinker-site so Dokploy can build the CDN site
+# from a repository that contains nothing else. One-way and force-pushed: this
+# repo is the only source of truth, and any commit made in the mirror is lost on
+# the next push here.
+#
+# Deploy keys are disabled org-wide on PyModel, so the push uses a
+# pythinker-release-bot installation token scoped to pythinker-site only — the
+# same shape release.yml uses for the Homebrew tap.
+name: Mirror site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/site/**'
+      - '.github/workflows/site-mirror.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: site-mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # git subtree split walks the full history of apps/site.
+          fetch-depth: 0
+
+      - name: Mint release-bot token
+        id: release-bot
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: PyModel
+          repositories: pythinker-site
+
+      - name: Push apps/site subtree
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+        run: |
+          set -euo pipefail
+          # subtree split rewrites commits, so it needs an identity.
+          git config user.name 'pythinker-release-bot[bot]'
+          git config user.email 'pythinker-release-bot[bot]@users.noreply.github.com'
+          # subtree split writes a \r-terminated progress counter to stdout, so
+          # the sha must be isolated or the refspec colon gets overwritten.
+          split="$(git subtree split --prefix=apps/site HEAD | tr -d '\r' | tail -c 41)"
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/PyModel/pythinker-site.git" \
+            "${split}:refs/heads/main"


### PR DESCRIPTION
## Related Issue

No issue — infrastructure change requested directly: the CDN site should build from a repository that contains only the site.

## Problem

Dokploy builds `code.pythinker.com` from `apps/site/Dockerfile` inside this monorepo, so every unrelated push to `main` is a candidate build context and the deploy app is coupled to the whole tree.

## What changed

A one-way mirror. On any push to `main` touching `apps/site/**`, `git subtree split --prefix=apps/site` is force-pushed to `PyModel/pythinker-site`, which Dokploy will build instead. This repo stays the only source of truth — commits made in the mirror are overwritten on the next push.

The push uses a `pythinker-release-bot` installation token scoped to `pythinker-site` only, the same shape `release.yml` uses for the Homebrew tap. Deploy keys are disabled org-wide on PyModel, so an App token is the only available path, and no new secret is needed: `vars.RELEASE_BOT_APP_ID` and `secrets.RELEASE_BOT_PRIVATE_KEY` already exist.

Verified by running the split locally and priming the mirror: `PyModel/pythinker-site@main` now holds the 14-commit history of `apps/site` with `Dockerfile`, `Caddyfile`, and `vite.config.js` at its root. That run also exposed the `\r` progress counter `git subtree split` writes to stdout, which silently corrupts the push refspec — the workflow strips it.

Follow-up, not in this PR: repoint the Dokploy app and its deploy webhook at `pythinker-site`, and update the stale comment at `release.yml:207`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — n/a; verified by executing the split and push against the real repo.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — CI-only, no published package changes.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated synchronization of the site to its mirror repository after relevant updates.
  * Added support for manually triggering the synchronization workflow.
  * Ensured synchronization runs are serialized to prevent overlapping updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->