### PR TITLE
feat(web): add retry on the last reply and copy on user messages

### DIFF
--- a/.changeset/web-message-actions.md
+++ b/.changeset/web-message-actions.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-code': minor
+---
+
+Add a Retry action to the last assistant reply and a copy button to user messages in the web UI. Retry asks for confirmation, then sends the original prompt again.

--- a/apps/pythinker-web/src/App.vue
+++ b/apps/pythinker-web/src/App.vue
@@ -749,6 +749,14 @@ async function handleEditMessage(text: string): Promise<void> {
   conversationPaneRef.value?.loadComposerForEdit(text);
 }
 
+// Retry the last assistant reply: undo the exchange, then send its original
+// user prompt as a new prompt. Undo reports any failure and returns null.
+async function handleRegenerate(): Promise<void> {
+  const text = await client.undo(1);
+  if (text === null) return;
+  await client.sendPrompt(text);
+}
+
 // Handler for slash commands emitted by Composer (via ConversationPane)
 function handleCommand(cmd: string): void {
   // `/compact <text>` carries an optional free-text instruction steering what
@@ -1167,6 +1175,7 @@ function openPr(url: string): void {
       @open-compaction="openCompactionPanel($event)"
       @open-agent="openAgentPanel($event)"
       @edit-message="handleEditMessage"
+      @regenerate="handleRegenerate"
     />
 
     <!-- Multi-workspace selection placeholder -->

--- a/apps/pythinker-web/src/components/ChatPane.vue
+++ b/apps/pythinker-web/src/components/ChatPane.vue
@@ -113,6 +113,8 @@ const emit = defineEmits<{
   openAgent: [target: { turnId: string; blockIndex: number; memberId: string }];
   /** Edit + resend the last user message (parent undoes, then refills composer). */
   editMessage: [text: string];
+  /** Undo the last exchange and send its user prompt again. */
+  regenerate: [];
 }>();
 
 // Id of the most recent user turn — the only one offered an "edit & resend"
@@ -166,6 +168,7 @@ const copiedTurn = ref<string | null>(null);
 
 // Undo/edit-and-resend confirmation state (keyed by turn id)
 const confirmingEditTurnId = ref<string | null>(null);
+const confirmingRetryTurnId = ref<string | null>(null);
 const undoingTurnId = ref<string | null>(null);
 let undoTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -199,6 +202,12 @@ function confirmEditMessage(turn: ChatTurn): void {
     emit('editMessage', turn.text);
     undoingTurnId.value = null;
   }, 240);
+}
+
+function confirmRegenerate(): void {
+  if (confirmingRetryTurnId.value === null) return;
+  confirmingRetryTurnId.value = null;
+  emit('regenerate');
 }
 
 // Copy-whole-conversation state
@@ -302,6 +311,38 @@ function isAssistantRunEnd(index: number): boolean {
   return !next || next.role !== 'assistant';
 }
 
+function isFinalAssistantRun(index: number): boolean {
+  if (!isAssistantRunEnd(index)) return false;
+  for (let i = index + 1; i < props.turns.length; i += 1) {
+    if (props.turns[i]?.role === 'assistant') return false;
+  }
+  return true;
+}
+
+function canRetryAssistantRun(index: number): boolean {
+  const turn = props.turns[index];
+  if (!turn || turn.role !== 'assistant') return false;
+
+  let precedingUser: ChatTurn | null = null;
+  for (let i = index - 1; i >= 0; i -= 1) {
+    if (props.turns[i]?.role === 'user') {
+      precedingUser = props.turns[i]!;
+      break;
+    }
+  }
+
+  return (
+    isFinalAssistantRun(index) &&
+    turn.id !== streamingTurnId.value &&
+    !props.running &&
+    !props.sending &&
+    precedingUser !== null &&
+    precedingUser.id === lastUserTurnId.value &&
+    !precedingUser.skillActivation &&
+    assistantRunFinalText(index).trim().length > 0
+  );
+}
+
 // One shared timer: copying B within 1.4s of copying A must not let A's stale
 // timer hide B's checkmark early. Cleared on unmount.
 let copiedTimer: ReturnType<typeof setTimeout> | null = null;
