### PR TITLE
feat(web): add shared menu, switch and chip primitives

### DIFF
--- a/.changeset/web-ui-primitives.md
+++ b/.changeset/web-ui-primitives.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Add four shared UI primitives to the web app: `Popover`, `MenuRow`, `SwitchToggle` and `Chip`. `Popover` holds the anchored-menu positioning that each menu used to write for itself, including the flip above the trigger and the viewport clamp. `MenuRow` carries the standard list row, sized from `--ui-font-size` so the font-size setting still scales it. All four style themselves only from theme tokens, and a guard test fails on any colour literal.

--- a/apps/pythinker-web/src/components/ui/Chip.vue
+++ b/apps/pythinker-web/src/components/ui/Chip.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+type ChipVariant = 'neutral' | 'active';
+
+const props = withDefaults(defineProps<{
+  label?: string;
+  variant?: ChipVariant;
+}>(), {
+  variant: 'neutral',
+});
+
+const emit = defineEmits<{
+  click: [event: MouseEvent];
+}>();
+</script>
+
+<template>
+  <button
+    type="button"
+    class="chip"
+    :class="variant"
+    @click="emit('click', $event)"
+  >
+    <span class="icon" aria-hidden="true">
+      <span v-if="$slots.icon" class="icon-default"><slot name="icon" /></span>
+      <span class="close-glyph">×</span>
+    </span>
+    <span v-if="label || $slots.label || $slots.default" class="label">
+      <slot name="label">{{ label }}<slot /></slot>
+    </span>
+  </button>
+</template>
+
+<style scoped>
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  box-sizing: border-box;
+  padding: 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: none;
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+.chip.neutral {
+  background: var(--panel);
+}
+
+.chip.active {
+  border-color: color-mix(in srgb, var(--blue) 30%, var(--line));
+  background: color-mix(in srgb, var(--soft) 60%, var(--panel));
+  color: var(--blue);
+}
+
+.chip:hover {
+  background: var(--hover);
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  line-height: 1;
+}
+
+.icon-default :deep(svg) {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
+.close-glyph {
+  display: none;
+  font-size: var(--ui-font-size-lg);
+  line-height: 1;
+}
+
+.chip:hover .icon-default {
+  display: none;
+}
+
+.chip:hover .close-glyph {
+  display: inline;
+}
+
+.label {
+  min-width: 0;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/apps/pythinker-web/src/components/ui/MenuRow.vue
+++ b/apps/pythinker-web/src/components/ui/MenuRow.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+  count?: number;
+  active?: boolean;
+  selected?: boolean;
+  disabled?: boolean;
+}>(), {
+  active: false,
+  selected: false,
+  disabled: false,
+});
+</script>
+
+<template>
+  <button
+    type="button"
+    class="menu-row"
+    :class="{ active, selected, disabled }"
+    :disabled="disabled"
+  >
+    <span v-if="$slots.leading" class="leading"><slot name="leading" /></span>
+    <span class="label">
+      <slot name="label"><slot /></slot>
+    </span>
+    <span v-if="count !== undefined" class="count">{{ count }}</span>
+    <span v-if="$slots.trailing" class="trailing"><slot name="trailing" /></span>
+  </button>
+</template>
+
+<style scoped>
+.menu-row {
+  /* Default 14px: 14 + 13 = 27px; 14 - 1 = 13px. */
+  width: 100%;
+  height: calc(var(--ui-font-size) + 13px);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-sizing: border-box;
+  padding: 0 8px;
+  border: 0;
+  border-radius: var(--r-md);
+  background: none;
+  color: var(--ink);
+  font-family: inherit;
+  font-size: calc(var(--ui-font-size) - 1px);
+  font-weight: 400;
+  line-height: 1;
+  text-align: left;
+  cursor: pointer;
+}
+
+.menu-row:hover {
+  background: var(--hover);
+}
+
+.menu-row.active,
+.menu-row.selected {
+  background: color-mix(in srgb, var(--soft) 45%, var(--panel));
+}
+
+.menu-row:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: -2px;
+}
+
+.menu-row.disabled,
+.menu-row:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.leading {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
+}
+
+.leading :deep(svg) {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
+.label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.count {
+  flex: none;
+  color: var(--muted);
+}
+
+.trailing {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  margin-left: auto;
+}
+</style>

--- a/apps/pythinker-web/src/components/ui/Popover.vue
+++ b/apps/pythinker-web/src/components/ui/Popover.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue';
+
+type Alignment = 'start' | 'end';
+
+const props = withDefaults(defineProps<{
+  anchor: HTMLElement | null;
+  open: boolean;
+  align?: Alignment;
+}>(), {
+  align: 'start',
+});
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const panelRef = ref<HTMLElement | null>(null);
+const panelStyle = ref<Record<string, string>>({});
+let opener: HTMLElement | null = null;
+let listenersAttached = false;
+
+function positionPanel(): void {
+  const anchor = props.anchor;
+  const panel = panelRef.value;
+  if (!anchor || !panel) return;
+
+  const anchorRect = anchor.getBoundingClientRect();
+  const gap = 4;
+  const margin = 16;
+  const panelWidth = panel.offsetWidth;
+  const panelHeight = panel.offsetHeight;
+  const preferredLeft = props.align === 'end'
+    ? anchorRect.right - panelWidth
+    : anchorRect.left;
+  const maxLeft = Math.max(margin, window.innerWidth - margin - panelWidth);
+  let left = Math.min(Math.max(preferredLeft, margin), maxLeft);
+  let top = anchorRect.bottom + gap;
+
+  if (top + panelHeight > window.innerHeight - margin) {
+    top = Math.max(margin, anchorRect.top - panelHeight - gap);
+  }
+
+  const maxTop = Math.max(margin, window.innerHeight - margin - panelHeight);
+  top = Math.min(Math.max(top, margin), maxTop);
+  left = Math.min(Math.max(left, margin), maxLeft);
+  panelStyle.value = {
+    top: `${Math.round(top)}px`,
+    left: `${Math.round(left)}px`,
+  };
+}
+
+function onViewportChange(): void {
+  if (props.open) positionPanel();
+}
+
+function onPointerDown(event: PointerEvent): void {
+  const target = event.target;
+  if (target instanceof Node && (panelRef.value?.contains(target) || props.anchor?.contains(target))) return;
+  emit('close');
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') emit('close');
+}
+
+function attachListeners(): void {
+  if (listenersAttached) return;
+  document.addEventListener('pointerdown', onPointerDown);
+  document.addEventListener('keydown', onKeydown);
+  document.addEventListener('scroll', onViewportChange, true);
+  window.addEventListener('resize', onViewportChange);
+  listenersAttached = true;
+}
+
+function detachListeners(): void {
+  if (!listenersAttached) return;
+  document.removeEventListener('pointerdown', onPointerDown);
+  document.removeEventListener('keydown', onKeydown);
+  document.removeEventListener('scroll', onViewportChange, true);
+  window.removeEventListener('resize', onViewportChange);
+  listenersAttached = false;
+}
+
+function restoreFocusIfNeeded(): void {
+  const panel = panelRef.value;
+  const activeElement = document.activeElement;
+  if (!panel || !(activeElement instanceof Node) || !panel.contains(activeElement)) return;
+
+  const target = props.anchor ?? opener;
+  if (target?.isConnected) target.focus();
+}
+
+watch(() => props.open, (open, wasOpen) => {
+  if (open) {
+    if (!wasOpen) {
+      opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    }
+    void nextTick(() => {
+      if (!props.open) return;
+      positionPanel();
+      attachListeners();
+    });
+    return;
+  }
+
+  restoreFocusIfNeeded();
+  detachListeners();
+  panelStyle.value = {};
+}, { immediate: true });
+
+watch([() => props.anchor, () => props.align], () => {
+  if (props.open) void nextTick(positionPanel);
+});
+
+onBeforeUnmount(() => {
+  restoreFocusIfNeeded();
+  detachListeners();
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      ref="panelRef"
+      class="popover"
+      :style="panelStyle"
+      role="menu"
+      tabindex="-1"
+    >
+      <slot />
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.popover {
+  position: fixed;
+  z-index: 200;
+  box-sizing: border-box;
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  padding: 2px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--panel);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--ink) 18%, transparent);
+}
+</style>

