### PR TITLE
test(desktop): validate release arguments against the Electron Builder schema

### DIFF
--- a/apps/desktop/tests/package-win.spec.ts
+++ b/apps/desktop/tests/package-win.spec.ts
@@ -6,49 +6,72 @@ import {
   windowsSigningArgs,
 } from '../scripts/package-win'
 
-interface SchemaNode {
-  readonly $ref?: string
-  readonly anyOf?: readonly SchemaNode[]
-  readonly properties?: Readonly<Record<string, SchemaNode>>
-}
+type JsonObject = Record<string, unknown>
 
 const requireFromTests = createRequire(import.meta.url)
-const schema = requireFromTests(
-  requireFromTests.resolve('app-builder-lib/scheme.json', {
-    paths: [requireFromTests.resolve('electron-builder')],
-  }),
-) as { readonly definitions: Readonly<Record<string, SchemaNode>> }
+const electronBuilderPath = requireFromTests.resolve('electron-builder')
+const schema: unknown = requireFromTests(
+  requireFromTests.resolve('app-builder-lib/scheme.json', { paths: [electronBuilderPath] }),
+)
+const Ajv = requireFromTests(requireFromTests.resolve('ajv', { paths: [electronBuilderPath] })) as {
+  readonly default: new (options: JsonObject) => {
+    compile: (schema: unknown) => ((data: unknown) => boolean) & { errors?: readonly { instancePath: string, keyword: string, message?: string, params: JsonObject }[] }
+  }
+}
+// The same Ajv settings app-builder-lib validates a release configuration with,
+// so a configuration this accepts is one Electron Builder accepts.
+const validateConfiguration = new Ajv.default({
+  allErrors: true,
+  verbose: true,
+  coerceTypes: true,
+  strict: false,
+}).compile(schema)
 
-function referencedDefinition(node: SchemaNode): SchemaNode | undefined {
-  const reference = node.$ref ?? node.anyOf?.find(branch => branch.$ref !== undefined)?.$ref
-  return reference === undefined ? undefined : schema.definitions[reference.replace('#/definitions/', '')]
+const baseConfiguration = (requireFromTests('../package.json') as { readonly build: JsonObject }).build
+
+/**
+ * Apply generated `--config.<path> <value>` arguments to the packaged build configuration.
+ * @param args - Arguments as they reach Electron Builder.
+ * @returns The configuration Electron Builder would validate.
+ */
+function configurationFrom(args: readonly string[]): JsonObject {
+  const configuration = structuredClone(baseConfiguration)
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]!
+    if (!argument.startsWith('--config.')) continue
+    const path = argument.slice('--config.'.length).split('.')
+    let node = configuration
+    for (const key of path.slice(0, -1)) {
+      node[key] ??= {}
+      node = node[key] as JsonObject
+    }
+    node[path.at(-1)!] = args[index + 1]
+    index += 1
+  }
+  return configuration
 }
 
 /**
- * Assert that a `--config.<path>` option exists in the installed Electron Builder schema.
+ * Assert Electron Builder would accept the configuration these arguments produce.
  *
- * `WindowsConfiguration` sets `additionalProperties: false`, so an option that
- * the schema does not declare fails validation before any build work and takes
- * the whole `win` object down with it. Comparing against the real schema keeps
- * these arguments honest across Electron Builder upgrades, which is what an
- * expected-array assertion cannot do.
- * @param path - Dotted option path with the `--config.` prefix removed.
+ * Comparing generated arguments against a hand-written array cannot tell that
+ * the arguments are invalid — both copies carry the same mistake. Electron
+ * Builder validates the merged configuration before it packages anything, so
+ * running that same validation here fails in the suite instead of at the tag.
+ * @param args - Arguments as they reach Electron Builder.
  */
-function assertSchemaOption(path: string): void {
-  const [root, ...rest] = path.split('.')
-  expect(root).toBe('win')
-  let definition = schema.definitions['WindowsConfiguration']!
-  rest.forEach((segment, index) => {
-    const property = definition.properties?.[segment]
-    if (property === undefined) {
-      throw new Error(`Electron Builder has no option '${rest.slice(0, index + 1).join('.')}' under win`)
-    }
-    const next = referencedDefinition(property)
-    if (next !== undefined) definition = next
-    else if (index !== rest.length - 1) {
-      throw new Error(`Electron Builder option 'win.${rest.slice(0, index + 1).join('.')}' has no nested options`)
-    }
-  })
+function assertConfigurationAccepted(args: readonly string[]): void {
+  if (validateConfiguration(configurationFrom(args))) return
+  const errors = validateConfiguration.errors ?? []
+  const unknown = errors
+    .filter(error => error.keyword === 'additionalProperties')
+    .map(error => `${error.instancePath}.${String(error.params['additionalProperty'])}`)
+  if (unknown.length > 0) throw new Error(`Electron Builder rejects unknown options: ${unknown.join(', ')}`)
+  // anyOf/type noise follows every real error; the specific keywords name the cause.
+  const specific = errors.filter(error => error.keyword !== 'anyOf' && error.keyword !== 'type')
+  const reported = (specific.length > 0 ? specific : errors)
+    .map(error => `${error.instancePath === '' ? 'configuration' : error.instancePath} ${error.message ?? 'is invalid'}`)
+  throw new Error(`Electron Builder rejects the configuration: ${[...new Set(reported)].join('; ')}`)
 }
 
 const signingEnvironment: NodeJS.ProcessEnv = {
@@ -101,24 +124,28 @@ describe('Windows Azure signing configuration', () => {
   })
 })
 
