### PR TITLE
ci: make a manual desktop run rehearse the signing gates

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -184,9 +184,10 @@ jobs:
             echo 'No macOS signing certificate configured; building unsigned.'
           fi
 
-      # A tag build that quietly produces an unsigned app is worse than a failed
+      # A build that quietly produces an unsigned app is worse than a failed
       # one: macOS rejects unsigned updates, so it ships a release users cannot
-      # install or update from. Manual runs stay free to build unsigned.
+      # install or update from. Manual runs are held to the same bar, which is
+      # what makes them a rehearsal rather than a smoke test.
       - name: Require signing
         working-directory: apps/desktop
         run: node --import tsx scripts/assert-release-signing.ts
@@ -316,9 +317,9 @@ jobs:
         working-directory: apps/desktop
         run: node --import tsx scripts/stage-runtime.ts
 
-      # Only non-empty WIN_CSC_* signing secrets are exported. Without them,
-      # Windows artifacts are unsigned and installers trigger a SmartScreen
-      # warning on first run.
+      # Only non-empty WIN_CSC_* signing secrets are exported. Without them the
+      # artifacts are unsigned and installers trigger a SmartScreen warning, so
+      # the credential check below fails the run rather than shipping one.
       - name: Resolve Windows signing credentials
         shell: bash
         env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -12,6 +12,11 @@ concurrency:
   group: desktop-release-${{ github.ref }}
   cancel-in-progress: false
 
+# A manual run is a release rehearsal: both platforms build and go through the
+# same signing gates a tag does, with nothing published and the installers
+# attached to the run instead. Only the release-repo steps stay tag-gated, so a
+# credential that has expired or a configuration Electron Builder no longer
+# accepts surfaces on demand rather than on the tag that needed it.
 jobs:
   # Create one draft before either platform uploads. It stays private until both
   # jobs and the final downloaded-asset validation succeed.
@@ -182,8 +187,7 @@ jobs:
       # A tag build that quietly produces an unsigned app is worse than a failed
       # one: macOS rejects unsigned updates, so it ships a release users cannot
       # install or update from. Manual runs stay free to build unsigned.
-      - name: Require signing for tagged releases
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
+      - name: Require signing
         working-directory: apps/desktop
         run: node --import tsx scripts/assert-release-signing.ts
 
@@ -206,7 +210,6 @@ jobs:
           node --import tsx apps/desktop/scripts/verify-update-manifest.ts mac apps/desktop/dist "$DESKTOP_VERSION"
 
       - name: Verify macOS signatures and notarization
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
         shell: bash
         run: |
           set -euo pipefail
@@ -347,8 +350,7 @@ jobs:
             if [ -n "$value" ]; then printf '%s<<%s\n%s\n%s\n' "$name" "$delimiter" "$value" "$delimiter" >> "$GITHUB_ENV"; fi
           done
 
-      - name: Require signing for tagged Windows releases
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
+      - name: Require signing
         working-directory: apps/desktop
         run: node --import tsx scripts/assert-windows-release-signing.ts
 
@@ -366,7 +368,6 @@ jobs:
           node --import tsx apps/desktop/scripts/verify-update-manifest.ts win apps/desktop/dist "$DESKTOP_VERSION"
 
       - name: Verify Windows release signatures
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
         working-directory: apps/desktop
         run: node --import tsx scripts/verify-windows-signatures.ts
 

--- a/apps/desktop/tests/desktop-release-workflow.spec.ts
+++ b/apps/desktop/tests/desktop-release-workflow.spec.ts
@@ -41,6 +41,24 @@ describe('desktop release workflow', () => {
     expect(workflow).toContain("if: startsWith(github.ref, 'refs/tags/desktop-v')\n        shell: bash\n        env:\n          GH_TOKEN:")
   })
 
