### PR TITLE
ci: bump the desktop app with every CLI release

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release:status": "node scripts/release/release-status.mjs",
     "test:release": "node --test scripts/release/*.test.mjs",
     "version": "changeset version",
-    "version:release": "changeset version",
+    "version:release": "node scripts/release/link-desktop-changesets.mjs && changeset version",
     "publish": "pnpm run typecheck && pnpm run lint && pnpm run sherif && pnpm run test && pnpm run build && pnpm run lint:pkg && changeset publish",
     "prepare": "simple-git-hooks",
     "dev:agent-gateway": "pnpm -C apps/pythinker-code run dev:agent-gateway",

--- a/scripts/release/link-desktop-changesets.mjs
+++ b/scripts/release/link-desktop-changesets.mjs
@@ -1,0 +1,78 @@
+/**
+ * The desktop app is a shell around the CLI and the web UI, so every CLI
+ * release changes what desktop users see. Changesets only bumps a package a
+ * changeset names, and most changesets name the CLI alone, so the CLI shipped
+ * to npm while desktop stayed on its old version.
+ *
+ * This runs before `changeset version` on the release branch: every changeset
+ * that names the CLI but not the desktop app gets the desktop app added at the
+ * same bump level. The desktop changelog then carries the real entries, and
+ * `release.yml` cuts the `desktop-v*` tag from the bump it detects. Desktop
+ * keeps its own version line; this is deliberately not a `fixed` group.
+ *
+ * Idempotent: a changeset that already names the desktop app is left alone.
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const CLI_PACKAGE = '@pymodel/pythinker-code';
+export const DESKTOP_PACKAGE = '@pymodel/pythinker-desktop';
+
+const FRONTMATTER_LINE = /^(\s*)(?:"([^"]+)"|'([^']+)'|([^:'"]+?))\s*:\s*([A-Za-z]+)\s*$/u;
+
+/**
+ * Add the desktop package to one changeset when it names the CLI alone.
+ *
+ * @param source - Raw changeset file contents.
+ * @returns The rewritten source, or `null` when nothing changes.
+ */
+export function linkDesktop(source) {
+  const normalized = source.replaceAll('\r\n', '\n');
+  if (!normalized.startsWith('---\n')) return null;
+  const end = normalized.indexOf('\n---', 3);
+  if (end === -1) return null;
+  const lines = normalized.slice(4, end + 1).split('\n');
+
+  let cliLine = -1;
+  let cliLevel = null;
+  for (const [index, line] of lines.entries()) {
+    const match = FRONTMATTER_LINE.exec(line);
+    if (match === null) continue;
+    const name = match[2] ?? match[3] ?? match[4];
+    if (name === DESKTOP_PACKAGE) return null;
+    if (name === CLI_PACKAGE) {
+      cliLine = index;
+      cliLevel = match[5].toLowerCase();
+    }
+  }
+  if (cliLine === -1) return null;
+
+  lines.splice(cliLine + 1, 0, `"${DESKTOP_PACKAGE}": ${cliLevel}`);
+  return `---\n${lines.join('\n')}${normalized.slice(end + 1)}`;
+}
+
+/**
+ * Rewrite every changeset in a directory.
+ *
+ * @param dir - The `.changeset` directory.
+ * @returns The file names that changed.
+ */
+export function linkDesktopChangesets(dir) {
+  const changed = [];
+  for (const name of readdirSync(dir).toSorted()) {
+    if (!name.endsWith('.md') || name === 'README.md') continue;
+    const path = join(dir, name);
+    const next = linkDesktop(readFileSync(path, 'utf8'));
+    if (next === null) continue;
+    writeFileSync(path, next);
+    changed.push(name);
+  }
+  return changed;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const changed = linkDesktopChangesets(process.argv[2] ?? '.changeset');
+  for (const name of changed) console.log(`linked desktop bump: ${name}`);
+  console.log(`${changed.length} changeset(s) now bump ${DESKTOP_PACKAGE} alongside ${CLI_PACKAGE}.`);
+}

