### PR TITLE
chore: prepare the VS Code extension and desktop releases

### DIFF
--- a/.changeset/desktop-log-token-redaction.md
+++ b/.changeset/desktop-log-token-redaction.md
@@ -1,5 +1,5 @@
 ---
-"@pymodel/pythinker-code": patch
+"@pymodel/pythinker-desktop": patch
 ---
 
 Stop the desktop app writing its server access token to the log.

--- a/.changeset/vscode-api-key-ready.md
+++ b/.changeset/vscode-api-key-ready.md
@@ -1,0 +1,5 @@
+---
+"pythinker": patch
+---
+
+Fix the VS Code extension asking you to sign in when a provider is already configured with an API key.

--- a/.changeset/vscode-model-setup-signin.md
+++ b/.changeset/vscode-model-setup-signin.md
@@ -1,0 +1,5 @@
+---
+"pythinker": patch
+---
+
+Keep a way back to the sign-in screen when the VS Code extension reports that no model is configured.


### PR DESCRIPTION
## Related Issue

No issue — release chore, follow-up to #145.

## Problem

Two of the three artifacts this release should ship cannot reach users, and neither
failure is visible in CI.

**VS Code extension.** All 43 pending changesets name only `@pymodel/pythinker-code`.
The extension depends on `@pymodel/pythinker-code-sdk`, so `changeset version` leaves
`apps/vscode` at 0.9.4. The release workflow's `publish-vscode-extension` job still runs
(it is gated on `packages_published`), but `vsix-publish.mjs` skips a version already in
the registry — the job goes green having published nothing, and the sign-in fixes from
#145 stay unreleased.

**Desktop.** `desktop-log-token-redaction` describes a change to
`apps/desktop/src/host-supervisor.ts` but is targeted at `@pymodel/pythinker-code`. It
would print in the CLI changelog, where it is not true, and leave
`@pymodel/pythinker-desktop` unbumped — so a `desktop-v*` tag would ship a version whose
changelog never mentions the fix.

Verified by running `changeset version` locally against the current `.changeset/`
contents, before and after this change.

## What changed

Two changesets bumping `pythinker` to 0.9.5, one per user-facing fix already merged in
#145:

- API-key-only providers no longer land on a sign-in screen they cannot satisfy
  (`resolveInitStatus` treats a configured model as ready).
- The "no model configured" state keeps a route back to sign-in
  (`resolveAppView` sets `canGoToLogin`).

And `desktop-log-token-redaction` retargeted to `@pymodel/pythinker-desktop`, which is
where the code it describes lives.

Resulting versions:

| Package | Before | After |
| --- | --- | --- |
| `@pymodel/pythinker-code` | 0.39.2 | 0.40.0 |
| `pythinker` (VS Code) | 0.9.4 | 0.9.5 |
| `@pymodel/pythinker-desktop` | 0.1.5 | 0.1.6 |

No source changes; every fix and its tests are already on `main`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works. — covered by `apps/vscode/test/app-init.test.ts` and `apps/desktop/tests/host-supervisor.spec.ts` in #145.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary VS Code sign-in prompts when an API key is already configured.
  - Preserved navigation back to the sign-in screen when no model has been configured.
  - Stopped the desktop app from recording server access tokens in logs, improving security and privacy.
  - Updated release information to accurately reflect these fixes across the relevant applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->