### PR TITLE
chore(desktop): bump version to 0.3.4

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Problem
The responsive desktop UI fixes (#198) landed after desktop 0.3.3 was tagged, so no shipped build has them.

## Changes
- Bump `apps/desktop/package.json` to 0.3.4 so `desktop-v0.3.4` can be tagged after merge.

[skip changeset]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application to version 0.3.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->