### PR TITLE
chore(desktop): bump version to 0.3.5

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Related Issue

N/A — maintainer desktop release task.

## Problem

The prompt anchor and sidebar branding changes from #201 are on `main`, but the current Stable desktop release is still 0.3.4.

## What changed

- Bump the private desktop package version from 0.3.4 to 0.3.5.
- Let the existing release workflow cut `desktop-v0.3.5` after merge and start the signed macOS and Windows release.

## Validation

- `pnpm test:release` — 20 passed
- `pnpm exec vitest run apps/desktop/tests` — 168 passed
- Desktop `tsc` and `tsgo` checks passed
- `pnpm lint` — 0 errors

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] This is a maintainer release task; no related issue is required.
- [x] Existing release and desktop tests cover this version signal.
- [x] Ran `gen-changesets`; no changeset is needed for the private desktop-only version bump.
- [x] No documentation update is needed because behavior and usage do not change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the desktop application to version 0.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->