### PR TITLE
chore: release the managed-endpoint removal as a major version

### DIFF
--- a/.changeset/remove-managed-kimi-endpoints.md
+++ b/.changeset/remove-managed-kimi-endpoints.md
@@ -1,5 +1,5 @@
 ---
-"@pymodel/pythinker-code": minor
+"@pymodel/pythinker-code": major
 ---
 
 Remove the hosted self-update checks, default plugin marketplace catalog, official plugin badges, tips banner, and sign-up links; Kimi now serves only as a model provider through OAuth or an API key. Set PYTHINKER_CODE_PLUGIN_MARKETPLACE_URL to keep using a plugin catalog.

--- a/.changeset/subagent-execution-inspector.md
+++ b/.changeset/subagent-execution-inspector.md
@@ -2,4 +2,4 @@
 "@pymodel/pythinker-code": patch
 ---
 
-Allow sub agent activity cards to open their live execution transcript.
+Allow subagent activity cards to open their live execution transcript.


### PR DESCRIPTION
## Related Issue

No issue — release chore, follow-up to #145 and #147. Addresses both CodeRabbit findings on the version PR #146.

## Problem

**Wrong release classification.** `remove-managed-kimi-endpoints` is declared `minor`, but the
change it describes removes hosted self-update checks, the default plugin marketplace catalog,
official plugin badges, the tips banner, and sign-up links. Existing installs lose behaviour they
have today, which is a breaking change and warrants a `major` release. The maintainer confirmed
the `major` bump, as `AGENTS.md` requires.

**Inconsistent spelling in a user-facing changelog.** `subagent-execution-inspector` writes
"sub agent" while every other entry in the same release writes "subagent".

## What changed

- `remove-managed-kimi-endpoints`: `minor` to `major`.
- `subagent-execution-inspector`: "sub agent" to "subagent".

Both corrections are made in the source changesets rather than in the generated
`CHANGELOG.md`, because `changeset-release/main` is rebuilt from scratch on every release run and
any edit to the generated file is discarded.

Resulting versions, verified with a local `changeset version` run against the current
`.changeset/` contents:

| Package | Before | After |
| --- | --- | --- |
| `@pymodel/pythinker-code` | 0.39.2 | 1.0.0 |
| `pythinker` (VS Code) | 0.9.4 | 0.9.5 |
| `@pymodel/pythinker-desktop` | 0.1.5 | 0.1.6 |

No source changes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works. — changeset metadata only, no behaviour to test.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed hosted self-update checks, the default plugin marketplace catalog, official plugin badges, the tips banner, and sign-up links.
  * Kimi remains available as a model provider through OAuth or an API key.
  * Plugin catalogs can still be enabled by configuring `PYTHINKER_CODE_PLUGIN_MARKETPLACE_URL`.
* **Documentation**
  * Updated activity card terminology from “sub agent” to “subagent.”
  * Marked the release as a major version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->