### PR TITLE
ci(desktop): notarize and staple the macOS DMG

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -236,6 +236,31 @@ jobs:
         working-directory: apps/desktop
         run: pnpm exec electron-builder --mac dmg zip --publish never
 
+      # electron-builder notarizes and staples the .app but never the disk
+      # image around it. A quarantined, unnotarized DMG is what Gatekeeper
+      # reports as "damaged" on some macOS builds, so give the image its own
+      # ticket and staple it. The API key is preferred; the Apple ID +
+      # app-specific password pair is the fallback, mirroring electron-builder.
+      - name: Notarize and staple macOS DMG
+        shell: bash
+        run: |
+          set -euo pipefail
+          dmg_path="$(find apps/desktop/dist -maxdepth 1 -type f -name '*.dmg' -print -quit)"
+          if [ -z "$dmg_path" ]; then
+            echo 'macOS DMG not found' >&2
+            exit 1
+          fi
+          if [ -n "${APPLE_API_KEY:-}" ]; then
+            auth=(--key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER")
+          elif [ -n "${APPLE_ID:-}" ]; then
+            auth=(--apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID")
+          else
+            echo 'No notarization credentials configured; the DMG cannot be notarized.' >&2
+            exit 1
+          fi
+          xcrun notarytool submit "$dmg_path" "${auth[@]}" --wait --timeout 30m
+          xcrun stapler staple "$dmg_path"
+
       - name: Verify macOS update artifacts
         shell: bash
         env:
@@ -293,12 +318,13 @@ jobs:
             exit 1
           fi
           verify_app "$dmg_app"
-          # electron-builder notarizes and staples the .app, then packs the
-          # already-stapled bundle into the disk image; the image itself never
-          # receives a ticket. Validate the staple where it actually lives.
           xcrun stapler validate "$dmg_app"
           cleanup_mount
           trap - EXIT
+          # The image carries its own ticket (see the notarize step above);
+          # Gatekeeper must accept it exactly as a user's browser download.
+          xcrun stapler validate "$dmg_path"
+          spctl --assess --type open --context context:primary-signature --verbose=2 "$dmg_path"
 
       - name: Mint releases-repo token
         if: needs.prepare.outputs.publish == 'true'


### PR DESCRIPTION
## Problem
Users downloading `Pythinker-0.3.1-arm64.dmg` from the site see **"Pythinker.app is damaged and can't be opened"**. The app bundle inside is signed, notarized and stapled, but the DMG itself only carries a Developer ID signature: `spctl --assess --type open` reports `rejected, Unnotarized Developer ID`. Gatekeeper on recent macOS surfaces that for quarantined browser downloads as "damaged".

## What changed
- New `Notarize and staple macOS DMG` step: `xcrun notarytool submit --wait` (API key preferred, Apple ID fallback — the same credentials electron-builder already uses) then `stapler staple` the image.
- The verification step now also runs `stapler validate` and `spctl --assess --type open --context context:primary-signature` **on the DMG**, so a release can no longer ship an unnotarized image. Checked locally: this gate fails on the current 0.3.1 DMG.

[skip changeset] — CI-only, no user-visible package change.