--- a/apps/pythinker-web/src/components/ui/SwitchToggle.vue
+++ b/apps/pythinker-web/src/components/ui/SwitchToggle.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  modelValue: boolean;
+  disabled?: boolean;
+}>(), {
+  disabled: false,
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+}>();
+
+function toggle(): void {
+  if (!props.disabled) emit('update:modelValue', !props.modelValue);
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (props.disabled) return;
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  event.preventDefault();
+  toggle();
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    class="switch-toggle"
+    role="switch"
+    :aria-checked="modelValue"
+    :disabled="disabled"
+    @click="toggle"
+    @keydown="onKeydown"
+  >
+    <span class="track" aria-hidden="true" />
+    <span class="thumb" aria-hidden="true" />
+  </button>
+</template>
+
+<style scoped>
+.switch-toggle {
+  position: relative;
+  width: 28px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: none;
+  cursor: pointer;
+}
+
+.track,
+.thumb {
+  position: absolute;
+  display: block;
+}
+
+.track {
+  inset: 0;
+  border-radius: 999px;
+  background: var(--line);
+  transition: background-color 150ms ease;
+}
+
+.switch-toggle[aria-checked="true"] .track {
+  background: var(--blue);
+}
+
+.thumb {
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--panel);
+  transition: transform 150ms ease;
+}
+
+.switch-toggle[aria-checked="true"] .thumb {
+  transform: translateX(12px);
+}
+
+.switch-toggle:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
+.switch-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/apps/pythinker-web/test/ui-primitives.test.ts
+++ b/apps/pythinker-web/test/ui-primitives.test.ts
@@ -1,0 +1,223 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import Chip from '../src/components/ui/Chip.vue';
+import MenuRow from '../src/components/ui/MenuRow.vue';
+import Popover from '../src/components/ui/Popover.vue';
+import SwitchToggle from '../src/components/ui/SwitchToggle.vue';
+
+// Resolved from this file, not the cwd: the pre-push hook runs the suite from
+// the repository root.
+const uiDir = join(import.meta.dirname, '../src/components/ui');
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? sourceFiles(path) : [path];
+  });
+}
+
+async function settle(): Promise<void> {
+  await nextTick();
+  await nextTick();
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('MenuRow', () => {
+  it('renders its label and count when provided', () => {
+    const wrapper = mount(MenuRow, {
+      props: { count: 3 },
+      slots: { label: 'Models' },
+    });
+
+    expect(wrapper.text()).toContain('Models');
+    expect(wrapper.find('.count').text()).toBe('3');
+  });
+
+  it('omits the count element when count is not provided', () => {
+    const wrapper = mount(MenuRow, { slots: { label: 'Models' } });
+
+    expect(wrapper.find('.count').exists()).toBe(false);
+  });
+
+  it('applies the disabled state', () => {
+    const wrapper = mount(MenuRow, {
+      props: { disabled: true },
+      slots: { label: 'Models' },
+    });
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('button').classes()).toContain('disabled');
+  });
+});
+
+describe('SwitchToggle', () => {
+  it('reflects aria-checked and emits on click', async () => {
+    const wrapper = mount(SwitchToggle, { props: { modelValue: false } });
+
+    expect(wrapper.attributes('aria-checked')).toBe('false');
+    await wrapper.trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]]);
+
+    await wrapper.setProps({ modelValue: true });
+    expect(wrapper.attributes('aria-checked')).toBe('true');
+  });
+
+  it('emits on keyboard activation', async () => {
+    const wrapper = mount(SwitchToggle, { props: { modelValue: false } });
+
+    await wrapper.trigger('keydown', { key: 'Enter' });
+    await wrapper.trigger('keydown', { key: ' ' });
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true], [true]]);
+  });
+});
+
+describe('Chip', () => {
+  it('renders neutral and active variants and emits on click', async () => {
+    const neutral = mount(Chip, {
+      props: { label: 'Neutral', variant: 'neutral' },
+      slots: { icon: '<svg aria-hidden="true" />' },
+    });
+    const active = mount(Chip, {
+      props: { label: 'Active', variant: 'active' },
+      slots: { icon: '<svg aria-hidden="true" />' },
+    });
+
+    expect(neutral.classes()).toContain('neutral');
+    expect(active.classes()).toContain('active');
+    expect(active.text()).toContain('Active');
+
+    await active.trigger('click');
+    expect(active.emitted('click')).toHaveLength(1);
+  });
+});
+
+describe('Popover', () => {
+  it('opens and closes with the open prop', async () => {
+    const anchor = document.createElement('button');
+    document.body.append(anchor);
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: { anchor, open: false },
+      slots: { default: 'Menu' },
+    });
+
+    expect(document.body.querySelector('[role="menu"]')).toBeNull();
+    await wrapper.setProps({ open: true });
+    expect(document.body.querySelector('[role="menu"]')?.textContent).toBe('Menu');
+    await wrapper.setProps({ open: false });
+    expect(document.body.querySelector('[role="menu"]')).toBeNull();
+  });
+
+  it('flips above the anchor and clamps to the viewport', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    const anchor = document.createElement('button');
+    anchor.getBoundingClientRect = () => ({
+      bottom: 720,
+      height: 20,
+      left: 700,
+      right: 760,
+      top: 700,
+      width: 60,
+      x: 700,
+      y: 700,
+      toJSON: () => ({}),
+    });
+    document.body.append(anchor);
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: { anchor, open: true },
+      slots: { default: 'Menu' },
+    });
+    const panel = document.body.querySelector('[role="menu"]') as HTMLElement;
+    Object.defineProperty(panel, 'offsetWidth', { configurable: true, value: 100 });
+    Object.defineProperty(panel, 'offsetHeight', { configurable: true, value: 80 });
+
+    await settle();
+
+    expect(readFileSync(join(uiDir, 'Popover.vue'), 'utf8')).toMatch(/position:\s*fixed/u);
+    expect(panel.style.top).toBe('616px');
+    expect(panel.style.left).toBe('684px');
+    wrapper.unmount();
+  });
+
+  it('closes on Escape', async () => {
+    const anchor = document.createElement('button');
+    document.body.append(anchor);
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: { anchor, open: true },
+    });
+
+    await settle();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('closes on outside pointerdown but not inside the panel', async () => {
+    const anchor = document.createElement('button');
+    const outside = document.createElement('div');
+    document.body.append(anchor, outside);
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: { anchor, open: true },
+      slots: { default: 'Menu' },
+    });
+
+    await settle();
+    const panel = document.body.querySelector('[role="menu"]') as HTMLElement;
+    panel.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    expect(wrapper.emitted('close')).toBeUndefined();
+
+    outside.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('restores focus to the anchor only when the panel held focus', async () => {
+    const anchor = document.createElement('button');
+    document.body.append(anchor);
+    anchor.focus();
+    const wrapper = mount(Popover, {
+      attachTo: document.body,
+      props: { anchor, open: false },
+    });
+
+    await wrapper.setProps({ open: true });
+    await settle();
+    const panel = document.body.querySelector('[role="menu"]') as HTMLElement;
+    panel.focus();
+    await wrapper.setProps({ open: false });
+    expect(document.activeElement).toBe(anchor);
+
+    await wrapper.setProps({ open: true });
+    await settle();
+    const outside = document.createElement('input');
+    document.body.append(outside);
+    outside.focus();
+    await wrapper.setProps({ open: false });
+    expect(document.activeElement).toBe(outside);
+  });
+});
+
+describe('UI primitive theme guard', () => {
+  it('keeps every source file free of forbidden color and dark-mode literals', () => {
+    const files = sourceFiles(uiDir).toSorted();
+
+    expect(files.length).toBeGreaterThanOrEqual(4);
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8');
+      expect(source, file).not.toMatch(/\bdark:/u);
+      expect(source, file).not.toMatch(/#[\da-f]{3,8}\b/iu);
+      expect(source, file).not.toMatch(/\brgba?\s*\(/iu);
+    }
+  });
+});


### PR DESCRIPTION
## Related Issue

No issue. The problem is described below.

## Problem

Every anchored menu in the web app writes its own positioning: `OpenInMenu.vue` measures the trigger, flips the panel above when there is no room below, and clamps it to the viewport, all by hand. The next menu will write the same code again. Separately, no two lists in the app agree on row height, radius or text size, so a menu built next to an existing one does not match it.

## What changed

Four primitives under `apps/pythinker-web/src/components/ui/`:

- `Popover` — the anchored panel: fixed positioning, teleported to `body`, 4px offset, below-first with a flip above when space runs out, a 16px viewport clamp, `role="menu"`, Escape and outside-pointerdown to close, and focus returned to the trigger only when the panel actually held focus.
- `MenuRow` — the standard list row, with leading, label, count and trailing slots, plus hover, selected and disabled states.
- `SwitchToggle` — an accessible switch, operable by click, Enter and Space.
- `Chip` — a pill with neutral and active variants that swaps its leading icon for a close glyph on hover.

Existing callers are untouched; moving them onto these primitives is a separate change.

Two things worth calling out:

- **`MenuRow` is sized relative to `--ui-font-size`,** not pinned to 27px. The app lets users change the UI font size, and a fixed row height would break that setting. At the 14px default the row resolves to exactly 27px with 13px text.
- **The primitives take no colour of their own.** The app has three themes, each in light and dark, all driven by CSS custom properties. A single hex literal or `dark:` utility would break two of the three. A guard test reads every file under `components/ui/` and fails on either. I verified the guard by adding a hex literal to `Chip.vue` and watching it go red, then removing it.

Verified locally: 338 web tests, typecheck, and lint all pass, and the suite passes again after the pre-commit autofix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable UI components for chips, menu rows, popovers, and switch toggles.
  * Chips support neutral and active states, labels, icons, and click interactions.
  * Menu rows support counts, selection, active, disabled, and customizable content states.
  * Popovers provide aligned, viewport-aware menus with outside-click and Escape dismissal.
  * Switch toggles support keyboard interaction, accessibility semantics, and disabled states.

* **Tests**
  * Added coverage for rendering, interactions, accessibility, positioning, focus restoration, and theme consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->