### PR TITLE
fix(desktop): correct the Windows and macOS release verification

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -246,7 +246,10 @@ jobs:
             exit 1
           fi
           verify_app "$dmg_app"
-          xcrun stapler validate "$dmg_path"
+          # electron-builder notarizes and staples the .app, then packs the
+          # already-stapled bundle into the disk image; the image itself never
+          # receives a ticket. Validate the staple where it actually lives.
+          xcrun stapler validate "$dmg_app"
           cleanup_mount
           trap - EXIT
 

--- a/apps/desktop/scripts/package-win.ts
+++ b/apps/desktop/scripts/package-win.ts
@@ -73,12 +73,12 @@ export function windowsSigningArgs(env: NodeJS.ProcessEnv): readonly string[] {
     )
   }
 
-  const publisherName = hasAzureValue
-    ? trimmedValue(env['AZURE_SIGNING_PUBLISHER_NAME'])!
-    : trimmedValue(env['WINDOWS_SIGNING_PUBLISHER_NAME'])!
-  if (!hasAzureValue) args.length = 0
-  args.push('--config.win.publisherName', publisherName)
-  return args
+  // Electron Builder 26 removed `win.publisherName`, and `win` rejects unknown
+  // keys, so passing it fails schema validation before any build work. The
+  // Azure path already carries the publisher in `azureSignOptions`; the
+  // certificate path now sets it where signtool reads it.
+  if (hasAzureValue) return args
+  return ['--config.win.signtoolOptions.publisherName', trimmedValue(env['WINDOWS_SIGNING_PUBLISHER_NAME'])!]
 }
 
 /** Require one complete signing method for a tagged Windows release. */

--- a/apps/desktop/tests/package-win.spec.ts
+++ b/apps/desktop/tests/package-win.spec.ts
@@ -1,9 +1,55 @@
+import { createRequire } from 'node:module'
 import { describe, expect, it } from 'vitest'
 import {
   requireWindowsReleaseSigning,
   windowsPackageInvocation,
   windowsSigningArgs,
 } from '../scripts/package-win'
+
+interface SchemaNode {
+  readonly $ref?: string
+  readonly anyOf?: readonly SchemaNode[]
+  readonly properties?: Readonly<Record<string, SchemaNode>>
+}
+
+const requireFromTests = createRequire(import.meta.url)
+const schema = requireFromTests(
+  requireFromTests.resolve('app-builder-lib/scheme.json', {
+    paths: [requireFromTests.resolve('electron-builder')],
+  }),
+) as { readonly definitions: Readonly<Record<string, SchemaNode>> }
+
+function referencedDefinition(node: SchemaNode): SchemaNode | undefined {
+  const reference = node.$ref ?? node.anyOf?.find(branch => branch.$ref !== undefined)?.$ref
+  return reference === undefined ? undefined : schema.definitions[reference.replace('#/definitions/', '')]
+}
+
+/**
+ * Assert that a `--config.<path>` option exists in the installed Electron Builder schema.
+ *
+ * `WindowsConfiguration` sets `additionalProperties: false`, so an option that
+ * the schema does not declare fails validation before any build work and takes
+ * the whole `win` object down with it. Comparing against the real schema keeps
+ * these arguments honest across Electron Builder upgrades, which is what an
+ * expected-array assertion cannot do.
+ * @param path - Dotted option path with the `--config.` prefix removed.
+ */
+function assertSchemaOption(path: string): void {
+  const [root, ...rest] = path.split('.')
+  expect(root).toBe('win')
+  let definition = schema.definitions['WindowsConfiguration']!
+  rest.forEach((segment, index) => {
+    const property = definition.properties?.[segment]
+    if (property === undefined) {
+      throw new Error(`Electron Builder has no option '${rest.slice(0, index + 1).join('.')}' under win`)
+    }
+    const next = referencedDefinition(property)
+    if (next !== undefined) definition = next
+    else if (index !== rest.length - 1) {
+      throw new Error(`Electron Builder option 'win.${rest.slice(0, index + 1).join('.')}' has no nested options`)
+    }
+  })
+}
 
 const signingEnvironment: NodeJS.ProcessEnv = {
   AZURE_TENANT_ID: 'tenant-id',
@@ -26,7 +72,6 @@ describe('Windows Azure signing configuration', () => {
       '--config.win.azureSignOptions.codeSigningAccountName', 'signing-account',
       '--config.win.azureSignOptions.certificateProfileName', 'certificate-profile',
       '--config.win.azureSignOptions.publisherName', 'CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US',
-      '--config.win.publisherName', 'CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US',
     ])
   })
 
@@ -56,6 +101,27 @@ describe('Windows Azure signing configuration', () => {
   })
 })
 
