### PR TITLE
ci: publish the desktop release atomically and stop the create race

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -13,7 +13,83 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # electron-builder's `getOrCreateRelease` lists the releases, and creates one
+  # when no tag matches. That is a check-then-act with no lock, so two platform
+  # jobs racing it both decide to create: one wins and the other gets
+  # `422 Published releases must have a valid tag`. Creating the release here,
+  # once, removes the race — every platform job then finds it and reuses it.
+  #
+  # It is created as a draft on purpose. A draft needs no valid git tag, so this
+  # step cannot hit the same 422, and `getOrCreateRelease` returns an existing
+  # draft before it consults either the release type or the two-hour rule.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # pinned from v4
+        with:
+          persist-credentials: false
+
+      - name: Resolve the desktop version
+        id: resolve
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          IS_TAG: ${{ startsWith(github.ref, 'refs/tags/desktop-v') }}
+        run: |
+          set -euo pipefail
+          # A tag build is authoritative; a manual run falls back to whatever
+          # version the checked-out tree declares.
+          if [ "$IS_TAG" = 'true' ]; then
+            version="${TAG_NAME#desktop-v}"
+          else
+            version="$(node -p 'require("./apps/desktop/package.json").version')"
+          fi
+          if [ -z "$version" ]; then
+            echo 'Could not resolve a desktop version' >&2
+            exit 1
+          fi
+          # electron-builder names the GitHub release `v${version}`; the tag we
+          # push here (`desktop-v*`) only triggers the workflow.
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing desktop ${version} as tag v${version}."
+
+      - name: Mint releases-repo token
+        id: releases_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # pinned from v3.2.0
+        with:
+          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+          owner: PyModel
+          repositories: pythinker-desktop-releases
+
+      - name: Create the draft release unless it already exists
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.releases_token.outputs.token }}
+          RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
+          RELEASE_REPO: PyModel/pythinker-desktop-releases
+        run: |
+          set -euo pipefail
+          # Re-runs and re-tags must not disturb a release that already exists,
+          # published or not — this only ever adds a missing draft.
+          if gh release view "$RELEASE_TAG" --repo "$RELEASE_REPO" >/dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists; leaving it as it is."
+            exit 0
+          fi
+          gh release create "$RELEASE_TAG" \
+            --repo "$RELEASE_REPO" \
+            --draft \
+            --title "$RELEASE_TAG" \
+            --notes 'Desktop build in progress. Assets appear as each platform finishes.'
+          echo "Created draft release ${RELEASE_TAG}."
+
   mac:
+    needs: prepare
     runs-on: macos-15
     steps:
       - name: Checkout
@@ -86,6 +162,11 @@ jobs:
         run: pnpm exec electron-builder --mac dmg zip --publish always
         env:
           GH_TOKEN: ${{ steps.releases_token.outputs.token }}
+          # Without this, electron-builder refuses to upload to a release that
+          # was published more than two hours ago — and it does so by logging
+          # "skipped publishing" and exiting 0, so a re-run would go green
+          # having shipped nothing.
+          EP_GH_IGNORE_TIME: 'true'
 
       - name: Verify macOS packaged update configuration
         shell: bash
@@ -109,6 +190,7 @@ jobs:
           if-no-files-found: error
 
   windows:
+    needs: prepare
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -185,6 +267,9 @@ jobs:
         run: node --import tsx scripts/package-win.ts --publish always
         env:
           GH_TOKEN: ${{ steps.releases_token.outputs.token }}
+          # See the macOS job: without this a re-run against an older release
+          # silently uploads nothing and still reports success.
+          EP_GH_IGNORE_TIME: 'true'
 
       - name: Verify Windows packaged update configuration
         shell: bash