--- a/scripts/release/link-desktop-changesets.mjs
+++ b/scripts/release/link-desktop-changesets.mjs
@@ -15,11 +15,12 @@
 
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 export const CLI_PACKAGE = '@pymodel/pythinker-code';
 export const DESKTOP_PACKAGE = '@pymodel/pythinker-desktop';
 
-const FRONTMATTER_LINE = /^(\s*)(?:"([^"]+)"|'([^']+)'|([^:'"]+?))\s*:\s*([A-Za-z]+)\s*$/u;
+const FRONTMATTER_LINE = /^(\s*)(?:"([^"]+)"|'([^']+)'|([^:'"]+?))\s*:\s*(?:"([A-Za-z]+)"|'([A-Za-z]+)'|([A-Za-z]+))\s*$/u;
 
 /**
  * Add the desktop package to one changeset when it names the CLI alone.
@@ -36,6 +37,7 @@ export function linkDesktop(source) {
 
   let cliLine = -1;
   let cliLevel = null;
+  let cliIndent = '';
   for (const [index, line] of lines.entries()) {
     const match = FRONTMATTER_LINE.exec(line);
     if (match === null) continue;
@@ -43,12 +45,13 @@ export function linkDesktop(source) {
     if (name === DESKTOP_PACKAGE) return null;
     if (name === CLI_PACKAGE) {
       cliLine = index;
-      cliLevel = match[5].toLowerCase();
+      cliLevel = (match[5] ?? match[6] ?? match[7]).toLowerCase();
+      cliIndent = match[1];
     }
   }
   if (cliLine === -1) return null;
 
-  lines.splice(cliLine + 1, 0, `"${DESKTOP_PACKAGE}": ${cliLevel}`);
+  lines.splice(cliLine + 1, 0, `${cliIndent}"${DESKTOP_PACKAGE}": ${cliLevel}`);
   return `---\n${lines.join('\n')}${normalized.slice(end + 1)}`;
 }
 
@@ -71,7 +74,7 @@ export function linkDesktopChangesets(dir) {
   return changed;
 }
 
-if (process.argv[1] !== undefined && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const changed = linkDesktopChangesets(process.argv[2] ?? '.changeset');
   for (const name of changed) console.log(`linked desktop bump: ${name}`);
   console.log(`${changed.length} changeset(s) now bump ${DESKTOP_PACKAGE} alongside ${CLI_PACKAGE}.`);

--- a/scripts/release/link-desktop-changesets.test.mjs
+++ b/scripts/release/link-desktop-changesets.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { linkDesktop, linkDesktopChangesets } from './link-desktop-changesets.mjs';
+
+const cliOnly = '---\n"@pymodel/pythinker-code": minor\n---\n\nAdd panel tabs.\n';
+
+void test('adds the desktop package at the CLI bump level', () => {
+  assert.equal(
+    linkDesktop(cliOnly),
+    '---\n"@pymodel/pythinker-code": minor\n"@pymodel/pythinker-desktop": minor\n---\n\nAdd panel tabs.\n',
+  );
+});
+
+void test('leaves a changeset that already names desktop alone', () => {
+  const both = '---\n"@pymodel/pythinker-desktop": patch\n"@pymodel/pythinker-code": patch\n---\n\nx\n';
+  assert.equal(linkDesktop(both), null);
+  assert.equal(linkDesktop(linkDesktop(cliOnly)), null);
+});
+
+void test('ignores changesets that do not name the CLI', () => {
+  assert.equal(linkDesktop('---\n"@pymodel/klient": patch\n---\n\nx\n'), null);
+  assert.equal(linkDesktop('no frontmatter\n'), null);
+});
+
+void test('keeps other packages and the prose intact', () => {
+  const source = '---\n"@pymodel/klient": patch\n"@pymodel/pythinker-code": patch\n---\n\nBody mentions "@pymodel/pythinker-desktop": major but that is prose.\n';
+  const next = linkDesktop(source);
+  assert.equal(
+    next,
+    '---\n"@pymodel/klient": patch\n"@pymodel/pythinker-code": patch\n"@pymodel/pythinker-desktop": patch\n---\n\nBody mentions "@pymodel/pythinker-desktop": major but that is prose.\n',
+  );
+});
+
+void test('rewrites only the changesets that need it and is idempotent', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'changesets-'));
+  writeFileSync(join(dir, 'README.md'), '---\n"@pymodel/pythinker-code": patch\n---\n');
+  writeFileSync(join(dir, 'config.json'), '{}');
+  writeFileSync(join(dir, 'a.md'), cliOnly);
+  writeFileSync(join(dir, 'b.md'), '---\n"@pymodel/klient": patch\n---\n\nx\n');
+  assert.deepEqual(linkDesktopChangesets(dir), ['a.md']);
+  assert.match(readFileSync(join(dir, 'a.md'), 'utf8'), /pythinker-desktop": minor/u);
+  assert.deepEqual(linkDesktopChangesets(dir), []);
+  assert.equal(readFileSync(join(dir, 'README.md'), 'utf8'), '---\n"@pymodel/pythinker-code": patch\n---\n');
+});

--- a/scripts/release/link-desktop-changesets.test.mjs
+++ b/scripts/release/link-desktop-changesets.test.mjs
@@ -21,6 +21,20 @@ void test('leaves a changeset that already names desktop alone', () => {
   assert.equal(linkDesktop(linkDesktop(cliOnly)), null);
 });
 
+void test('accepts quoted bump values and does not duplicate the desktop entry', () => {
+  const quoted = '---\n"@pymodel/pythinker-code": "minor"\n---\n\nx\n';
+  assert.equal(linkDesktop(quoted), '---\n"@pymodel/pythinker-code": "minor"\n"@pymodel/pythinker-desktop": minor\n---\n\nx\n');
+  assert.equal(linkDesktop(linkDesktop(quoted)), null);
+  assert.equal(linkDesktop("---\n'@pymodel/pythinker-desktop': 'patch'\n\"@pymodel/pythinker-code\": 'patch'\n---\n\nx\n"), null);
+});
+
+void test('reuses the CLI entry indentation', () => {
+  assert.equal(
+    linkDesktop('---\n  "@pymodel/pythinker-code": patch\n---\n\nx\n'),
+    '---\n  "@pymodel/pythinker-code": patch\n  "@pymodel/pythinker-desktop": patch\n---\n\nx\n',
+  );
+});
+
 void test('ignores changesets that do not name the CLI', () => {
   assert.equal(linkDesktop('---\n"@pymodel/klient": patch\n---\n\nx\n'), null);
   assert.equal(linkDesktop('no frontmatter\n'), null);


### PR DESCRIPTION
## Summary

Changesets only bumps a package a changeset names. Nearly every changeset names `@pymodel/pythinker-code` alone, so #233 would ship CLI 1.6.0 to npm with 29 changes desktop users can see, while the desktop app stayed on 0.3.9 with no build.

- `scripts/release/link-desktop-changesets.mjs`: before `changeset version`, add `@pymodel/pythinker-desktop` at the same bump level to every changeset that names the CLI but not desktop. Idempotent; changesets that already name desktop, or do not name the CLI, are untouched. Prose is never scanned.
- `package.json` `version:release` (the command `changesets/action` runs): link first, then `changeset version`.

Desktop keeps its own version line (0.3.9 → 0.4.0 here, not a `fixed` group), its `CHANGELOG.md` gets the real entries the updater shows, and `release.yml` already cuts `desktop-v*` from the bump `detect-lane-bumps.mjs` sees. `changeset version` was run with this on the current changesets: CLI 1.6.0, desktop 0.4.0, 29 entries in the desktop changelog.

## Test plan

- [x] `node --test scripts/release/link-desktop-changesets.test.mjs` — 5 tests (adds at CLI level, idempotent, skips non-CLI and frontmatter-less files, keeps other packages and prose, directory rewrite skips README/config)
- [x] `pnpm run version:release` locally against the real `.changeset/`, then reverted
- [ ] After merge: the release bot regenerates #233 with the desktop bump and the `desktop-v0.4.0` tag follows the npm publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Improvements**
  * Release preparation now automatically links eligible CLI changes to the desktop package.
  * Existing package entries, unrelated changesets, and surrounding release notes are preserved.
  * Quoted and unquoted version bump values are supported, with formatting and indentation retained.
  * Changeset files are safely rewritten without duplicate entries, including when processing them repeatedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->