### PR TITLE
chore(desktop): add a changeset for the 0.4.0 desktop release

### DIFF
--- a/.changeset/desktop-web-workspace-update.md
+++ b/.changeset/desktop-web-workspace-update.md
@@ -1,0 +1,5 @@
+---
+'@pymodel/pythinker-desktop': minor
+---
+
+The desktop app ships the updated web workspace: the Dynamic Workflow card with per-subagent routing details, Subagent Model Routing settings, attachment previews, panel tabs, message folding, and session permission controls.


### PR DESCRIPTION
## Summary

Adds a \`minor\` changeset for \`@pymodel/pythinker-desktop\` so the next release PR bumps the desktop app (0.3.9 → 0.4.0) alongside \`@pymodel/pythinker-code\` 1.6.0. The desktop build is cut from the monorepo at the \`desktop-v*\` tag, so it ships every web-workspace change merged in #234–#242; without its own changeset the desktop version never moves and \`desktop-release.yml\` never fires.

## Changes

- \`.changeset/desktop-web-workspace-update.md\`: one user-facing sentence, shown verbatim in the in-app updater.

## Testing

- Changeset-only change; no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated web workspace features are now available in the desktop application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->