@@ -199,3 +284,64 @@ jobs:
             apps/desktop/dist/*.exe
             apps/desktop/dist/latest.yml
           if-no-files-found: error
+
+  # Publishing last, and only once both platforms uploaded, is what makes the
+  # release atomic. A platform that fails leaves a draft nobody can download,
+  # which is recoverable by re-running that job; publishing per-platform instead
+  # would leave a live release missing an operating system.
+  publish:
+    needs: [prepare, mac, windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint releases-repo token
+        id: releases_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # pinned from v3.2.0
+        with:
+          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+          owner: PyModel
+          repositories: pythinker-desktop-releases
+
+      - name: Require every expected artifact before publishing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.releases_token.outputs.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_REPO: PyModel/pythinker-desktop-releases
+        run: |
+          set -euo pipefail
+          gh release view "$RELEASE_TAG" --repo "$RELEASE_REPO" \
+            --json assets --jq '.assets[].name' > assets.txt
+          echo 'Assets on the release:'
+          sed 's/^/  /' assets.txt
+
+          # Counting assets is not enough: the half-release that shipped before
+          # had four of them and no .dmg. Each artifact is named individually.
+          missing=0
+          require() {
+            if ! grep -qE "$1" assets.txt; then
+              echo "Missing artifact: $2" >&2
+              missing=1
+            fi
+          }
+          require '\.dmg$'          'macOS disk image'
+          require '\-mac\.zip$'     'macOS update archive'
+          require '^latest-mac\.yml$' 'macOS update manifest'
+          require '\-Setup\.exe$'   'Windows installer'
+          require '^latest\.yml$'   'Windows update manifest'
+          if [ "$missing" -ne 0 ]; then
+            echo 'Leaving the release as a draft.' >&2
+            exit 1
+          fi
+          echo 'All expected artifacts are present.'
+
+      - name: Publish the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.releases_token.outputs.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_REPO: PyModel/pythinker-desktop-releases
+        run: |
+          set -euo pipefail
+          gh release edit "$RELEASE_TAG" --repo "$RELEASE_REPO" --draft=false
+          echo "Published ${RELEASE_TAG}."


### PR DESCRIPTION
## Related Issue

No issue. The first real desktop release (`desktop-v0.1.3`) exposed the problems described below; both were diagnosed from the run logs and from electron-builder's own source.

## Problem

**The two platform jobs race to create the release.** electron-builder's `getOrCreateRelease` (`packages/electron-publish/src/gitHubPublisher.ts`) lists the releases, looks for one whose tag matches, and calls `createRelease()` when none does. That is a check-then-act with no lock. The macOS and Windows jobs start together, both see no release, and both `POST /releases`. One wins; the other gets `422 Validation Failed: Published releases must have a valid tag`. electron-builder's `doesErrorMeanAlreadyExists` guard covers only *asset upload* conflicts, so the create path has no retry at all.

That is exactly what happened on `desktop-v0.1.3`: Windows created the release at `04:02:42Z`, macOS failed one second later.

**Publishing per platform leaves half a release.** Because the winner publishes immediately, the failed macOS job left a live, published `v0.1.3` containing the Windows installer, a stray `.dmg.blockmap`, and no `.dmg` at all. Anyone landing on it during that window got a release with no macOS build.

**A re-run can silently ship nothing.** For a non-draft release published more than two hours ago, `getOrCreateRelease` returns `null`, and `doUpload` then logs `skipped publishing` and returns normally — the job goes green having uploaded no assets. The macOS re-run only worked because it landed inside the two-hour window.

## What changed

- **`prepare`** creates the release once, before either platform job. It is created as a **draft** deliberately: a draft needs no valid git tag, so this step cannot hit the same 422, and `getOrCreateRelease` returns an existing draft before it consults either the release type or the two-hour rule. It is idempotent — an existing release, draft or published, is left untouched.
- **`mac` and `windows`** now `needs: prepare`, so they find the draft and reuse it instead of creating anything. Both set `EP_GH_IGNORE_TIME` so a re-run cannot silently upload nothing.
- **`publish`** runs only after both platforms succeed. It names each expected artifact — `.dmg`, `-mac.zip`, `latest-mac.yml`, `-Setup.exe`, `latest.yml` — and flips the draft only when all five are present. A count check would not do: the half-release that shipped had four assets.

A platform failure now leaves a draft that no one can download and that is fixed by re-running that one job, instead of a live release missing an operating system.

### Verification

- The workflow parses, and every `run:` block passes `bash -n`.
- The asset gate was run against two fixtures: the real, complete `v0.1.3` asset list (publishes) and the exact broken list that shipped (stays a draft, naming the three missing macOS artifacts). `.dmg$` correctly rejects `.dmg.blockmap`.
- `EP_GH_IGNORE_TIME` was read from electron-builder's source rather than from docs, and the spelling matches `isEnvTrue(process.env.EP_GH_IGNORE_TIME)`.

**Not verified end to end.** Exercising this needs a real release, and cutting one only to test a workflow change is not worth it. The first genuine exercise is the next desktop tag.

### Note for reviewers

The App token is now minted in four jobs per release rather than two.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — a workflow cannot be unit-tested here; the asset gate was instead exercised against real and broken fixtures, as described above.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — CI-only change under `.github/`, nothing enters a package artifact.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
