### PR TITLE
chore(desktop): bump version to 0.3.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Problem
Desktop 0.3.2 errors when switching back to the Stable update channel (#197, merged). The fix only ships with a new desktop tag.

## Changes
- Bump `apps/desktop/package.json` to 0.3.3 so `desktop-v0.3.3` can be tagged after merge.

[skip changeset]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application to version 0.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->