### PR TITLE
chore(desktop): prepare 0.3.1 release

### DIFF
--- a/.changeset/restore-desktop-downloads.md
+++ b/.changeset/restore-desktop-downloads.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-desktop": patch
+---
+
+Restore downloadable desktop releases for macOS and Windows.


### PR DESCRIPTION
## Related Issue

No tracking issue — this is maintainer-side recovery for the unpublished desktop `v0.3.0` draft.

## Problem

The immutable `desktop-v0.3.0` tag points to the release commit whose Windows build failed. The corrected workflow is now on `main`, but the desktop version remains `0.3.0`, so release automation cannot cut a new tag.

## What changed

- Add a confirmed patch changeset for `@pymodel/pythinker-desktop`.
- Schedule desktop `0.3.1` so the Changesets version PR can create a new immutable release boundary.

This PR does not change application code, move the failed tag, or publish a release. Merging the generated version PR remains a separate, explicit publication decision.

## Verification

- `changeset status` — only `@pymodel/pythinker-desktop` receives a patch bump.
- Major changeset policy self-test — 19 cases passed.
- Major changeset policy against `origin/main` — no new major changeset.
- Pre-push-equivalent gates — Sherif, lint with 0 errors, web assets, Nix hash, no affected typecheck packages, and no affected tests.
- Internal-identifier audit — no findings.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] No related issue is required for this maintainer-directed release recovery.
- [x] Tests are not required for changeset-only release metadata; the affected-test gate found no tests.
- [x] Ran `gen-changesets`; this PR contains the confirmed desktop patch changeset.
- [x] Ran `gen-docs`; no documentation update is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored downloadable desktop releases for macOS and Windows.
  * Included a patch release for the desktop application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->