### PR TITLE
ci(desktop): finalize the DMG with the tested release script

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -237,29 +237,13 @@ jobs:
         run: pnpm exec electron-builder --mac dmg zip --publish never
 
       # electron-builder notarizes and staples the .app but never the disk
-      # image around it. A quarantined, unnotarized DMG is what Gatekeeper
-      # reports as "damaged" on some macOS builds, so give the image its own
-      # ticket and staple it. The API key is preferred; the Apple ID +
-      # app-specific password pair is the fallback, mirroring electron-builder.
+      # image around it; a quarantined, unnotarized DMG is what Gatekeeper
+      # reports as "damaged". Stapling changes the DMG bytes, so the same
+      # script also rewrites its latest-mac.yml entry and drops the stale
+      # blockmap, keeping the update manifest verification below honest.
       - name: Notarize and staple macOS DMG
-        shell: bash
-        run: |
-          set -euo pipefail
-          dmg_path="$(find apps/desktop/dist -maxdepth 1 -type f -name '*.dmg' -print -quit)"
-          if [ -z "$dmg_path" ]; then
-            echo 'macOS DMG not found' >&2
-            exit 1
-          fi
-          if [ -n "${APPLE_API_KEY:-}" ]; then
-            auth=(--key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER")
-          elif [ -n "${APPLE_ID:-}" ]; then
-            auth=(--apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID")
-          else
-            echo 'No notarization credentials configured; the DMG cannot be notarized.' >&2
-            exit 1
-          fi
-          xcrun notarytool submit "$dmg_path" "${auth[@]}" --wait --timeout 30m
-          xcrun stapler staple "$dmg_path"
+        working-directory: apps/desktop
+        run: node --import tsx scripts/finalize-mac-artifacts.ts dist
 
       - name: Verify macOS update artifacts
         shell: bash

--- a/apps/desktop/scripts/finalize-mac-artifacts.ts
+++ b/apps/desktop/scripts/finalize-mac-artifacts.ts
@@ -10,7 +10,8 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs'
-import { basename, join } from 'node:path'
+import { basename, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { resolveNotarizationCredentials } from './release-preflight'
 
 export interface CommandResult {
@@ -190,4 +191,16 @@ export function finalizeMacArtifacts(options: FinalizeMacArtifactsOptions): void
   }
 
   writeFileSync(metadataPath, metadata)
+}
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  const distDir = process.argv[2]
+  try {
+    if (distDir === undefined) throw new Error('Usage: finalize-mac-artifacts.ts <dist-directory>')
+    finalizeMacArtifacts({ distDir: resolve(distDir), env: process.env })
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
 }


### PR DESCRIPTION
## Problem
`desktop-v0.3.2` failed at **Verify macOS update artifacts**: `Pythinker-0.3.2-arm64.dmg size does not match latest-mac.yml`. The notarize step from #194 stapled the DMG after electron-builder had written the manifest, so size/sha512 (and the `.dmg.blockmap`) went stale. Notarization itself succeeded.

## What changed
- The workflow now runs `apps/desktop/scripts/finalize-mac-artifacts.ts` (already used by `dist:mac`, covered by `tests/finalize-mac-artifacts.spec.ts`): notarytool submit → staple → rewrite the DMG entry in `latest-mac.yml` → drop the stale blockmap (full download instead of differential; the zip still has its blockmap).
- Added a CLI entry to that script (`finalize-mac-artifacts.ts <dist-dir>`), same pattern as the other release scripts.
- Removed the hand-written shell step it replaces. The DMG-level `stapler validate` + `spctl --type open` gate stays.

After merge, `desktop-v0.3.2` will be re-tagged on the merge commit (0.3.2 was never published).

[skip changeset] — CI-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS release artifact finalization, including notarization and stapling.
  - Updated release manifests automatically and removed stale blockmap files.
  - Improved error handling so release failures are reported clearly and return a failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->