### PR TITLE
fix(agent-core-v2): adopt the replayed turn outcome on restore

### DIFF
--- a/.changeset/restore-reconciles-turn-outcome.md
+++ b/.changeset/restore-reconciles-turn-outcome.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Fix a resumed session showing a stale "manually stopped" or failed state when its last turn had actually completed.

--- a/packages/agent-core-v2/src/session/sessionActivity/sessionOutcomeMirrorService.ts
+++ b/packages/agent-core-v2/src/session/sessionActivity/sessionOutcomeMirrorService.ts
@@ -129,6 +129,11 @@ export class SessionOutcomeMirror extends Disposable implements ISessionOutcomeM
       this.write(undefined, { touchUpdatedAt: false });
       return;
     }
+    const replayed = replayedOutcome(lastEnded.reason);
+    if (replayed !== undefined && replayed !== this.lastPersisted) {
+      this.write(replayed, { touchUpdatedAt: false, turnId: lastEnded.turnId });
+      return;
+    }
     if (this.lastPersistedTurnId === undefined) this.lastPersistedTurnId = lastEnded.turnId;
   }
 
@@ -164,3 +169,9 @@ registerScopedService(
   ScopeActivation.OnScopeCreated,
   'sessionActivity',
 );
+
+function replayedOutcome(reason: TurnEnded['reason']): SessionTurnOutcome | undefined {
+  if (reason === 'completed') return 'completed';
+  if (reason === 'failed' || reason === 'blocked') return 'failed';
+  return undefined;
+}

--- a/packages/agent-core-v2/test/session/sessionActivity/sessionOutcomeMirror.test.ts
+++ b/packages/agent-core-v2/test/session/sessionActivity/sessionOutcomeMirror.test.ts
@@ -371,6 +371,79 @@ describe('SessionOutcomeMirror (Session scope)', () => {
     expect(writes).toEqual([]);
   });
 
+  const restoredSession = (
+    id: string,
+    persisted: SessionMeta['lastTurnReason'],
+    lastEnded: FakeAgentLifecycle['lastEnded'],
+  ) => {
+    const scope = host.child(LifecycleScope.Session, id, [
+      stubPair(ISessionMetadata, {
+        read: async () => ({ lastTurnReason: persisted }) as SessionMeta,
+        update: async (
+          patch: { lastTurnReason?: SessionMeta['lastTurnReason'] },
+          uopts?: { touchUpdatedAt?: boolean },
+        ) => {
+          writes.push(patch.lastTurnReason);
+          touches.push(uopts?.touchUpdatedAt !== false);
+        },
+      } as unknown as ISessionMetadata),
+    ]);
+    const scopeLifecycle = scope.accessor.get(IAgentLifecycleService) as unknown as FakeAgentLifecycle;
+    scope.accessor.get(ISessionOutcomeMirror);
+    scopeLifecycle.addMain();
+    scopeLifecycle.lastEnded = lastEnded;
+    return scopeLifecycle;
+  };
+
+  it('replaces a stale persisted outcome with the replayed completed turn', async () => {
+    const restored = restoredSession('session-restored-completed', 'cancelled', {
+      turnId: 3,
+      reason: 'completed',
+      durationMs: 5,
+    });
+    await tick();
+    for (const hook of restored.restoreHooks) await hook(undefined, async () => {});
+    expect(writes).toEqual(['completed']);
+    expect(touches).toEqual([false]);
+  });
+
+  it('maps a replayed blocked turn onto the persisted failed outcome', async () => {
+    const restored = restoredSession('session-restored-blocked', 'completed', {
+      turnId: 3,
+      reason: 'blocked',
+      durationMs: 5,
+    });
+    await tick();
+    for (const hook of restored.restoreHooks) await hook(undefined, async () => {});
+    expect(writes).toEqual(['failed']);
+    expect(touches).toEqual([false]);
+  });
+
+  it('keeps the persisted outcome when the replayed turn was cancelled', async () => {
+    const restored = restoredSession('session-restored-cancelled', 'completed', {
+      turnId: 3,
+      reason: 'cancelled',
+      durationMs: 5,
+    });
+    await tick();
+    for (const hook of restored.restoreHooks) await hook(undefined, async () => {});
+    expect(writes).toEqual([]);
+  });
+
+  it('tracks the replayed turn for the undo range after a restore reconcile', async () => {
+    const restored = restoredSession('session-restored-undo', 'cancelled', {
+      turnId: 3,
+      reason: 'completed',
+      durationMs: 5,
+    });
+    await tick();
+    for (const hook of restored.restoreHooks) await hook(undefined, async () => {});
+    restored.bus.publish(new ContextUndone({ agentId: 'main', turns: 1, fromTurnId: 4 }));
+    expect(writes).toEqual(['completed']);
+    restored.bus.publish(new ContextUndone({ agentId: 'main', turns: 1, fromTurnId: 3 }));
+    expect(writes).toEqual(['completed', undefined]);
+  });
+
   it('reattaches when the main agent is disposed and recreated', async () => {
     lifecycle.addMain();
     await tick();


### PR DESCRIPTION
## Related Issue

Follow-up to #213, from the review discussion on `reconcileAfterRestore`.

## Problem

`SessionOutcomeMirror` persists the last turn outcome (`completed` / `failed` / `cancelled`) into the session metadata. On restore it only reconciled one stale case: a persisted outcome with no ended turn on the replayed wire. If the persisted value itself went stale — the async metadata write never landed before shutdown — a session whose last turn had actually completed still resumed showing "manually stopped" (or a failed badge), because the replayed wire had an ended turn and the reconcile kept whatever was on disk.

## What changed

- `sessionOutcomeMirrorService.ts`: after restore, when the replayed `lastEnded` reason is unambiguous, adopt it with `touchUpdatedAt: false` and track its turn id for the undo range check: `completed` → `completed`, `failed` / `blocked` → `failed`. A replayed `cancelled` is deliberately left alone: the wire carries no `interruptReason`, so it cannot distinguish a user stop from a programmatic abort, and only user stops are ever persisted.
- Tests: stale `cancelled` replaced by replayed `completed`; replayed `blocked` maps to `failed`; replayed `cancelled` keeps the persisted `completed`; the adopted turn id feeds the undo range check.

## Verification

- `pnpm --filter @pymodel/agent-core-v2 exec vitest run` — 347 files, 5,723 tests passed
- `typecheck`, `tsgo`, `lint:imports`, `check-no-comments`, oxlint on the changed files — all exit 0

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
