### PR TITLE
fix: make desktop release shell explicit

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -171,6 +171,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Configure desktop release
+        shell: bash
         env:
           DESKTOP_CHANNEL: ${{ needs.prepare.outputs.channel }}
           DESKTOP_VERSION: ${{ needs.prepare.outputs.version }}
@@ -355,6 +356,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Configure desktop release
+        shell: bash
         env:
           DESKTOP_CHANNEL: ${{ needs.prepare.outputs.channel }}
           DESKTOP_VERSION: ${{ needs.prepare.outputs.version }}

--- a/scripts/release/release-workflows.test.mjs
+++ b/scripts/release/release-workflows.test.mjs
@@ -8,8 +8,10 @@ const read = (path) => readFileSync(resolve(root, path), 'utf8');
 
 void test('desktop releases configure both platforms with Bash', () => {
   const workflow = read('.github/workflows/desktop-release.yml');
-  const configuredWithBash = workflow.match(/^      - name: Configure desktop release\n        shell: bash$/gmu);
-  assert.equal(configuredWithBash?.length ?? 0, 2);
+  const configuredWithBash = /^      - name: Configure desktop release\n        shell: bash$/mu;
+  const windowsStart = workflow.indexOf('\n  windows:');
+  assert.match(workflow.slice(workflow.indexOf('\n  mac:'), windowsStart), configuredWithBash);
+  assert.match(workflow.slice(windowsStart, workflow.indexOf('\n  publish:', windowsStart)), configuredWithBash);
 });
 
 void test('release workflow uses full push-boundary lane signals and isolated jobs', () => {

--- a/scripts/release/release-workflows.test.mjs
+++ b/scripts/release/release-workflows.test.mjs
@@ -6,6 +6,12 @@ import test from 'node:test';
 const root = resolve(import.meta.dirname, '../..');
 const read = (path) => readFileSync(resolve(root, path), 'utf8');
 
+void test('desktop releases configure both platforms with Bash', () => {
+  const workflow = read('.github/workflows/desktop-release.yml');
+  const configuredWithBash = workflow.match(/^      - name: Configure desktop release\n        shell: bash$/gmu);
+  assert.equal(configuredWithBash?.length ?? 0, 2);
+});
+
 void test('release workflow uses full push-boundary lane signals and isolated jobs', () => {
   const workflow = read('.github/workflows/release.yml');
   const desktopJob = workflow.slice(


### PR DESCRIPTION
## Related Issue

No tracking issue — this is maintainer-side recovery for [Desktop Release run 32870712954](https://github.com/PyModel/pythinker-code/actions/runs/32870712954).

## Problem

The desktop release workflow passed Bash-style `$DESKTOP_VERSION` and `$DESKTOP_CHANNEL` variables to an implicit shell. macOS uses Bash by default, but Windows uses PowerShell, which expanded both values to empty strings. The Windows release stopped at package configuration and left `v0.3.0` as an unpublished draft.

Actionlint did not catch the mismatch because the Windows step did not declare Bash.

## What changed

- Declare `shell: bash` on both macOS and Windows desktop package configuration steps.
- Add a release workflow regression test that requires both declarations.

This keeps the change on the two affected steps. Signing, artifact verification, and atomic publishing remain fail-closed and unchanged.

## Verification

- RED on `origin/main`: release workflow test failed with `0 !== 2`.
- `pnpm run test:release` — 20/20 passed.
- Actionlint 1.7.12 — passed.
- `pnpm run lint` — 0 errors.
- `pnpm run sherif` — passed.
- `pnpm run typecheck` — passed.
- `pnpm test` — 1,216 files and 20,343 tests passed.
- Security and internal-identifier review — no findings.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue — none; this is maintainer-side release infrastructure.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` — no changeset; this CI/test-only fix does not change the shipped CLI.
- [x] Ran `gen-docs` — no user-facing documentation change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of desktop releases on macOS and Windows by ensuring release configuration steps run consistently with Bash.

- **Tests**
  - Added coverage to verify Bash is configured correctly for both macOS and Windows desktop release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->