### PR TITLE
test(agent-core): give the sweep-resilience wait the full test budget

### DIFF
--- a/packages/agent-core/test/mcp/oauth-service.test.ts
+++ b/packages/agent-core/test/mcp/oauth-service.test.ts
@@ -158,8 +158,12 @@ async function deliverCallback(flow: BeginAuthorizationResult): Promise<void> {
   await response.text();
 }
 
-async function waitFor(condition: () => boolean, description: string): Promise<void> {
-  const deadline = Date.now() + 5000;
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   while (!condition()) {
     if (Date.now() > deadline) throw new Error(`timed out waiting for ${description}`);
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -618,9 +622,13 @@ describe('McpOAuthService sweepProactiveRefresh resilience', () => {
     await writeFile(join(fixture.storeDir, 'corrupt-meta.json'), '{not json', 'utf-8');
 
     expect(() => fixture.service.sweepProactiveRefresh()).not.toThrow();
+    // The immediate refresh spans two localhost HTTP round-trips plus token
+    // writes; on a loaded CI runner that can outlast the default 5s budget
+    // while staying well inside this test's own 15s timeout.
     await waitFor(
       () => authServer.counts.refresh === 1,
       'the swept credential to refresh immediately',
+      12_000,
     );
   }, 15000);
 });


### PR DESCRIPTION
## Related Issue

None — test-stability fix (internal PR).

## Problem

`McpOAuthService sweepProactiveRefresh resilience > skips malformed meta sidecars` flaked on a loaded CI runner today and blocked the release gate: the immediate refresh spans two localhost HTTP round-trips plus token writes, but `waitFor` used a hard-coded 5s deadline while the test itself allows 15s. One `gh run rerun --failed` cleared it, but it will bite future releases the same way.

## What changed

`waitFor` now takes an optional budget (default unchanged at 5s), and the sweep-resilience wait uses 12s — inside the test's own 15s timeout, with margin for cleanup. No production code touched.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (internal stability fix).
- [x] I have added tests that prove my feature works (the test itself is the change; scoped run passes 20/20).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by allowing asynchronous checks to use configurable wait periods.
  * Extended the proactive refresh resilience test’s wait window while preserving its overall timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->