### PR TITLE
chore(desktop): bump to 0.3.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Problem
Desktop 0.3.1 shipped an unnotarized DMG that macOS reports as "Pythinker.app is damaged". #194 fixed the release pipeline; a new version is needed to ship it.

## What changed
`apps/desktop/package.json` 0.3.1 → 0.3.2. After merge, tag `desktop-v0.3.2` on the merge commit to cut the release.

[skip changeset] — desktop app versions are not managed by changesets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application to version 0.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->