### PR TITLE
chore: release the removed web flag as a minor bump

### DIFF
--- a/.changeset/drop-allow-remote-terminals.md
+++ b/.changeset/drop-allow-remote-terminals.md
@@ -1,5 +1,5 @@
 ---
-"@pymodel/pythinker-code": major
+"@pymodel/pythinker-code": minor
 ---
 
 Remove the `--allow-remote-terminals` flag from `pythinker web`; PTY terminal routes now stay available on loopback binds only.


### PR DESCRIPTION
## Related Issue

None — release version policy.

## Problem

The pending release PR (#193) resolves to `@pymodel/pythinker-code@2.0.0` because `drop-allow-remote-terminals.md` carries a `major` bump. We do not want to spend the 2.0.0 version on this change.

## What changed

Changed that changeset from `major` to `minor`. The release PR regenerates from `.changeset/` on `main`, so the next release becomes `1.4.0` instead of `2.0.0`. The changelog sentence stays the same, so users still read that the flag is gone.

Note the trade-off: removing a CLI flag under a minor bump gives users no major-version signal. Anyone passing `--allow-remote-terminals` to `pythinker web` still gets a clear error, and PTY terminal routes remain available on loopback binds.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. [skip changeset]
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `--allow-remote-terminals` option.
  * PTY terminal routes are now available only when bound to loopback addresses.

* **Release**
  * Reclassified the package update from a major to a minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->