### PR TITLE
chore(desktop): bump version to 0.3.6

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Related Issue

Direct release request; no GitHub issue.

## Problem

Desktop Stable remains at 0.3.5. Release v0.3.6 needs a new immutable artifact set.

## What changed

Bump the private desktop package to 0.3.6. The existing release lane detects the version change, cuts `desktop-v0.3.6` from merged main, then publishes stable macOS and Windows artifacts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (direct release request; no issue exists).
- [x] Ran existing desktop and release-path tests; no production logic changed.
- [x] Ran `gen-changesets` skill; this private desktop lane needs no changeset.
- [x] This PR needs no documentation update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application to version 0.3.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->