-describe('Electron Builder option names', () => {
+describe('Electron Builder configuration', () => {
   const certificateEnvironment: NodeJS.ProcessEnv = {
     WIN_CSC_LINK: 'certificate.p12',
     WIN_CSC_KEY_PASSWORD: 'password',
     WINDOWS_SIGNING_PUBLISHER_NAME: 'CN=Example Publisher, O=Example Publisher',
   }
 
-  it('emits only options the installed Electron Builder schema declares', () => {
+  it('accepts the packaged configuration on its own', () => {
+    expect(() => { assertConfigurationAccepted([]) }).not.toThrow()
+  })
+
+  it('accepts the configuration every signing method produces', () => {
     for (const environment of [signingEnvironment, certificateEnvironment]) {
-      const options = windowsSigningArgs(environment).filter(argument => argument.startsWith('--config.'))
-      expect(options.length).toBeGreaterThan(0)
-      for (const option of options) assertSchemaOption(option.slice('--config.'.length))
+      const args = windowsSigningArgs(environment)
+      expect(args.length).toBeGreaterThan(0)
+      expect(() => { assertConfigurationAccepted(args) }).not.toThrow()
     }
   })
 
-  it('rejects an option the schema does not declare', () => {
-    expect(() => { assertSchemaOption('win.publisherName') })
-      .toThrow("Electron Builder has no option 'publisherName' under win")
+  it('rejects an option Electron Builder has removed', () => {
+    expect(() => { assertConfigurationAccepted(['--config.win.publisherName', 'CN=Example Publisher']) })
+      .toThrow('Electron Builder rejects unknown options: /win.publisherName')
   })
 })
 


### PR DESCRIPTION
## Related Issue

No issue — follow-up hardening for the release failure fixed in #167.

## Problem

The `desktop-v0.2.1` build died at Electron Builder's schema validation on `--config.win.publisherName`, an option removed in v26. The suite was green throughout, because `package-win.spec.ts` compared the generated argument array to a hand-written expected array. Both copies carried the same mistake, so the test only detected *change*, never *invalidity* — Google's "change-detector test".

The consequence is structural, not incidental: these arguments are only emitted when signing secrets are present, so a tag build is the first time they ever execute. A test that cannot judge them means the release is the first judge.

## What changed

`package-win.spec.ts` now merges the generated `--config.*` arguments onto the packaged `build` configuration and validates the result with Ajv against the installed `app-builder-lib/scheme.json`, using the same Ajv options `app-builder-lib` itself validates with (`allErrors`, `verbose`, `coerceTypes`, `strict: false`).

- **No new dependency.** Both `scheme.json` and `ajv` resolve through the existing `electron-builder` dependency (pnpm hides them from a direct resolve out of `apps/desktop`, so resolution is anchored at `require.resolve('electron-builder')`).
- **Follows the installed version.** It reads whatever schema the pinned Electron Builder ships, so a future major that relocates these options fails here rather than at a tag.
- Failure output is trimmed to the actionable errors instead of Ajv's verbose dump.

Three cases: the packaged configuration alone, the configuration each signing method produces, and a negative case pinning the exact regression.

## Verification

Mutation-tested, both caught:

| Mutation | Result |
|---|---|
| Reintroduce `--config.win.publisherName` | 3 failed — `Electron Builder rejects unknown options: /win.publisherName` |
| Drop required `azureSignOptions.certificateProfileName` | 3 failed — `must have required property 'certificateProfileName'` |
| Restored | 17 passed |

The second case is a class the previous test could not detect at all.

- `pnpm exec vitest run tests/package-win.spec.ts` — 17 passed
- `pnpm run typecheck` (apps/desktop) — clean, both tsconfigs
- `oxlint --type-aware` — 0 warnings, 0 errors
- `scripts/check-no-comments.mjs` — OK

## Checklist

- [x] I have read the CONTRIBUTING document.
- [ ] I have linked a related issue — none; follow-up to #167.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset — no changeset: test-only, nothing users can perceive.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of desktop package configurations against the Electron Builder schema.
  * Added coverage for base configurations, signing modes, invalid options, and removed settings.
  * Enhanced error reporting for unknown or invalid configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->