### PR TITLE
chore(desktop): prepare 0.2.1 release

### DIFF
--- a/.changeset/desktop-live-activity.md
+++ b/.changeset/desktop-live-activity.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-desktop": patch
+---
+
+Remove duplicate live activity and keep narrow subagent panel controls visible.

--- a/.changeset/desktop-task-outcomes.md
+++ b/.changeset/desktop-task-outcomes.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-desktop": patch
+---
+
+Show task outcome cards with subagent model and thinking-effort details in conversations.


### PR DESCRIPTION
## Related Issue

Owner-directed desktop release preparation; no separate issue.

## Problem

The desktop-visible changes from PR #162 only had CLI changesets. The release bot therefore cannot bump the desktop application from 0.2.0.

## What changed

- Add two approved patch changesets for the desktop live-activity and task-outcome surfaces.
- Prepare the release bot to generate desktop 0.2.1 without editing package versions by hand.
- Keep publication separate: this PR does not create a tag or publish desktop assets.

## Verification

- `pnpm exec changeset status` resolves `@pymodel/pythinker-desktop` from 0.2.0 to 0.2.1.
- `pnpm -C apps/desktop exec vitest run` passes 151 tests.
- Desktop `tsc`, `tsgo`, build, and `git diff --check` pass.
- GitNexus reports two changed metadata files, no changed symbols, and low risk.
- Read-only identifier audit found no secrets, internal identifiers, or unrelated files.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] This is owner-directed release preparation; no separate issue is required.
- [x] Existing desktop tests pass; this metadata-only change adds no behavior.
- [x] Ran `gen-changesets`; the user approved both entries before commit.
- [x] No documentation update is needed for release metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task outcome cards now show the subagent model and thinking-effort details within conversations.
  * Narrow subagent panels continue to provide access to their controls.

* **Bug Fixes**
  * Removed duplicate live activity entries for a cleaner conversation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->