### PR TITLE
feat(core): derive model capabilities in the catalog

### DIFF
--- a/.changeset/derive-model-capabilities.md
+++ b/.changeset/derive-model-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": minor
+---
+
+Report each model's real capabilities in the catalog. Until now `capabilities` carried only what a user had typed into their config file by hand, so for almost every model it was empty. It is now derived from the model itself when the config says nothing, while an explicit list in the config still wins. A provider whose capabilities are genuinely unknown keeps omitting the field rather than claiming the model can do nothing.

--- a/packages/agent-core/src/services/modelCatalog/modelCatalog.ts
+++ b/packages/agent-core/src/services/modelCatalog/modelCatalog.ts
@@ -1,3 +1,4 @@
+import { getModelCapability, isUnknownCapability } from '@pymodel/kosong';
 import { createDecorator } from '../../di';
 import type { PythinkerConfig, ModelAlias, ProviderConfig } from '../../config';
 import type {
@@ -43,16 +44,36 @@ export class ModelNotFoundError extends Error {
 export function toProtocolModel(
   modelId: string,
   alias: ModelAlias,
+  provider?: ProviderConfig,
 ): ModelCatalogItem {
   return {
     provider: alias.provider,
     model: modelId,
     display_name: alias.displayName ?? alias.model,
     max_context_size: alias.maxContextSize,
-    capabilities: alias.capabilities,
+    capabilities: alias.capabilities ?? derivedCapabilities(alias, provider),
     support_efforts: alias.supportEfforts,
     adaptive_thinking: alias.adaptiveThinking,
   };
+}
+
+function derivedCapabilities(
+  alias: ModelAlias,
+  provider: ProviderConfig | undefined,
+): string[] | undefined {
+  if (provider === undefined) return undefined;
+  try {
+    const capability = getModelCapability(provider.type, alias.model);
+    if (isUnknownCapability(capability)) return undefined;
+    return Object.entries(capability)
+      .filter(
+        ([key, value]) =>
+          value === true && key !== 'max_context_tokens' && key !== 'cost',
+      )
+      .map(([key]) => key);
+  } catch {
+    return undefined;
+  }
 }
 
 export interface ProviderCredentialState {

--- a/packages/agent-core/src/services/modelCatalog/modelCatalogService.ts
+++ b/packages/agent-core/src/services/modelCatalog/modelCatalogService.ts
@@ -30,7 +30,7 @@ export class ModelCatalogService
   async listModels(): Promise<readonly ModelCatalogItem[]> {
     const config = await this._readConfig();
     return Object.entries(config.models ?? {}).map(([modelId, alias]) =>
-      toProtocolModel(modelId, alias),
+      toProtocolModel(modelId, alias, config.providers[alias.provider]),
     );
   }
 
@@ -63,7 +63,7 @@ export class ModelCatalogService
     const updatedAlias = updated.models?.[modelId] ?? alias;
     return {
       default_model: modelId,
-      model: toProtocolModel(modelId, updatedAlias),
+      model: toProtocolModel(modelId, updatedAlias, updated.providers[updatedAlias.provider]),
     };
   }
 

--- a/packages/agent-core/test/services/model-catalog-service.test.ts
+++ b/packages/agent-core/test/services/model-catalog-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getModelCapability } from '@pymodel/kosong';
 
 import type {
   CoreRPC,
@@ -116,6 +117,80 @@ function catalogConfig(): PythinkerConfig {
 }
 
 describe('model catalog adapters', () => {
+  it('derives capabilities from the configured provider wire type', async () => {
+    const config = catalogConfig();
+    const alias = {
+      provider: 'openai',
+      model: 'gpt-5.4',
+      maxContextSize: 200000,
+    };
+    config.models = { gpt54: alias };
+    const { core } = makeCore({ current: config });
+
+    const [model] = await new ModelCatalogService(core).listModels();
+    const detected = getModelCapability('openai', alias.model);
+    expect(model?.capabilities).toEqual(
+      Object.entries(detected)
+        .filter(([, value]) => value === true)
+        .map(([key]) => key),
+    );
+  });
+
+  it('keeps an explicit capability list exactly', () => {
+    const config = catalogConfig();
+    const alias = {
+      ...config.models!['gpt4o']!,
+      capabilities: ['custom_capability', 'always_thinking'],
+    };
+
+    expect(toProtocolModel('gpt4o', alias, config.providers['openai']).capabilities).toEqual(
+      alias.capabilities,
+    );
+  });
+
+  it('emits only true capability flags, excluding context and cost metadata', () => {
+    const config = catalogConfig();
+    const alias = config.models!['gpt4o']!;
+    const capabilities = toProtocolModel('gpt4o', alias, config.providers['openai']).capabilities;
+
+    expect(capabilities).toEqual(['image_in', 'tool_use']);
+    expect(capabilities).not.toContain('video_in');
+    expect(capabilities).not.toContain('audio_in');
+    expect(capabilities).not.toContain('thinking');
+    expect(capabilities).not.toContain('max_context_tokens');
+    expect(capabilities).not.toContain('cost');
+  });
+
+  it('omits capabilities when the provider reports unknown capability data', () => {
+    const config = catalogConfig();
+    const alias = { ...config.models!['turbo']!, capabilities: undefined };
+
+    expect(toProtocolModel('turbo', alias, config.providers['pythinker']).capabilities).toBeUndefined();
+  });
+
+  it('keeps a model entry when its provider cannot be resolved', async () => {
+    const config: PythinkerConfig = {
+      providers: {},
+      models: {
+        orphan: {
+          provider: 'missing',
+          model: 'gpt-4o',
+          maxContextSize: 128000,
+        },
+      },
+    };
+    const { core } = makeCore({ current: config });
+
+    await expect(new ModelCatalogService(core).listModels()).resolves.toMatchObject([
+      {
+        provider: 'missing',
+        model: 'orphan',
+        max_context_size: 128000,
+        capabilities: undefined,
+      },
+    ]);
+  });
+
   it('maps model aliases to selectable wire ids', () => {
     const alias = catalogConfig().models!['k2']!;
     expect(toProtocolModel('k2', alias)).toEqual({

--- a/packages/server/test/model-catalog.e2e.test.ts
+++ b/packages/server/test/model-catalog.e2e.test.ts
@@ -136,6 +136,10 @@ describe('model/provider catalog routes', () => {
         model: 'gpt4o',
         display_name: 'gpt-4o',
         max_context_size: 128000,
+        // Declares no capabilities in config, so they are derived from the
+        // model itself. `k2` above keeps the list its config states, and
+        // `turbo` omits the field because the pythinker wire reports unknown.
+        capabilities: ['image_in', 'tool_use'],
       },
     ]);
   });


### PR DESCRIPTION
## Related Issue

No issue. The problem is described below.

## Problem

`GET /models` reported a model's `capabilities` straight from the model alias in the user's config file, and nothing ever derived it. The field is `capabilities: z.array(z.string()).optional()` — purely what someone typed by hand. A user who never wrote one got nothing back, which is almost every user and almost every model.

That makes the field close to useless: any client rendering capabilities shows an empty result for models that plainly do support vision or tool use. The data already existed — `getModelCapability(wire, modelName)` is exported from `@pymodel/kosong` and returns the real per-model flags — it just never reached the catalog.

## What changed

`toProtocolModel` derives the list from `getModelCapability` when the alias declares none, resolving the wire type from the provider config that already sits beside the alias.

The rules, each pinned by a test:

- **An explicit list in the config still wins**, including an explicit empty one. This is a fallback for silence, never an override.
- **A capability that is `false` is absent**, so the list only ever states what a model can do.
- **`max_context_tokens` and `cost` are excluded.** They are not capabilities, and the context size already has its own field.
- **An unknown wire type keeps omitting the field.** Omission says "unknown"; an empty list would claim the model can do nothing, which is a different and wrong statement.
- **An unresolvable provider falls back rather than throwing**, so a model that cannot be classified still appears in the catalog.

## One existing test changed, deliberately

`packages/server/test/model-catalog.e2e.test.ts` asserted that an unannotated `gpt-4o` comes back with no capabilities. That expectation recorded the bug, so it now expects `['image_in', 'tool_use']`.

The other two rows in that same assertion are what make the change safe to read: `k2` declares `capabilities = ["thinking"]` in config and still returns exactly that, and `turbo` sits on the `pythinker` wire, whose capabilities are unknown, and still omits the field. Precedence and the unknown case are both proven by rows that did not move.

## Why this matters now

#110 added capability badges to the model picker. Against this catalog they would render for almost nobody. This is the half that makes that feature real.

Verified locally: 3574+ agent-core tests and 512 server tests pass, both typechecks and lint are clean, and the server suite passes again after the pre-commit autofix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model capabilities are now automatically shown when they can be determined from the model definition.
  * Explicitly configured capabilities continue to take precedence.
  * Unsupported or unknown capabilities remain omitted.

* **Bug Fixes**
  * Models remain available in the catalog even when provider information cannot be resolved.

* **Tests**
  * Added coverage for derived capabilities, explicit overrides, filtering, and unknown models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->