### PR TITLE
fix(cli): keep OAuth query parameters when opening the browser on Windows

### DIFF
--- a/.changeset/windows-browser-url.md
+++ b/.changeset/windows-browser-url.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-code': patch
+---
+
+Open the browser on Windows through `rundll32` instead of `cmd /c start`. `cmd` cut every URL at the first `&`, so OAuth logins reached the provider with only the first query parameter and failed with an invalid authorize request.

--- a/apps/pythinker-code/src/utils/open-url.ts
+++ b/apps/pythinker-code/src/utils/open-url.ts
@@ -1,11 +1,30 @@
 import { execFile } from 'node:child_process';
 
+export interface OpenUrlCommand {
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+/**
+ * Windows uses `rundll32` rather than `cmd /c start` because `cmd` re-parses
+ * its arguments and cuts a URL at the first `&`, which strips every OAuth
+ * query parameter after `client_id`.
+ */
+export function openUrlCommandFor(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): OpenUrlCommand {
+  switch (platform) {
+    case 'darwin':
+      return { command: 'open', args: [url] };
+    case 'win32':
+      return { command: 'rundll32', args: ['url.dll,FileProtocolHandler', url] };
+    default:
+      return { command: 'xdg-open', args: [url] };
+  }
+}
+
 export function openUrl(url: string): void {
-  const command: [string, string[]] =
-    process.platform === 'darwin'
-      ? ['open', [url]]
-      : process.platform === 'win32'
-        ? ['cmd', ['/c', 'start', '', url]]
-        : ['xdg-open', [url]];
-  execFile(command[0], command[1], () => {});
+  const { command, args } = openUrlCommandFor(url);
+  execFile(command, [...args], () => {});
 }

--- a/apps/pythinker-code/test/utils/open-url.test.ts
+++ b/apps/pythinker-code/test/utils/open-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { openUrlCommandFor } from '#/utils/open-url';
+
+const AUTHORIZE_URL =
+  'https://auth.openai.com/oauth/authorize?client_id=app_test&response_type=code&state=abc';
+
+describe('openUrlCommandFor', () => {
+  it('keeps every query parameter on Windows', () => {
+    const { command, args } = openUrlCommandFor(AUTHORIZE_URL, 'win32');
+    expect(command).toBe('rundll32');
+    // `cmd /c start` cuts the URL at the first `&`, so the launcher must not
+    // hand the URL to a command interpreter.
+    expect(command).not.toBe('cmd');
+    expect(args.at(-1)).toBe(AUTHORIZE_URL);
+  });
+
+  it('uses the platform launcher elsewhere', () => {
+    expect(openUrlCommandFor(AUTHORIZE_URL, 'darwin')).toEqual({
+      command: 'open',
+      args: [AUTHORIZE_URL],
+    });
+    expect(openUrlCommandFor(AUTHORIZE_URL, 'linux')).toEqual({
+      command: 'xdg-open',
+      args: [AUTHORIZE_URL],
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue

No issue filed. Users report that Codex OAuth login fails with:

```json
{ "error": { "message": "Invalid authorize request", "code": "invalid_authorize_request" } }
```

The browser lands on `…/oauth/authorize?client_id=app_EMoamEEZ73f0CkXaXp7hrann` — the first query parameter and nothing else.

## Problem

`openUrl` launched the browser on Windows with `cmd /c start "" <url>`. `cmd` re-parses its arguments and treats `&` as a command separator, so the URL is cut at the first `&`. Every parameter after `client_id` — `response_type`, `redirect_uri`, `scope`, `code_challenge`, `state` — never reaches OpenAI, and the authorize request is rejected. The generated URL itself is correct and matches the upstream Codex CLI parameter set, so this only affects Windows users.

## What changed

`openUrl` now hands the URL to `rundll32 url.dll,FileProtocolHandler`, which takes the argument verbatim and never runs a command interpreter. The command choice moves into an exported `openUrlCommandFor(url, platform)` so it can be asserted per platform, matching the shape of `openFileCommandFor` in `packages/server/src/lib/fileLaunch.ts`. macOS and Linux keep `open` and `xdg-open`.

## Verification

- `apps/pythinker-code/test/utils/open-url.test.ts` — new; asserts the full URL survives on Windows. Confirmed it fails against the old `cmd /c start` command and passes after the change.
- `tsc -p apps/pythinker-code/tsconfig.json --noEmit` — pass

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows URL opening for links containing query parameters, including OAuth authorization URLs.
  * Improved platform-specific browser launching while preserving existing behavior on macOS and Linux.

* **Tests**
  * Added coverage to verify URL handling across Windows, macOS, and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->