### PR TITLE
ci: stop the release job re-running the test suite before it pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,21 @@ on:
     branches:
       - main
 
+# Never cancel a release in flight: a publish that is interrupted between npm
+# and the git tags cannot be undone. Runs therefore queue instead. GitHub keeps
+# only one pending run per group, so a third push while a release is running
+# silently drops the one waiting behind it — the commits still ship, on the
+# next run, but nothing announces the skip. Keeping this job short is what
+# keeps that window small.
 concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+# This repository installs a local pre-push gate that re-runs the full test
+# suite. It exists to save a CI round trip from a developer's machine; inside
+# CI it is pure duplication, and `scripts/pre-push.sh` reads this to stand
+# down. Set at the workflow level so it reaches every push, including the ones
+# a JS action spawns.
+env:
+  SKIP_HOOKS: "1"
 
 jobs:
   # Publishing to npm is irreversible — never let a commit that fails CI or
@@ -93,6 +107,32 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # The `prepare` script reinstalls the local hooks during the install
+      # above, so this has to run after it, not before. `SKIP_HOOKS` already
+      # tells the hook to stand down; deleting it as well removes the last way
+      # the suite could run inside this job — an environment that reaches the
+      # hook scrubbed, or a hook that stops honouring the variable.
+      #
+      # Worth the belt and braces: on the publish path, the push these hooks
+      # would gate carries the version tags, and it runs after npm has already
+      # accepted the packages. A hook failure there — one flaky test under
+      # runner load is enough — leaves the release published but untagged, and
+      # skips every job that depends on it: docs, native artifacts, the VS Code
+      # extension, the Homebrew tap, the CDN.
+      - name: Disarm the local git hooks
+        run: |
+          # `--git-path hooks` is git's own resolution of core.hooksPath, so
+          # this deletes from the directory git will actually read rather than
+          # assuming `.git/hooks`.
+          hooks_dir=$(git rev-parse --git-path hooks)
+          rm -f "${hooks_dir}/pre-push" "${hooks_dir}/pre-commit"
+          if [ -e "${hooks_dir}/pre-push" ] || [ -e "${hooks_dir}/pre-commit" ]; then
+            echo "::error::A git hook survived removal in ${hooks_dir}."
+            echo "::error::The release push would re-run the full test suite; fix this before releasing."
+            exit 1
+          fi
+          echo "Local git hooks disarmed (${hooks_dir})."
 
       - name: Generate Pythinker Code built-in catalog
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
   SKIP_HOOKS: "1"
 
+# Fail closed: a job gets no token scope it does not ask for, so the repository
+# or organisation default can never quietly hand write access to a job that
+# only reads. Every job below grants itself exactly what it needs.
+permissions: {}
+
 jobs:
   # Publishing to npm is irreversible — never let a commit that fails CI or
   # Nix Build ship. Those workflows run in parallel on the same push, so this
@@ -126,7 +131,7 @@ jobs:
           # this deletes from the directory git will actually read rather than
           # assuming `.git/hooks`.
           hooks_dir=$(git rev-parse --git-path hooks)
-          rm -f "${hooks_dir}/pre-push" "${hooks_dir}/pre-commit"
+          rm -f -- "${hooks_dir}/pre-push" "${hooks_dir}/pre-commit"
           if [ -e "${hooks_dir}/pre-push" ] || [ -e "${hooks_dir}/pre-commit" ]; then
             echo "::error::A git hook survived removal in ${hooks_dir}."
             echo "::error::The release push would re-run the full test suite; fix this before releasing."
@@ -418,6 +423,8 @@ jobs:
   redeploy-cdn:
     timeout-minutes: 10
     name: Redeploy CDN
+    # Posts to a webhook with a secret; it never touches the GitHub API.
+    permissions: {}
     needs:
       - release
       - publish-native-assets
@@ -493,6 +500,9 @@ jobs:
   verify-cdn-release:
     timeout-minutes: 20
     name: Verify release consistency
+    # Checkout only; verify-release-consistency.mjs uses no GitHub token.
+    permissions:
+      contents: read
     needs:
       - release
       - redeploy-cdn
@@ -525,6 +535,9 @@ jobs:
 
   update-brew-tap:
     timeout-minutes: 15
+    # Checkout only; the tap push uses a minted app token, not this one.
+    permissions:
+      contents: read
     name: Update Homebrew tap
     needs: release
     if: needs.release.outputs.packages_published == 'true'
@@ -575,6 +588,10 @@ jobs:
   native-artifacts:
     name: Native release artifact
     needs: release
+    # Matches the `contents: read` that _native-build.yml declares for itself;
+    # a called workflow cannot exceed what the calling job grants.
+    permissions:
+      contents: read
     if: needs.release.outputs.pythinker_native_release == 'true'
     uses: ./.github/workflows/_native-build.yml
     with:


### PR DESCRIPTION
## Related Issue

No issue — this came out of the release run for `98c0121cd`, which failed on its push to `changeset-release/main`.

## Problem

`pnpm install` runs `prepare: simple-git-hooks`, which reinstalls this repo's local pre-push gate **inside the release job**. Every `git push` the changesets action makes therefore re-ran the whole suite in CI: 20,387 tests, 1030 seconds, on a commit CI had already tested — `wait-for-checks` blocks the job on exactly that.

That is what failed the last run. The push held its lease for the full 17 minutes and was rejected:

```
! [remote rejected] HEAD -> changeset-release/main
  (cannot lock ref 'refs/heads/changeset-release/main': is at faf98e82a but expected bf1c7266c)
```

That instance was harmless — the branch already had the right content from the run before it. The publish path is not. There, the same push carries the version tags and runs **after** npm has already accepted the packages. One flaky test under runner load, or the 30-minute job timeout, would leave a published release untagged and skip every job that depends on it: docs, native artifacts, the VS Code extension, the Homebrew tap, the CDN. The failed run already demonstrated that skip cascade.

The job also sat at 21 of its 30 allotted minutes, almost all of it re-running tests.

## What changed

Two independent layers, because either alone has a gap:

- **`SKIP_HOOKS: "1"` at the workflow level.** `scripts/pre-push.sh` reads it and stands down. Set on the workflow rather than a step so it reaches the pushes a JS action spawns, and so it survives a hook being reinstalled.
- **Deleting the hooks after install, with a check.** This does not depend on the environment surviving that hop. It runs *after* `pnpm install`, because install is what puts the hooks back. It resolves the directory with `git rev-parse --git-path hooks` — git's own resolution of `core.hooksPath` — rather than assuming `.git/hooks`, and fails the job if a hook is still present afterwards.

Also documented the `concurrency` behaviour that shaped this: not cancelling in-progress runs is deliberate (never interrupt a publish), but GitHub holds only one pending run per group, so a third push while a release is running silently drops the one queued behind it. A short release job is what keeps that window small — which matters more now that the release PR can merge on a cadence.

Verified the guard against a default hooks dir, a custom `core.hooksPath`, and a mutation where removal is defeated — the last one fails the step, as intended. `shellcheck` clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works. (The step verifies its own effect and fails the job if a hook survives; checked locally against a default hooks dir, a custom `core.hooksPath`, and a mutation that defeats the removal.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened release automation by applying least-privilege permissions by default.
  * Added explicit read-only permissions where required for release verification, CDN redeployment, Homebrew updates, and native artifacts.
  * Improved safety when removing release-related Git hooks by handling paths securely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->