### PR TITLE
fix(telemetry): report every region to the one telemetry host

### DIFF
--- a/apps/pythinker-code/src/utils/region.ts
+++ b/apps/pythinker-code/src/utils/region.ts
@@ -9,12 +9,15 @@ export interface PythinkerRegionProfile {
   readonly telemetryEndpoint: string;
 }
 
+// Pythinker runs a single telemetry host, so every region reports to it.
+const TELEMETRY_ENDPOINT = 'https://telemetry-logs.pythinker.com/v1/event';
+
 const PROFILES: Record<PythinkerRegion, PythinkerRegionProfile> = {
   'mainland-cn': {
-    telemetryEndpoint: 'https://telemetry-logs.pythinker.com/v1/event',
+    telemetryEndpoint: TELEMETRY_ENDPOINT,
   },
   global: {
-    telemetryEndpoint: 'https://telemetry-logs.pythinker.ai/v1/event',
+    telemetryEndpoint: TELEMETRY_ENDPOINT,
   },
 };
 

--- a/packages/agent-core-v2/src/app/telemetry/cloudAppender.ts
+++ b/packages/agent-core-v2/src/app/telemetry/cloudAppender.ts
@@ -84,10 +84,6 @@ export class CloudAppender implements ITelemetryAppender {
       storage: options.storage,
       deviceId: options.deviceId,
       endpoint: options.endpoint,
-      homeDir: options.bootstrap.homeDir,
-      readMarker:
-        (options.bootstrap.getEnv('PYTHINKER_CODE_REGION_MARKER') ??
-          process.env['PYTHINKER_CODE_REGION_MARKER']) !== 'off',
       getAccessToken: options.getAccessToken,
       fetchImpl: options.fetchImpl,
       retryBackoffsMs: options.retryBackoffsMs,

--- a/packages/agent-core-v2/src/app/telemetry/cloudTransport.ts
+++ b/packages/agent-core-v2/src/app/telemetry/cloudTransport.ts
@@ -1,6 +1,4 @@
 import { randomBytes } from 'node:crypto';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
 import { isAbortError } from '#/_base/utils/abort';
 import type { IFileSystemStorageService } from '#/persistence/interface/storage';
@@ -33,8 +31,6 @@ export interface CloudTransportOptions {
   readonly storage: IFileSystemStorageService;
   readonly deviceId: string;
   readonly endpoint?: string;
-  readonly homeDir?: string;
-  readonly readMarker?: boolean;
   readonly getAccessToken?: () => string | null | Promise<string | null>;
   readonly fetchImpl?: typeof fetch;
   readonly retryBackoffsMs?: readonly number[];
@@ -50,24 +46,12 @@ export const DISK_EVENT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export const RETRY_BACKOFFS_MS = [1_000, 4_000, 16_000] as const;
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
-const GLOBAL_TELEMETRY_ENDPOINT = 'https://telemetry-logs.pythinker.ai/v1/event';
 const TELEMETRY_SCOPE = 'telemetry';
 const FAILED_PREFIX = 'failed_';
 const JSONL_SUFFIX = '.jsonl';
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
-
-function defaultTelemetryEndpoint(homeDir?: string, readMarker = true): string {
-  if (!readMarker || homeDir === undefined) return TELEMETRY_ENDPOINT;
-  try {
-    return readFileSync(join(homeDir, 'region'), 'utf8').trim() === 'global'
-      ? GLOBAL_TELEMETRY_ENDPOINT
-      : TELEMETRY_ENDPOINT;
-  } catch {
-    return TELEMETRY_ENDPOINT;
-  }
-}
 
 export class CloudTransport {
   private readonly storage: IFileSystemStorageService;
@@ -83,7 +67,7 @@ export class CloudTransport {
   constructor(options: CloudTransportOptions) {
     this.storage = options.storage;
     this.deviceId = options.deviceId;
-    this.endpoint = options.endpoint ?? defaultTelemetryEndpoint(options.homeDir, options.readMarker);
+    this.endpoint = options.endpoint ?? TELEMETRY_ENDPOINT;
     this.getAccessToken = options.getAccessToken ?? null;
     this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
     this.retryBackoffsMs = options.retryBackoffsMs ?? RETRY_BACKOFFS_MS;

--- a/packages/agent-core-v2/test/app/telemetry/cloudAppender.test.ts
+++ b/packages/agent-core-v2/test/app/telemetry/cloudAppender.test.ts
@@ -111,33 +111,12 @@ describe('CloudAppender', () => {
     expect(typeof event?.['timestamp']).toBe('number');
   });
 
-  it('reads the install marker from the bootstrapped home for the default endpoint', async () => {
+  it('reports to the single telemetry host whatever the install marker says', async () => {
     writeFileSync(join(homeDir, 'region'), 'global\n');
     const requests: CapturedRequest[] = [];
     const appender = new CloudAppender(
       baseOptions({
         homeDir,
-        fetchImpl: makeFetch((req) => {
-          requests.push(req);
-          return okResponse();
-        }),
-      }),
-    );
-
-    appender.track('tool.call', { name: 'bash' });
-    await appender.flush();
-
-    expect(requests).toHaveLength(1);
-    expect(requests[0]?.url).toBe('https://telemetry-logs.pythinker.ai/v1/event');
-  });
-
-  it('honors the marker opt-out from the bootstrap env bag (no process.env needed)', async () => {
-    writeFileSync(join(homeDir, 'region'), 'global\n');
-    const requests: CapturedRequest[] = [];
-    const appender = new CloudAppender(
-      baseOptions({
-        homeDir,
-        bootstrapEnv: { PYTHINKER_CODE_REGION_MARKER: 'off' },
         fetchImpl: makeFetch((req) => {
           requests.push(req);
           return okResponse();
@@ -150,33 +129,6 @@ describe('CloudAppender', () => {
 
     expect(requests).toHaveLength(1);
     expect(requests[0]?.url).toBe('https://telemetry-logs.pythinker.com/v1/event');
-  });
-
-  it('honors PYTHINKER_CODE_REGION_MARKER=off so embedded servers ignore the install marker', async () => {
-    writeFileSync(join(homeDir, 'region'), 'global\n');
-    const savedMarkerFlag = process.env['PYTHINKER_CODE_REGION_MARKER'];
-    process.env['PYTHINKER_CODE_REGION_MARKER'] = 'off';
-    try {
-      const requests: CapturedRequest[] = [];
-      const appender = new CloudAppender(
-        baseOptions({
-          homeDir,
-          fetchImpl: makeFetch((req) => {
-            requests.push(req);
-            return okResponse();
-          }),
-        }),
-      );
-
-      appender.track('tool.call', { name: 'bash' });
-      await appender.flush();
-
-      expect(requests).toHaveLength(1);
-      expect(requests[0]?.url).toBe('https://telemetry-logs.pythinker.com/v1/event');
-    } finally {
-      if (savedMarkerFlag === undefined) delete process.env['PYTHINKER_CODE_REGION_MARKER'];
-      else process.env['PYTHINKER_CODE_REGION_MARKER'] = savedMarkerFlag;
-    }
   });
 
   it('applies setContext sessionId and model updates to subsequent events', async () => {

--- a/packages/agent-gateway/test/setup.ts
+++ b/packages/agent-gateway/test/setup.ts
@@ -10,7 +10,7 @@ process.env['PYTHINKER_CODE_EXPERIMENTAL_SEARCH_WORKER'] = 'false';
 process.env['PYTHINKER_CODE_EXPERIMENTAL_PERSISTENCE_MINIDB_READMODEL'] = 'false';
 
 const realFetch = globalThis.fetch.bind(globalThis);
-const TELEMETRY_HOSTS = new Set(['telemetry-logs.pythinker.com', 'telemetry-logs.pythinker.ai']);
+const TELEMETRY_HOSTS = new Set(['telemetry-logs.pythinker.com']);
 globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
   const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
   if (TELEMETRY_HOSTS.has(new URL(url).hostname)) {


### PR DESCRIPTION

[skip changeset] — no user-perceivable change: telemetry is invisible to users, and the affected path was already failing silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Telemetry reporting now uses a single endpoint across all regions.
  * Updated telemetry handling to consistently use the `.com` host.
  * Removed region-based telemetry opt-out behavior.
  * Updated automated checks and test configuration to reflect the unified telemetry destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->