### PR TITLE
fix(desktop): install Windows updates without the installer UI

### DIFF
--- a/.changeset/desktop-silent-windows-update.md
+++ b/.changeset/desktop-silent-windows-update.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-desktop": patch
+---
+
+Install Windows updates in the background instead of opening the installer wizard, and report an update that did not take effect.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -103,7 +103,7 @@
       ]
     },
     "nsis": {
-      "allowElevation": true,
+      "allowElevation": false,
       "allowToChangeInstallationDirectory": true,
       "artifactName": "Pythinker-${version}-${arch}-Setup.${ext}",
       "createDesktopShortcut": true,

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -59,6 +59,7 @@ export type UpdateState = {
   notifiedVersion?: string
   skippedVersion?: string
   completedVersion?: string
+  failedInstallVersion?: string
 }
 
 export type UpdateTelemetryTrack = (
@@ -129,16 +130,31 @@ function isVerifiedUpgrade(currentVersion: string, previousVersion: string | und
     && gt(currentVersion, previousVersion)
 }
 
-function reconcileStartupReceipt(value: UpdateSettings, currentVersion: string): UpdateSettings {
+/**
+ * A silent installer reports nothing back: the app quits, the installer runs
+ * hidden, and the only evidence either way is the version that comes back up.
+ * A pending receipt that does not match this launch therefore means the install
+ * did not take effect, and it has to become a visible error rather than silence.
+ */
+function reconcileStartupReceipt(
+  value: UpdateSettings,
+  currentVersion: string,
+): { settings: UpdateSettings, failedInstallVersion?: string } {
   let completedVersion = value.completedVersion === currentVersion ? value.completedVersion : undefined
+  let failedInstallVersion: string | undefined
   if (value.pendingInstallVersion === currentVersion) {
     if (isVerifiedUpgrade(currentVersion, value.lastRunVersion)) completedVersion = currentVersion
+  } else if (value.pendingInstallVersion !== undefined) {
+    failedInstallVersion = value.pendingInstallVersion
   }
   return {
-    ...value,
-    pendingInstallVersion: undefined,
-    completedVersion,
-    lastRunVersion: currentVersion,
+    settings: {
+      ...value,
+      pendingInstallVersion: undefined,
+      completedVersion,
+      lastRunVersion: currentVersion,
+    },
+    failedInstallVersion,
   }
 }
 
@@ -295,7 +311,7 @@ function scheduleChecks(): void {
 async function runCheck(): Promise<UpdateState> {
   if (checkPromise !== undefined) return checkPromise
   checkPromise = (async () => {
-    updateState({ status: 'checking', message: undefined })
+    updateState({ status: 'checking', message: undefined, failedInstallVersion: undefined })
     try {
       configureExplicitConsent()
       await autoUpdater.checkForUpdates()
@@ -329,7 +345,7 @@ function wireUpdaterEvents(): void {
   if (listenersWired) return
   try {
     autoUpdater.on('checking-for-update', () => {
-      updateState({ status: 'checking', message: undefined })
+      updateState({ status: 'checking', message: undefined, failedInstallVersion: undefined })
     })
     autoUpdater.on('update-available', applyAvailableUpdate)
     autoUpdater.on('update-not-available', () => {
@@ -389,12 +405,19 @@ export function initUpdater(
   updateTelemetryTrack = track
   const userData = app.getPath('userData')
   settings = readUpdateSettings(userData)
+  let failedInstallVersion: string | undefined
   if (app.isPackaged) {
-    settings = reconcileStartupReceipt(settings, app.getVersion())
+    const receipt = reconcileStartupReceipt(settings, app.getVersion())
+    settings = receipt.settings
+    failedInstallVersion = receipt.failedInstallVersion
     writeUpdateSettings(userData, settings)
   }
   state = {
-    status: app.isPackaged ? 'idle' : 'disabled',
+    status: app.isPackaged ? (failedInstallVersion === undefined ? 'idle' : 'error') : 'disabled',
+    message: failedInstallVersion === undefined
+      ? undefined
+      : `Update to v${failedInstallVersion} did not complete. Pythinker is still on v${app.getVersion()}.`,
+    failedInstallVersion,
     installedVersion: app.getVersion(),
     autoUpdate: settings.autoUpdate,
     channel: settings.channel,
@@ -619,7 +642,10 @@ export function installDownloadedUpdateNow(): UpdateState {
     } catch {
       // Telemetry must never delay an explicit installation.
     }
-    autoUpdater.quitAndInstall()
+    // Silent NSIS install: `--updated /S --force-run`. Without `isSilent` the
+    // assisted installer opens its wizard, and relaunch falls to
+    // `autoRunAppAfterInstall` instead of `isForceRunAfter`.
+    autoUpdater.quitAndInstall(true, true)
   } catch (error) {
     installRequestedVersion = undefined
     if (settings.pendingInstallVersion === version) {

--- a/apps/desktop/tests/packaging-config.spec.ts
+++ b/apps/desktop/tests/packaging-config.spec.ts
@@ -143,7 +143,7 @@ describe('desktop packaging configuration', () => {
   it('configures the Windows x64 NSIS installer', () => {
     expect(desktopPackage.build.win.target).toEqual([{ target: 'nsis', arch: ['x64'] }])
     expect(desktopPackage.build.nsis).toEqual({
-      allowElevation: true,
+      allowElevation: false,
       allowToChangeInstallationDirectory: true,
       artifactName: 'Pythinker-${version}-${arch}-Setup.${ext}',
       createDesktopShortcut: true,
@@ -160,7 +160,7 @@ describe('desktop packaging configuration', () => {
   it('offers an assisted installer that defaults to a per-user install', () => {
     expect(desktopPackage.build.nsis.oneClick).toBe(false)
     expect(desktopPackage.build.nsis.perMachine).toBe(false)
-    expect(desktopPackage.build.nsis.allowElevation).toBe(true)
+    expect(desktopPackage.build.nsis.allowElevation).toBe(false)
   })
 
   it('exposes desktop commands at the repository root', () => {

--- a/apps/desktop/tests/updater.spec.ts
+++ b/apps/desktop/tests/updater.spec.ts
@@ -454,6 +454,7 @@ describe('strict update consent', () => {
     expect(installLocalUpdate()).toMatchObject({ status: 'downloaded' })
     expect(installLocalUpdate()).toMatchObject({ status: 'downloaded' })
     expect(localAutoUpdater.quitAndInstall).toHaveBeenCalledOnce()
+    expect(localAutoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true)
     expect(readUpdateSettings(directory)).toMatchObject({ pendingInstallVersion: '1.2.3' })
   })
 
@@ -885,5 +886,59 @@ describe('update prompt receipts', () => {
     expect(getLocalUpdateState().completedVersion).toBeUndefined()
     expect(readLocalUpdateSettings(directory)).toMatchObject({ lastRunVersion: currentVersion })
     expect(readLocalUpdateSettings(directory).pendingInstallVersion).toBeUndefined()
+  })
+
+  it('reports a pending install that did not take effect as an error', async () => {
+    vi.resetModules()
+    const directory = temporaryDirectory()
+    writeFileSync(join(directory, 'app-update.yml'), '', 'utf8')
+    writeFileSync(
+      join(directory, 'update-settings.json'),
+      '{"autoUpdate":false,"lastRunVersion":"1.1.0","pendingInstallVersion":"1.2.0"}\n',
+      'utf8',
+    )
+    const { app: localApp } = await import('electron')
+    const {
+      getUpdateState: getLocalUpdateState,
+      initUpdater: initLocalUpdater,
+    } = await import('../src/updater')
+    vi.mocked(localApp.getPath).mockReturnValue(directory)
+    vi.mocked(localApp.getVersion).mockReturnValue('1.1.0')
+    Object.defineProperty(localApp, 'isPackaged', { configurable: true, value: true })
+    Object.defineProperty(process, 'resourcesPath', { configurable: true, value: directory })
+
+    initLocalUpdater(() => undefined)
+
+    expect(getLocalUpdateState()).toMatchObject({
+      status: 'error',
+      failedInstallVersion: '1.2.0',
+      installedVersion: '1.1.0',
+    })
+    expect(getLocalUpdateState().message).toContain('1.2.0')
+  })
+
+  it('leaves a completed install without a failure receipt', async () => {
+    vi.resetModules()
+    const directory = temporaryDirectory()
+    writeFileSync(join(directory, 'app-update.yml'), '', 'utf8')
+    writeFileSync(
+      join(directory, 'update-settings.json'),
+      '{"autoUpdate":false,"lastRunVersion":"1.1.0","pendingInstallVersion":"1.2.0"}\n',
+      'utf8',
+    )
+    const { app: localApp } = await import('electron')
+    const {
+      getUpdateState: getLocalUpdateState,
+      initUpdater: initLocalUpdater,
+    } = await import('../src/updater')
+    vi.mocked(localApp.getPath).mockReturnValue(directory)
+    vi.mocked(localApp.getVersion).mockReturnValue('1.2.0')
+    Object.defineProperty(localApp, 'isPackaged', { configurable: true, value: true })
+    Object.defineProperty(process, 'resourcesPath', { configurable: true, value: directory })
+
+    initLocalUpdater(() => undefined)
+
+    expect(getLocalUpdateState()).toMatchObject({ status: 'idle', completedVersion: '1.2.0' })
+    expect(getLocalUpdateState().failedInstallVersion).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Related Issue

No linked issue — reported directly: on Windows, **Restart to update** opened the installer wizard and asked the user to click through Next / Next / Install.

## Problem

`installDownloadedUpdateNow()` called `autoUpdater.quitAndInstall()` with no arguments. In electron-updater 6.8.9 that means `isSilent = false`, so `NsisUpdater.doInstall` spawns the setup with only `--updated` — the assisted NSIS installer UI — and relaunch falls to `autoRunAppAfterInstall` instead of `isForceRunAfter`.

A silent installer also reports nothing back, so an install that does not take effect would be invisible. The existing startup receipt proved success only.

## What changed

- **Silent install.** `quitAndInstall(true, true)` → `Pythinker-x.y.z-x64-Setup.exe --updated /S --force-run`. No window, and the app relaunches itself. Behaviourally unchanged on macOS: `MacUpdater.quitAndInstall()` takes no such flags.
- **Failure receipt.** `reconcileStartupReceipt` now returns `{ settings, failedInstallVersion }`. A pending install version that does not match the running version opens the app in `status: 'error'` with a message naming both versions; the next check clears it. Success detection is unchanged.
- **`nsis.allowElevation: false`.** Soft hardening: it stops a normally launched installer from offering the all-users path, whose per-machine installs are the only ones that still hit `UAC_RunElevated` on update. It is not a guarantee — an installer started as Administrator still offers both modes. A hard per-user policy would need a `customInstallMode` macro in `build/installer.nsh`, which is a larger decision and not part of this change.

Verified against the pinned `app-builder-lib` 26.15.3 NSIS templates rather than documentation: the assisted installer honours `/S` and only then applies `--force-run` (`installSection.nsh`), the directory the user chose is read back from the HKCU `InstallLocation` so no `/D=` is needed (`multiUser.nsh`), and elevation under `/S` is gated on an existing per-machine installation (`installer.nsi`).

Not changed: `autoDownload` stays `false` and `autoInstallOnAppQuit` stays `false`. Downloading and installing remain two deliberate user actions, and closing the app is still not consent to install.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

### Tests

`updater.spec.ts` asserted only `toHaveBeenCalledOnce()`, which passes with or without the flags. Added `toHaveBeenCalledWith(true, true)` — which also makes the eventual electron-updater v7 migration to `{ isSilent, isForceRunAfter }` explicit — plus two failure-receipt tests, and flipped the two existing `allowElevation` expectations. Reverting all three product values fails exactly 4 tests; 172 pass as shipped.

### Still to do

A Windows VM pass: install the current release into a non-default directory, then update. The invariant is that the app stays at the previously selected `InstallLocation` with no second installation under the default per-user Programs directory, and relaunches on its own after the installer finishes.
