### PR TITLE
fix(web): keep the model quick-switch menu inside the viewport

### DIFF
--- a/.changeset/web-model-dropdown-viewport.md
+++ b/.changeset/web-model-dropdown-viewport.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Keep the web model quick-switch menu inside the viewport when the composer sits near the top of the window.

--- a/apps/pythinker-web/src/components/Composer.vue
+++ b/apps/pythinker-web/src/components/Composer.vue
@@ -749,7 +749,7 @@ function toggleDropdown(): void {
   if (dropdownOpen.value) {
     const rect = modelPillRef.value?.getBoundingClientRect();
     modelDropdownStyle.value = rect
-      ? { maxHeight: `${Math.min(360, Math.max(160, rect.top - 4 - 12))}px` }
+      ? { maxHeight: `${Math.min(360, Math.max(0, rect.top - 4 - 12))}px` }
       : {};
     permDropdownOpen.value = false;
     document.addEventListener('click', onDocClick, true);

--- a/apps/pythinker-web/test/composer.test.ts
+++ b/apps/pythinker-web/test/composer.test.ts
@@ -408,9 +408,11 @@ describe('Composer model dropdown', () => {
     const pill = wrapper.get('.model-pill');
     const rect = vi.spyOn(pill.element, 'getBoundingClientRect');
 
+    // A pill near the top of the viewport used to get a 160px menu that reached
+    // above the viewport edge, so its upper entries could not be scrolled to.
     rect.mockReturnValue({ top: 20 } as DOMRect);
     await pill.trigger('click');
-    expect(wrapper.get('.model-dropdown').element.style.maxHeight).toBe('160px');
+    expect(wrapper.get('.model-dropdown').element.style.maxHeight).toBe('4px');
 
     rect.mockReturnValue({ top: 300 } as DOMRect);
     await pill.trigger('click');


### PR DESCRIPTION
## Related Issue

No issue. The problem is described below.

## Problem

The web model quick-switch menu opens above its pill with a fixed `160px`
minimum height. When the pill sits near the top of the viewport, the menu
reached past the viewport edge, so its upper entries could not be scrolled to.
The existing test asserted the `160px` value, so it encoded the off-screen
behaviour rather than catching it.

## What changed

Clamp the menu height to the space actually available above the pill. The
`360px` cap is unchanged. The low-space case in the test now asserts the
constrained height.

This pull request was originally a larger desktop and web branch. #97 landed
that work, so only this fix is left; the branch has been reset onto `main`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
