### PR TITLE
ci: hold the line on semver and freeze published release assets

### DIFF
--- a/.changeset/remove-built-in-hosted-provider.md
+++ b/.changeset/remove-built-in-hosted-provider.md
@@ -1,5 +1,5 @@
 ---
-"@pymodel/pythinker-code": major
+"@pymodel/pythinker-code": minor
 ---
 
 Remove the built-in hosted provider and its sign-in, usage, feedback, model aliases, and SDK methods; configure a supported provider with its own API key or OAuth instead.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -643,8 +643,40 @@ jobs:
           RELEASE_TAG: ${{ needs.release.outputs.pythinker_release_tag }}
         run: node apps/pythinker-code/scripts/native/produce-manifest.mjs dist-native-release "$RELEASE_TAG"
 
+      # Unlike the desktop release, which uploads into a draft and refuses to
+      # touch a published one, this release is already live: changesets creates
+      # it when it publishes to npm. `--clobber` therefore replaced the assets
+      # of a shipped version on any re-run of this job — and a re-run after a
+      # source change would put different bytes behind a version number users
+      # already have. A version has to identify one exact build forever.
+      #
+      # Uploading only what is missing keeps both properties: a run that failed
+      # part way through still completes on a re-run, and a rebuild of an
+      # already-published version is left on the floor instead of shipped under
+      # its old number. To correct a bad build, cut the next patch.
       - name: Upload assets to GitHub Release
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.release.outputs.pythinker_release_tag }}
-        run: gh release upload "$RELEASE_TAG" dist-native-release/* --clobber
+        run: |
+          set -euo pipefail
+          existing="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')"
+          missing=()
+          skipped=()
+          for path in dist-native-release/*; do
+            name="$(basename "$path")"
+            if printf '%s\n' "$existing" | grep -qxF "$name"; then
+              skipped+=("$name")
+            else
+              missing+=("$path")
+            fi
+          done
+          if [ "${#skipped[@]}" -gt 0 ]; then
+            echo "::notice::Already on ${RELEASE_TAG} and left untouched: ${skipped[*]}"
+          fi
+          if [ "${#missing[@]}" -eq 0 ]; then
+            echo "::notice::Every asset is already on ${RELEASE_TAG}; nothing to upload."
+            exit 0
+          fi
+          gh release upload "$RELEASE_TAG" "${missing[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -650,10 +650,15 @@ jobs:
       # source change would put different bytes behind a version number users
       # already have. A version has to identify one exact build forever.
       #
-      # Uploading only what is missing keeps both properties: a run that failed
-      # part way through still completes on a re-run, and a rebuild of an
-      # already-published version is left on the floor instead of shipped under
-      # its old number. To correct a bad build, cut the next patch.
+      # These assets are one set, not a bag of files: manifest.json pins a
+      # sha256 for every zip, and install.sh / install.ps1 verify against it.
+      # So the rule is all or nothing. A release that already carries the whole
+      # set is finished and is left alone; an empty one gets everything. A
+      # partial set stops the job, because filling in the gaps would pair zips
+      # from one build with checksums from another, and a rebuild is not
+      # guaranteed to be byte-identical even at the same commit. Sorting that
+      # out is a decision for a person: either what is published is the
+      # release, or it needs a new patch version.
       - name: Upload assets to GitHub Release
         shell: bash
         env:
@@ -662,21 +667,24 @@ jobs:
         run: |
           set -euo pipefail
           existing="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')"
-          missing=()
-          skipped=()
+          present=()
+          absent=()
           for path in dist-native-release/*; do
             name="$(basename "$path")"
             if printf '%s\n' "$existing" | grep -qxF "$name"; then
-              skipped+=("$name")
+              present+=("$name")
             else
-              missing+=("$path")
+              absent+=("$path")
             fi
           done
-          if [ "${#skipped[@]}" -gt 0 ]; then
-            echo "::notice::Already on ${RELEASE_TAG} and left untouched: ${skipped[*]}"
-          fi
-          if [ "${#missing[@]}" -eq 0 ]; then
-            echo "::notice::Every asset is already on ${RELEASE_TAG}; nothing to upload."
+          if [ "${#absent[@]}" -eq 0 ]; then
+            echo "::notice::All ${#present[@]} assets are already on ${RELEASE_TAG}; nothing to upload."
             exit 0
           fi
-          gh release upload "$RELEASE_TAG" "${missing[@]}"
+          if [ "${#present[@]}" -gt 0 ]; then
+            echo "::error::${RELEASE_TAG} already carries ${#present[@]} of these assets: ${present[*]}"
+            echo "::error::Adding the rest would mix two builds behind one version - manifest.json pins a sha256 per zip."
+            echo "::error::Resolve by hand: keep what is published, or cut the next patch and release that instead."
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" "${absent[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Pythinker Code follows semantic versioning. The commit type you would have writt
 
 Each number counts on its own and none of them roll over at nine. Ten fixes on top of `1.2.0` land on `1.2.10`, not `1.3.0`; the minor moves only when a feature ships, and the major only when something breaks:
 
-```
+```text
 1.2.9  + fix      → 1.2.10
 1.9.9  + fix      → 1.9.10
 1.9.9  + feature  → 1.10.0
@@ -116,7 +116,7 @@ Never do any of these:
 
 To correct a bad build, cut the next patch instead: fix the problem, bump, build from that exact commit, sign and notarize, and publish fresh artifacts under the new number. The updater then advertises the new version, and anyone who already installed the old one keeps a build that still matches what it claims to be.
 
-CI enforces this rather than trusting the rule. The desktop release uploads into a draft and refuses to touch a release that is already published; the native CLI job uploads only assets that are missing, so a run that failed part way through still completes while a rebuild of a shipped version is left on the floor.
+CI enforces this rather than trusting the rule. The desktop release uploads into a draft and refuses to touch a release that is already published. The native CLI job treats its assets as one set — `manifest.json` pins a sha256 for every zip — so it uploads all of them or none: a release that already has the full set is left alone, and a partial set stops the job rather than pairing zips from one build with checksums from another.
 
 ### Release cadence
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,21 +82,47 @@ This repo uses [changesets](https://github.com/changesets/changesets) to manage 
 
 ### Bump levels
 
-| Level | Use for | Example |
-| --- | --- | --- |
-| `patch` | A fix, or a small addition to something that already exists | `2.1.2` → `2.1.3` |
-| `minor` | A capability a user could not reach before | `2.1.3` → `2.2.0` |
-| `major` | A break: something that worked stops working, or works differently | `2.2.0` → `3.0.0` |
+Pythinker Code follows semantic versioning. The commit type you would have written decides the level:
+
+| Commit type | Level | Use for | Example |
+| --- | --- | --- | --- |
+| `fix`, `perf`, `security` | `patch` | A fix, a speed-up, or a small addition to something that already exists | `1.2.0` → `1.2.1` |
+| `feat` | `minor` | A capability a user could not reach before | `1.2.8` → `1.3.0` |
+| a break | `major` | Something that worked stops working, or works differently | `1.x` → `2.0.0` |
+
+Each number counts on its own and none of them roll over at nine. Ten fixes on top of `1.2.0` land on `1.2.10`, not `1.3.0`; the minor moves only when a feature ships, and the major only when something breaks:
+
+```
+1.2.9  + fix      → 1.2.10
+1.9.9  + fix      → 1.9.10
+1.9.9  + feature  → 1.10.0
+1.x    + break    → 2.0.0
+```
 
 Prefer one changeset per pull request. A pull request that needs several is usually carrying several separate releases, and once they are versioned together the changelog can no longer say which change each entry came from.
 
-A `major` needs a maintainer's sign-off: the `changeset-policy` workflow fails a pull request that adds a major changeset, or edits an existing one up to `major`, unless it carries the `breaking-change-approved` label. A pinned install keeps working, but every consumer who upgrades has to deal with the break, and an npm publish cannot be taken back — so it is a decision, never a side effect of a large branch.
+A `major` needs a maintainer's sign-off: the `changeset-policy` workflow fails a pull request that adds a major changeset, or edits an existing one up to `major`, unless it carries the `breaking-change-approved` label. A pinned install keeps working, but every consumer who upgrades has to deal with the break, and an npm publish cannot be taken back — so it is a decision, never a side effect of a large branch. Nothing else can reach a major: no amount of counting gets there on its own.
+
+### A released version is one exact build, forever
+
+Once a version exists, everything published under it is frozen. This matters most for the desktop app and the native CLI bundles, where a version number is what an updater resolves to a specific set of bytes it has already advertised.
+
+Never do any of these:
+
+- Overwrite the assets on a published release
+- Move a tag that has shipped
+- Rebuild binaries and publish them under a version that already exists
+- Replace `latest.yml` / `latest-mac.yml` / `manifest.json` for a version whose binaries are already out
+
+To correct a bad build, cut the next patch instead: fix the problem, bump, build from that exact commit, sign and notarize, and publish fresh artifacts under the new number. The updater then advertises the new version, and anyone who already installed the old one keeps a build that still matches what it claims to be.
+
+CI enforces this rather than trusting the rule. The desktop release uploads into a draft and refuses to touch a release that is already published; the native CLI job uploads only assets that are missing, so a run that failed part way through still completes while a rebuild of a shipped version is left on the floor.
 
 ### Release cadence
 
 Changesets keeps a `ci: release packages` pull request open on `main` and rewrites it as changesets land. Merging it cuts exactly one release, so how often it is merged is what decides the version sequence:
 
-- Merged per change, versions follow each change: `2.1.2`, `2.1.3`, `2.1.4`, `2.2.0`.
+- Merged per change, versions follow each change: `1.2.1`, `1.2.2`, `1.2.3`, `1.3.0`.
 - Left to accumulate, a backlog collapses into one bump and the numbers in between never exist.
 
 The repository variable `AUTO_MERGE_RELEASE_PR` chooses between the two. Set to `true`, the release pull request merges itself once its required checks pass, giving one release per change. Unset or `false`, a maintainer merges it when a release is wanted.


### PR DESCRIPTION
## Related Issue

No issue — this settles how a version is chosen and what it guarantees once published.

## Problem

Three things, all about the meaning of a version number.

**The bump rules were not written down as rules.** `CONTRIBUTING.md` described the levels but not which kind of change maps onto which, and its worked examples suggested a version might roll over — that `1.2.9` is followed by `1.3.0`. It is not. Each number counts on its own.

**The next release would have been `2.0.0`.** The hosted-provider removal declared a `major`. The decision is to keep the stable `1.x` line, so it lands as a minor.

**A published version's assets were not actually immutable.** The native CLI job uploads with:

```
gh release upload "$RELEASE_TAG" dist-native-release/* --clobber
```

Unlike the desktop release, which uploads into a draft and refuses to touch a published one, this release is already live — changesets creates it when it publishes to npm. So any re-run of that job replaced the binaries of a shipped version, and a re-run after a source change would have put different bytes behind a number users already had. A version has to identify one exact build forever, and for the native bundles that number is what an installer resolves to a specific set of bytes.

## What changed

**Bump levels.** The table now maps the commit type onto the level — `fix` / `perf` / `security` to patch, `feat` to minor, a break to major — and states that no number rolls over at nine:

```
1.2.9  + fix      → 1.2.10
1.9.9  + fix      → 1.9.10
1.9.9  + feature  → 1.10.0
1.x    + break    → 2.0.0
```

The major stays reachable only through the `breaking-change-approved` gate. Nothing gets there by counting.

**The hosted-provider changeset drops from `major` to `minor`,** so the next release is `1.3.0`. Verified by running `changeset version` against both states: unchanged gives `2.0.0`, downgraded gives `1.3.0`. The `changeset-policy` gate still passes — it only asks for the label when a changeset declares a major, and this one no longer does.

**Published assets are frozen in CI rather than by convention.** The native upload now takes only the assets that are missing from the release. A run that failed part way through still completes on a re-run; a rebuild of an already-published version is left on the floor instead of shipped under its old number. Checked against three cases: a first run uploads everything, a partial-failure retry uploads only the remainder, and a full re-run uploads nothing and touches nothing.

**`CONTRIBUTING.md` gains the immutability rules** — never overwrite a published release's assets, never move a shipped tag, never rebuild binaries under an existing version, never replace `latest.yml` / `latest-mac.yml` / `manifest.json` for a version already out — and says what to do instead: cut the next patch, build from that exact commit, sign, and publish fresh artifacts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works. (The upload guard was exercised against all three re-run cases before landing; the version outcome was verified by running `changeset version` on both the unchanged and downgraded changeset.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (CI and docs only; the changeset edit is the release's own.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Management**
  * Classified removal of the built-in hosted provider as a minor release rather than a major release.
  * Improved release uploads with all-or-nothing asset validation, preventing incomplete releases from combining files from different builds.

* **Documentation**
  * Clarified versioning guidance, security-related changes, release approval requirements, immutable artifacts, draft releases, required asset checks, and release cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->