+describe('Electron Builder option names', () => {
+  const certificateEnvironment: NodeJS.ProcessEnv = {
+    WIN_CSC_LINK: 'certificate.p12',
+    WIN_CSC_KEY_PASSWORD: 'password',
+    WINDOWS_SIGNING_PUBLISHER_NAME: 'CN=Example Publisher, O=Example Publisher',
+  }
+
+  it('emits only options the installed Electron Builder schema declares', () => {
+    for (const environment of [signingEnvironment, certificateEnvironment]) {
+      const options = windowsSigningArgs(environment).filter(argument => argument.startsWith('--config.'))
+      expect(options.length).toBeGreaterThan(0)
+      for (const option of options) assertSchemaOption(option.slice('--config.'.length))
+    }
+  })
+
+  it('rejects an option the schema does not declare', () => {
+    expect(() => { assertSchemaOption('win.publisherName') })
+      .toThrow("Electron Builder has no option 'publisherName' under win")
+  })
+})
+
 describe('Windows tagged-release signing', () => {
   it('rejects an unsigned tagged release', () => {
     expect(() => requireWindowsReleaseSigning({})).toThrow('Windows release signing is not configured')
@@ -70,7 +136,7 @@ describe('Windows tagged-release signing', () => {
 
     expect(requireWindowsReleaseSigning(environment)).toBe('CN=Example Publisher, O=Example Publisher')
     expect(windowsSigningArgs(environment)).toEqual([
-      '--config.win.publisherName', 'CN=Example Publisher, O=Example Publisher',
+      '--config.win.signtoolOptions.publisherName', 'CN=Example Publisher, O=Example Publisher',
     ])
   })
 
@@ -111,7 +177,6 @@ describe('Windows package invocation', () => {
       '--config.win.azureSignOptions.codeSigningAccountName', 'signing-account',
       '--config.win.azureSignOptions.certificateProfileName', 'certificate-profile',
       '--config.win.azureSignOptions.publisherName', 'CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US',
-      '--config.win.publisherName', 'CN=Example Publisher, O=Example Publisher, L=Redmond, S=WA, C=US',
     ])
   })
 


### PR DESCRIPTION
## Related Issue

No issue — this is a live release failure. The `desktop-v0.2.1` tag build failed on both platforms ([run 32647843142](https://github.com/PyModel/pythinker-code/actions/runs/32647843142)), leaving `v0.2.1` as an empty draft with no installers.

## Problem

**Windows** — the job passes `--config.win.publisherName`. Electron Builder 26 removed that option in favour of `signtoolOptions.publisherName`, and `WindowsConfiguration` sets `additionalProperties: false`, so the unknown key invalidates the whole `win` object:

```
⨯ Invalid configuration object. electron-builder 26.15.3 ...
 - configuration.win should be one of these:
   null
```

The build dies during schema validation, before packaging. This path had never run in CI: it only emits those flags when Windows signing is configured, and the `AZURE_*` secrets were set for the first time today. The unit tests compared the generated argument array against a hand-written expected array, so they encoded the bug rather than catching it.

**macOS** — the verify step runs `xcrun stapler validate` against the `.dmg`. Electron Builder notarizes and staples the `.app`, then packs the already-stapled bundle into the disk image; the image itself never receives a ticket, so that assertion can never pass. Notarization had actually succeeded — the same run logged `source=Notarized Developer ID` for the mounted bundle immediately before failing.

## What changed

- `windowsSigningArgs` drops the duplicate publisher argument on the Azure path (the publisher is already carried in `azureSignOptions.publisherName`) and moves the certificate path to `--config.win.signtoolOptions.publisherName`.
- The macOS verify step validates the staple on the app inside the disk image instead of on the image.
- `package-win.spec.ts` now resolves the installed `app-builder-lib/scheme.json` through `electron-builder` and walks every emitted `--config.win.*` path against it, so an option Electron Builder does not declare fails the suite instead of the release. No new dependency. Verified by reintroducing `--config.win.publisherName`: 3 tests fail with `Electron Builder has no option 'publisherName' under win`; restored, 16 pass.

## Verification

- `pnpm exec vitest run tests/package-win.spec.ts` — 16 passed
- `pnpm run typecheck` (apps/desktop) — clean, both tsconfigs
- `oxlint --type-aware` on the touched files — 0 warnings, 0 errors
- `scripts/check-no-comments.mjs` — OK
- Reproduced the original failure locally with the exact flags, and confirmed the corrected flags validate and reach `signing with Azure Trusted Signing`

## Checklist

- [x] I have read the CONTRIBUTING document.
- [ ] I have linked a related issue — none; this fixes a live release failure.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset — no changeset: release-pipeline verification only, nothing users can perceive, and `desktop-v0.2.1` is being re-cut at the same version.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release validation by checking the signed application within the mounted disk image.
  * Updated Windows signing configuration to correctly support certificate-based and Azure signing options.

* **Tests**
  * Added validation to ensure Windows signing settings match supported configuration options.
  * Expanded coverage for valid signing configurations and rejection of unsupported options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->