### PR TITLE
chore(desktop): bump the desktop app to 0.1.4

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Related Issue

No issue — release chore. The `desktop-v0.1.3` build predates the macOS signing secrets, so it shipped unsigned and macOS refuses to auto-update from it.

## Problem

`apps/desktop` is a private package, so it publishes nothing to npm and needs no changeset. A new `desktop-v*` tag still needs the tree version to match the tag, otherwise `main` drifts from the released build. [skip changeset]

## What changed

Bump `apps/desktop/package.json` from `0.1.3` to `0.1.4`. Tagging `desktop-v0.1.4` after this merges produces the first Developer ID signed and notarized macOS build. Windows still builds unsigned — no `WIN_CSC_*` or `AZURE_*` signing secrets are configured yet.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — version-only change, no behavior to test.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — private package, not part of the changesets release flow.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application to version 0.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->