@@ -311,6 +352,18 @@ function copyAssistantRun(index: number): void {
   const text = assistantRunFinalText(index);
   if (!text.trim()) return;
   navigator.clipboard.writeText(text).then(() => {
+    copiedTurn.value = turn.id;
+    if (copiedTimer !== null) clearTimeout(copiedTimer);
+    copiedTimer = setTimeout(() => {
+      copiedTimer = null;
+      copiedTurn.value = null;
+    }, 1400);
+  }).catch(() => {/* ignore */});
+}
+
+function copyUserTurn(turn: ChatTurn): void {
+  if (turn.skillActivation) return;
+  navigator.clipboard.writeText(turn.text).then(() => {
     copiedTurn.value = turn.id;
     if (copiedTimer !== null) clearTimeout(copiedTimer);
     copiedTimer = setTimeout(() => {
@@ -473,7 +526,24 @@ function renderBlockKey(block: AssistantRenderBlock, index: number): string {
           <!-- User input renders verbatim (pre-wrap), never through Markdown -->
           <div v-else class="u-text">{{ turn.text }}</div>
         </div>
-        <div v-if="turn.createdAt || canEditTurn(turn)" class="u-meta">
+        <div v-if="turn.createdAt || canEditTurn(turn) || !turn.skillActivation" class="u-meta">
+          <button
+            v-if="!turn.skillActivation"
+            type="button"
+            class="a-cpbtn user-cpbtn"
+            :aria-label="t('filePreview.copy')"
+            :data-user-turn-id="turn.id"
+            @click.stop="copyUserTurn(turn)"
+          >
+            <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="3" y="3" width="9" height="9" rx="1.5"/>
+              <path d="M6 1h7a1 1 0 0 1 1 1v7"/>
+            </svg>
+            <svg v-else viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="3,8 6.5,11.5 13,5"/>
+            </svg>
+            <span class="a-cpbtn-text">{{ t('filePreview.copy') }}</span>
+          </button>
           <div v-if="canEditTurn(turn)" class="u-edit-wrap" :class="{ undoing: undoingTurnId === turn.id }">
             <button
               v-if="confirmingEditTurnId !== turn.id"
@@ -563,6 +633,29 @@ function renderBlockKey(block: AssistantRenderBlock, index: number): string {
             </svg>
             <span class="a-cpbtn-text">{{ t('filePreview.copy') }}</span>
           </button>
+          <button
+            v-if="canRetryAssistantRun(ti) && confirmingRetryTurnId !== turn.id"
+            type="button"
+            class="a-cpbtn retry-btn"
+            :aria-label="t('conversation.retry')"
+            tabindex="-1"
+            @click="confirmingRetryTurnId = turn.id"
+          >
+            <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 7a5 5 0 1 1 1.5 3.6"/>
+              <path d="M3 3.5V7h3.5"/>
+            </svg>
+            <span class="a-cpbtn-text">{{ t('conversation.retry') }}</span>
+          </button>
+          <div v-else-if="canRetryAssistantRun(ti)" class="u-edit-confirm retry-confirm" @click.stop>
+            <span>{{ t('conversation.retryConfirm') }}</span>
+            <button type="button" class="u-edit-confirm-btn confirm" @click.stop="confirmRegenerate">
+              {{ t('conversation.confirm') }}
+            </button>
+            <button type="button" class="u-edit-confirm-btn" @click.stop="confirmingRetryTurnId = null">
+              {{ t('conversation.cancel') }}
+            </button>
+          </div>
         </div>
       </div>
     </template>
@@ -631,6 +724,17 @@ function renderBlockKey(block: AssistantRenderBlock, index: number): string {
               <span class="who"> &gt; </span>
             </template>
 
+            <button v-if="turn.role === 'user' && !turn.skillActivation" class="cpbtn user-cpbtn" :aria-label="t('filePreview.copy')" :data-user-turn-id="turn.id" @click="copyUserTurn(turn)" tabindex="-1">
+              <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="3" width="9" height="9" rx="1.5"/>
+                <path d="M6 1h7a1 1 0 0 1 1 1v7"/>
+              </svg>
+              <svg v-else viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <polyline points="3,8 6.5,11.5 13,5"/>
+              </svg>
+              <span class="cpbtn-text">{{ t('filePreview.copy') }}</span>
+            </button>
+
             <!-- Per-message copy button (always visible, only when turn is complete) -->
             <button v-if="turn.id !== streamingTurnId && isAssistantRunEnd(ti) && assistantRunFinalText(ti).trim().length > 0" class="cpbtn" @click="copyAssistantRun(ti)" tabindex="-1">
               <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -642,6 +746,28 @@ function renderBlockKey(block: AssistantRenderBlock, index: number): string {
               </svg>
               <span class="cpbtn-text">{{ t('filePreview.copy') }}</span>
             </button>
+            <button
+              v-if="canRetryAssistantRun(ti) && confirmingRetryTurnId !== turn.id"
+              class="cpbtn retry-btn"
+              :aria-label="t('conversation.retry')"
+              @click="confirmingRetryTurnId = turn.id"
+              tabindex="-1"
+            >
+              <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M3 7a5 5 0 1 1 1.5 3.6"/>
+                <path d="M3 3.5V7h3.5"/>
+              </svg>
+              <span class="cpbtn-text">{{ t('conversation.retry') }}</span>
+            </button>
+            <div v-else-if="canRetryAssistantRun(ti)" class="u-edit-confirm retry-confirm" @click.stop>
+              <span>{{ t('conversation.retryConfirm') }}</span>
+              <button type="button" class="u-edit-confirm-btn confirm" @click.stop="confirmRegenerate">
+                {{ t('conversation.confirm') }}
+              </button>
+              <button type="button" class="u-edit-confirm-btn" @click.stop="confirmingRetryTurnId = null">
+                {{ t('conversation.cancel') }}
+              </button>
+            </div>
             <span v-if="turn.durationMs !== undefined && turn.role === 'assistant'" class="turn-duration" :title="`${turn.durationMs} ms`">{{ formatDuration(turn.durationMs) }}</span>
           </div>
 

--- a/apps/pythinker-web/src/components/ConversationPane.vue
+++ b/apps/pythinker-web/src/components/ConversationPane.vue
@@ -104,6 +104,8 @@ const emit = defineEmits<{
   refreshGitStatus: [];
   /** Edit + resend the last user message (App undoes, then refills composer). */
   editMessage: [text: string];
+  /** Undo the last exchange and send its user prompt again. */
+  regenerate: [];
   /** Empty-composer workspace picker: start a new conversation elsewhere. */
   selectWorkspace: [workspaceId: string];
   /** Empty-composer workspace picker: create a new workspace. */
@@ -940,6 +942,7 @@ defineExpose({ loadComposerForEdit });
               @open-compaction="emit('openCompaction', $event)"
               @open-agent="emit('openAgent', $event)"
               @edit-message="emit('editMessage', $event)"
+              @regenerate="emit('regenerate')"
             />
             <div v-if="activeDynamicWorkflows.length > 0" class="dynamic-workflow-stack">
               <DynamicWorkflowCard v-for="group in activeDynamicWorkflows" :key="group.id" :group="group" />

--- a/apps/pythinker-web/src/i18n/locales/en/conversation.ts
+++ b/apps/pythinker-web/src/i18n/locales/en/conversation.ts
@@ -18,6 +18,8 @@ export default {
   undo: 'Undo',
   undoTooltip: 'Undoing the conversation will not roll back code changes',
   undoConfirm: 'Undo last message?',
+  retry: 'Retry',
+  retryConfirm: 'Retry last reply?',
   confirm: 'Confirm',
   cancel: 'Cancel',
   yesterday: 'Yesterday',

--- a/apps/pythinker-web/test/message-actions.test.ts
+++ b/apps/pythinker-web/test/message-actions.test.ts
@@ -1,0 +1,200 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { flushPromises, mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ChatPane from '../src/components/ChatPane.vue';
+import type { ChatTurn } from '../src/types';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      conversation: {
+        cancel: 'Cancel',
+        compactedPlain: 'Context compacted',
+        compactedAuto: 'Context auto-compacted',
+        compactedTokens: ' ({before} -> {after})',
+        confirm: 'Confirm',
+        loading: 'Loading',
+        retry: 'Retry',
+        retryConfirm: 'Retry last reply?',
+        undo: 'Undo',
+        undoConfirm: 'Undo last message?',
+        undoTooltip: 'Undoing the conversation will not roll back code changes',
+        viewSummary: 'View summary',
+        yesterday: 'Yesterday',
+      },
+      filePreview: { copy: 'Copy' },
+    },
+  },
+  missingWarn: false,
+  fallbackWarn: false,
+});
+
+function mountPane(
+  turns: ChatTurn[],
+  props: { mobile?: boolean; running?: boolean; sending?: boolean } = {},
+) {
+  return mount(ChatPane, {
+    props: { turns, ...props },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        Markdown: { props: ['text'], template: '<div class="markdown-stub">{{ text }}</div>' },
+        ThinkingBlock: true,
+        ToolCall: true,
+        ActivityNotice: true,
+        ActivitySpinner: true,
+        MascotSprite: true,
+        AgentCard: true,
+        AgentGroup: true,
+      },
+    },
+  });
+}
+
+function userTurn(id: string, no: number, text: string, skillActivation?: ChatTurn['skillActivation']): ChatTurn {
+  return { id, role: 'user', no, text, skillActivation };
+}
+
+function assistantTurn(id: string, no: number, text: string): ChatTurn {
+  return { id, role: 'assistant', no, text };
+}
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  return writeText;
+}
+
+const finalExchange: ChatTurn[] = [
+  userTurn('u1', 1, 'old prompt'),
+  assistantTurn('a1', 2, 'old reply'),
+  userTurn('u2', 3, 'last prompt'),
+  assistantTurn('a2', 4, 'last reply'),
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ChatPane message actions', () => {
+  it.each([false, true])('renders Retry only on the final assistant run in both layouts', (mobile) => {
+    const wrapper = mountPane(finalExchange, { mobile });
+
+    expect(wrapper.findAll('.retry-btn')).toHaveLength(1);
+    expect(wrapper.find('[data-turn-id="a1"] .retry-btn').exists()).toBe(false);
+    expect(wrapper.find('[data-turn-id="a2"] .retry-btn').exists()).toBe(true);
+  });
+
+  it.each([
+    { name: 'running', props: { running: true } },
+    { name: 'sending', props: { sending: true } },
+  ])('does not render Retry while $name is true', ({ props }) => {
+    const idleWrapper = mountPane(finalExchange);
+    expect(idleWrapper.find('.retry-btn').exists()).toBe(true);
+
+    const wrapper = mountPane(finalExchange, props);
+    expect(wrapper.find('.retry-btn').exists()).toBe(false);
+  });
+
+  it('requires confirmation before emitting regenerate', async () => {
+    const wrapper = mountPane(finalExchange);
+    const retry = wrapper.find('.retry-btn');
+    expect(retry.exists()).toBe(true);
+
+    await retry.trigger('click');
+
+    expect(wrapper.emitted('regenerate')).toBeUndefined();
+    expect(wrapper.find('.retry-confirm').exists()).toBe(true);
+
+    await wrapper.find('.retry-confirm .confirm').trigger('click');
+
+    expect(wrapper.emitted('regenerate')).toHaveLength(1);
+  });
+
+  it('cancelling Retry emits nothing and restores the button', async () => {
+    const wrapper = mountPane(finalExchange);
+    expect(wrapper.find('.retry-btn').exists()).toBe(true);
+
+    await wrapper.find('.retry-btn').trigger('click');
+    await wrapper.find('.retry-confirm .u-edit-confirm-btn:not(.confirm)').trigger('click');
+
+    expect(wrapper.emitted('regenerate')).toBeUndefined();
+    expect(wrapper.find('.retry-btn').exists()).toBe(true);
+  });
+
+  it.each([false, true])('copies a user turn verbatim in both layouts', async (mobile) => {
+    const text = '  keep this text exactly\nwith its spaces  ';
+    const writeText = mockClipboard();
+    const wrapper = mountPane([userTurn('u1', 1, text)], { mobile });
+    const copy = wrapper.find('.user-cpbtn');
+    expect(copy.exists()).toBe(true);
+
+    await copy.trigger('click');
+    await flushPromises();
+
+    expect(writeText).toHaveBeenCalledWith(text);
+  });
+
+  it.each([false, true])('shows user copy on an older user turn in both layouts', (mobile) => {
+    const turns = [
+      userTurn('u1', 1, 'older prompt'),
+      assistantTurn('a1', 2, 'older reply'),
+      userTurn('u2', 3, 'last prompt'),
+    ];
+    const wrapper = mountPane(turns, { mobile });
+
+    expect(wrapper.findAll('.user-cpbtn')).toHaveLength(2);
+    expect(wrapper.find('[data-user-turn-id="u1"]').exists()).toBe(true);
+  });
+
+  it.each([false, true])('skips user copy for skill activations in both layouts', (mobile) => {
+    const wrapper = mountPane(
+      [
+        userTurn('u1', 1, 'normal prompt'),
+        userTurn('skill', 2, '/review src/app.ts', { name: 'review', args: 'src/app.ts' }),
+      ],
+      { mobile },
+    );
+
+    expect(wrapper.find('[data-user-turn-id="u1"]').exists()).toBe(true);
+    expect(wrapper.find('[data-user-turn-id="skill"]').exists()).toBe(false);
+  });
+});
+
+describe('message action theme guard', () => {
+  const sourceAllowlist: Array<{ path: string; colors: string[] }> = [
+    { path: '../src/components/ChatPane.vue', colors: [] },
+    {
+      path: '../src/components/ConversationPane.vue',
+      colors: [
+        '#'.concat('000'),
+        'rgba'.concat('(0, 0, 0, 0.28)'),
+        'rgba'.concat('(0, 0, 0, 0.14)'),
+        'rgba'.concat('(0, 0, 0, 0.12)'),
+        'rgba'.concat('(0, 0, 0, 0.18)'),
+      ],
+    },
+    { path: '../src/App.vue', colors: [] },
+    { path: '../src/i18n/locales/en/conversation.ts', colors: [] },
+    { path: './message-actions.test.ts', colors: [] },
+  ];
+  const colorLiteralPattern = /#[0-9a-f]{3,8}\b|\b(?:rgb|rgba)\([^)]*\)/giu;
+  const darkUtilityPattern = new RegExp(['dark', ':'].join(''), 'gu');
+
+  it('keeps touched files free of new theme literals and dark utilities', async () => {
+    for (const { path, colors } of sourceAllowlist) {
+      const source = await readFile(resolve(import.meta.dirname, path), 'utf8');
+      expect(source.match(darkUtilityPattern) ?? [], path).toEqual([]);
+      expect((source.match(colorLiteralPattern) ?? []).toSorted(), path).toEqual([...colors].toSorted());
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Per-message actions were already partly built: assistant runs carry a copy button in both layouts, and the most recent user message carries an undo / edit-and-resend affordance. Two gaps remained.

**Retry** on the final assistant run. It sits beside the existing copy button in both layouts, asks for confirmation, then undoes the exchange and sends the original prompt again.

**Copy** on user messages, in both layouts. It reuses the existing copied-state timer and icons, appears on every user turn rather than only the last, and is skipped on skill-activation turns whose text is not what the user typed.

## The constraint behind the gating

`client.undo(1)` removes the **last** exchange regardless of which message was clicked. A Retry button on an older assistant message would therefore destroy the wrong turn. It is gated by two independent conditions — the run must be the final assistant run, and its preceding user turn must be the last user turn — plus the same idle guards `canEditTurn` already uses (`!running`, `!sending`, no skill activation).

Retry keeps a confirm step, matching the existing undo. The discarded reply cannot be recovered, so a single click must not fire it.

No read-aloud, ratings, branching, or response versions. Those are product features this app does not have.

## Verification

Run from the repository root:

- `pnpm run lint` — exit 0, no error lines
- `pnpm -C apps/pythinker-web run typecheck` — exit 0
- `pnpm -C apps/pythinker-web exec vitest run` — 339 passed, 59 files

13 new tests in `test/message-actions.test.ts`. I mutation-checked the older-message guard by hand after the run: removing **one** of the two conditions keeps the suite green, because the other still excludes older runs; removing both turns it red. The redundancy is deliberate, and the coverage is real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Retry** action for the latest assistant response.
  - Retry asks for confirmation before resending the original message.
  - Added **Copy** buttons for user messages across supported chat layouts.
  - Retry controls appear only when the latest response is eligible and complete.
- **Bug Fixes**
  - Canceling a retry leaves the conversation unchanged.
- **Tests**
  - Added coverage for retry visibility, confirmation, cancellation, copying, and theme consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->