### PR TITLE
chore(desktop): bump the desktop app to 0.1.5

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Related Issue

No issue — release chore for the merged desktop update restart fix.

## Problem

The fix is on `main`, but desktop installers need a new `desktop-v*` tag and a matching tree version. `apps/desktop` is private, so it is not published to npm and does not need a changeset. [skip changeset]

## What changed

Bump `apps/desktop/package.json` from `0.1.4` to `0.1.5`. After this PR merges, tag `desktop-v0.1.5` to publish the macOS and Windows update artifacts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — version-only change; the pre-push gate passed 10,525 tests.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — private desktop package.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — version-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application version to 0.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->