### PR TITLE
chore: drop changesets that only bump ignored packages

### DIFF
--- a/.changeset/general-session-mode.md
+++ b/.changeset/general-session-mode.md
@@ -1,6 +1,0 @@
----
-"@pymodel/agent-core": minor
-"@pymodel/protocol": minor
----
-
-Add a general non-coding session mode for research and connected tools.

--- a/.changeset/model-catalog-thinking-metadata.md
+++ b/.changeset/model-catalog-thinking-metadata.md
@@ -1,7 +1,0 @@
----
-"@pymodel/protocol": minor
-"@pymodel/agent-core": minor
-"@pymodel/pythinker-web": minor
----
-
-The model catalog now carries per-model thinking-effort levels and the adaptive-thinking flag to API clients.


### PR DESCRIPTION
## Related Issue

No issue. The problem is described below.

## Problem

The `Release` workflow run for `ci: release packages (#98)` failed:

```
HttpError: Validation Failed: {"resource":"PullRequest","code":"custom",
"message":"No commits between main and changeset-release/main"}
```

Two changeset entries stayed on `main` after #98 merged:

- `.changeset/general-session-mode.md` — bumps `@pymodel/agent-core`, `@pymodel/protocol`
- `.changeset/model-catalog-thinking-metadata.md` — bumps `@pymodel/protocol`, `@pymodel/agent-core`, `@pymodel/pythinker-web`

Every package they name is in the `ignore` list of `.changeset/config.json`, so `changeset version` writes no files. The action pushes `changeset-release/main` at the same commit as `main` and the PR creation fails.

The larger effect: because pending changesets exist, the action stays on the version-PR path and never reaches the publish path. `main` is at `0.20.0` while the npm `latest` dist-tag is `0.19.1`, so `0.20.0` is unpublished and all publish-gated jobs (CDN redeploy, Homebrew tap, native assets, docs) are skipped.

## What changed

Delete the two changeset files. With no pending changesets, the next push to `main` takes the publish path and releases `0.20.0`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — not applicable, this only removes release metadata.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — no user-facing behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed pending release notes for general session mode.
  * Removed pending release notes for model thinking-effort levels and adaptive-thinking metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->