+  it('runs every signing gate on a manual rehearsal, not only on a tag', () => {
+    // A manual run is the only chance to prove the signing path before the tag
+    // that depends on it. Gating these behind the tag would make a rehearsal
+    // pass while the credentials it was meant to exercise were already broken.
+    const rehearsed = [
+      'scripts/assert-release-signing.ts',
+      'scripts/assert-windows-release-signing.ts',
+      'scripts/verify-windows-signatures.ts',
+      'xcrun stapler validate',
+    ]
+    for (const step of rehearsed) {
+      const stepIndex = workflow.indexOf(step)
+      expect(stepIndex).toBeGreaterThan(-1)
+      const precedingStep = workflow.lastIndexOf('      - name:', stepIndex)
+      expect(workflow.slice(precedingStep, stepIndex)).not.toContain('refs/tags/desktop-v')
+    }
+  })
+
   it('downloads and revalidates uploaded assets before publishing', () => {
     expect(workflow).toContain('gh release download "$RELEASE_TAG"')
     expect(workflow).toContain('scripts/verify-update-manifest.ts mac release-assets')

--- a/apps/desktop/tests/desktop-release-workflow.spec.ts
+++ b/apps/desktop/tests/desktop-release-workflow.spec.ts
@@ -55,7 +55,11 @@ describe('desktop release workflow', () => {
       const stepIndex = workflow.indexOf(step)
       expect(stepIndex).toBeGreaterThan(-1)
       const precedingStep = workflow.lastIndexOf('      - name:', stepIndex)
-      expect(workflow.slice(precedingStep, stepIndex)).not.toContain('refs/tags/desktop-v')
+      // Any condition at all, not just a tag test, would skip one trigger:
+      // `github.event_name == 'workflow_dispatch'` reintroduces the same hole
+      // from the other side. These steps must be unconditional.
+      const declaration = workflow.slice(precedingStep, stepIndex)
+      expect(declaration).not.toMatch(/^\s+if:/mu)
     }
   })
 


### PR DESCRIPTION
## Related Issue

No issue — third and last hardening item from the `desktop-v0.2.1` release failure (#167, #168).

## Problem

`Desktop Release` already supports `workflow_dispatch`, and both platforms already build with `--publish never`, so a manual run is safe. But every signing gate is tag-gated:

- `Require signing for tagged releases` (mac)
- `Verify macOS signatures and notarization`
- `Require signing for tagged Windows releases`
- `Verify Windows release signatures`

So a manual run skipped precisely the steps worth rehearsing. Those checks first executed on the tag that depended on them — which is how `desktop-v0.2.1` burned two builds: an electron-builder option removed in v26, and a `stapler validate` aimed at the `.dmg` instead of the `.app`. Both were findable in a rehearsal; there was no rehearsal that could find them.

## What changed

The four verification steps lose their `if:`. Everything touching the releases repository stays tag-gated:

| Stays tag-gated | Now runs on a rehearsal |
|---|---|
| `Require the tagged commit to be on main` | `Require signing` (mac + win) |
| `Mint releases-repo token` (×3) | `Verify macOS signatures and notarization` |
| `Create the draft release unless it already exists` | `Verify Windows release signatures` |
| `Upload verified {macOS,Windows} release assets` | |
| `publish` job | |

A manual run is now the whole release path minus publication, with installers attached to the run. Run it before any `desktop-v*` tag:

```
gh workflow run "Desktop Release" --ref main
```

It also closes the last untested corner: `packageManagerInvocation` adds literal quotes on Windows for values containing spaces, and until now only a tag build ever exercised that with a real publisher name.

## Verification

A test pins the arrangement, since re-adding one `if:` would restore the hole without breaking anything visible.

| | |
|---|---|
| Restore the tag gate on the Windows credential check | `× runs every signing gate on a manual rehearsal, not only on a tag` |
| Restored | 9 passed |

- `pnpm exec vitest run` (apps/desktop) — 155 passed, 14 files
- `pnpm run typecheck` — clean, both tsconfigs
- `oxlint --type-aware`, `check-no-comments.mjs` — clean

## Checklist

- [x] I have read the CONTRIBUTING document.
- [ ] I have linked a related issue — none; follow-up to #167 / #168.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset — no changeset: CI-only, nothing users can perceive.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Manual release rehearsals now run macOS and Windows signing and signature verification without publishing releases.
  * Release creation, asset uploads, and publishing remain limited to tagged releases.

* **Tests**
  * Updated workflow coverage to ensure signing and signature verification always run during rehearsals, without conditional gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->