### PR TITLE
chore(desktop): bump version to 0.3.7

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pymodel/pythinker-desktop",
   "description": "Pythinker desktop application with tray-owned Host lifecycle",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
## Related Issue

None — routine desktop version bump.

## Problem

The desktop app version stayed at 0.3.6, so a new desktop release cannot be tagged and shipped to update clients.

## What changed

Bumped `apps/desktop/package.json` from `0.3.6` to `0.3.7`. The desktop app is `private` and its version moves through an explicit commit, the same way as PRs #205, #203, and #200. Version-only change, no user-visible code change. [skip changeset]

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application version to 0.3.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->