### PR TITLE
fix(vscode): bundle immer into the extension

### DIFF
--- a/.changeset/vsix-immer-bundle.md
+++ b/.changeset/vsix-immer-bundle.md
@@ -1,0 +1,4 @@
+---
+"pythinker": patch
+---
+Fix the extension bundle to inline every runtime dependency.

--- a/.changeset/vsix-immer-bundle.md
+++ b/.changeset/vsix-immer-bundle.md
@@ -1,4 +1,4 @@
 ---
 "pythinker": patch
 ---
-Fix the extension bundle to inline every runtime dependency.
+Fix the extension bundle to inline `immer`.

--- a/apps/vscode/tsdown.config.ts
+++ b/apps/vscode/tsdown.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
   },
   deps: {
     onlyBundle: false,
-    alwaysBundle: [/^@pymodel\//, 'zod', 'diff'],
+    alwaysBundle: [/^@pymodel\//, 'zod', 'diff', 'immer'],
     neverBundle: ['vscode'],
   },
   outputOptions: {


### PR DESCRIPTION
## Related Issue

None — release-pipeline fix (internal PR).

## Problem

The release workflow's VSIX publish has failed since the port line landed with: `VSIX packaging failed: Bare runtime dependency "immer" remains in extension/dist/extension.js.` The extension bundler force-bundles only `@pymodel/*`, `zod`, and `diff`; `immer` entered the runtime graph through the ported agent-core-v2 state layer and was externalized, which the packaging verifier rejects.

## What changed

Added `immer` to `alwaysBundle` in the extension's tsdown config. Verified locally: `build:extension` leaves zero bare `immer` imports in `dist/extension.js` and the full `vsix-package.mjs` static checks pass for every target.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (internal release fix).
- [x] I have added tests that prove my feature works (packaging verifier itself is the gate).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause the VS Code extension to fail when loading required functionality.
  * Improved runtime reliability by ensuring all necessary components are available within the extension package.

* **Release**
  * Included this fix in a patch release of the VS Code extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->