### PR TITLE
fix(cli): restore self-update from the CDN and GitHub release archives

### DIFF
--- a/.changeset/reenable-self-update.md
+++ b/.changeset/reenable-self-update.md
@@ -1,0 +1,5 @@
+---
+"@pymodel/pythinker-code": patch
+---
+
+Restore `pythinker update` and `pythinker upgrade`: version checks read code.pythinker.com again and native installs download the release archive from GitHub.

--- a/apps/pythinker-code/src/cli/update/cdn.ts
+++ b/apps/pythinker-code/src/cli/update/cdn.ts
@@ -1,7 +1,11 @@
 import { valid } from 'semver';
 import { z } from 'zod';
 
+import { PYTHINKER_CODE_CDN_LATEST_JSON_URL, PYTHINKER_CODE_CDN_LATEST_URL } from '#/constant/app';
+
 import type { UpdateManifest } from './types';
+
+const CDN_FETCH_TIMEOUT_MS = 3_000;
 
 const RolloutBatchSchema = z.object({
   percent: z.number().int().min(0).max(100),
@@ -29,17 +33,65 @@ export interface FetchLatestResult {
   readonly manifest: UpdateManifest | null;
 }
 
-export const UPDATE_DISABLED_MESSAGE =
-  'Self-update is disabled in this build. Install updates from https://github.com/PyModel/pythinker-code/releases or via npm.';
-
-export async function fetchLatestVersionFromCdn(
-  _fetchImpl: typeof fetch = fetch,
-): Promise<string> {
-  throw new Error(UPDATE_DISABLED_MESSAGE);
+async function fetchWithTimeout(fetchImpl: typeof fetch, input: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, CDN_FETCH_TIMEOUT_MS);
+  try {
+    return await fetchImpl(input, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
+/**
+ * Fetch the latest published Pythinker Code version from the CDN.
+ *
+ * **Throws** on any failure (network error, non-2xx, empty body, non-semver
+ * text). Callers must catch — `refreshUpdateCache` deliberately lets the
+ * error propagate so the existing cache stays intact instead of being
+ * overwritten with a null `latest` on a transient blip.
+ *
+ * `fetchImpl` is injectable for tests; defaults to the global `fetch`.
+ */
+export async function fetchLatestVersionFromCdn(
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const response = await fetchWithTimeout(fetchImpl, PYTHINKER_CODE_CDN_LATEST_URL);
+  if (!response.ok) {
+    throw new Error(`CDN /latest returned HTTP ${response.status}`);
+  }
+  const raw = (await response.text()).trim();
+  if (valid(raw) === null) {
+    throw new Error(`CDN /latest returned invalid semver: ${JSON.stringify(raw)}`);
+  }
+  return raw;
+}
+
+async function fetchUpdateManifestFromCdn(fetchImpl: typeof fetch): Promise<UpdateManifest> {
+  const response = await fetchWithTimeout(fetchImpl, PYTHINKER_CODE_CDN_LATEST_JSON_URL);
+  if (!response.ok) {
+    throw new Error(`CDN /latest.json returned HTTP ${response.status}`);
+  }
+  return UpdateManifestSchema.parse(JSON.parse(await response.text()));
+}
+
+/**
+ * Fetch the rollout manifest, falling back to the plain-text `/latest` when
+ * `latest.json` is unavailable or malformed. The fallback removes any
+ * deployment-order coupling between client releases and the CDN file, and a
+ * null manifest means "fully rolled out" — exactly the pre-rollout behavior.
+ *
+ * **Throws** only when both sources fail; callers must catch (see above).
+ */
 export async function fetchLatestFromCdn(
-  _fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<FetchLatestResult> {
-  throw new Error(UPDATE_DISABLED_MESSAGE);
+  const manifest = await fetchUpdateManifestFromCdn(fetchImpl).catch(() => null);
+  if (manifest !== null) {
+    return { latest: manifest.version, manifest };
+  }
+  const latest = await fetchLatestVersionFromCdn(fetchImpl);
+  return { latest, manifest: null };
 }

--- a/apps/pythinker-code/src/cli/update/native-manifest.ts
+++ b/apps/pythinker-code/src/cli/update/native-manifest.ts
@@ -1,16 +1,18 @@
 /**
- * Per-release native artifact manifest (`/binaries/<version>/manifest.json`).
+ * Per-release native artifact manifest (`manifest.json` on the GitHub
+ * release of that version).
  *
  * Published alongside the release and consumed by the install scripts; the
  * staged updater reuses the same file so checksums and file names have a
- * single source of truth. Entries point at the bare platform binary
- * (`pythinker-code-<target>[.exe]`), not an archive.
+ * single source of truth. Entries point at the per-platform zip archive
+ * (`pythinker-code-<target>.zip`) holding the single platform binary; the
+ * checksum is the archive's sha256.
  */
 
 import { valid } from 'semver';
 import { z } from 'zod';
 
-import { UPDATE_DISABLED_MESSAGE } from './cdn';
+import { pythinkerCodeReleaseAssetUrl } from '#/constant/app';
 
 const MANIFEST_FETCH_TIMEOUT_MS = 10_000;
 
@@ -32,12 +34,12 @@ export const NativeReleaseManifestSchema = z.object({
 export type NativeReleaseManifest = z.infer<typeof NativeReleaseManifestSchema>;
 export type NativePlatformEntry = z.infer<typeof PlatformEntrySchema>;
 
-export function nativeManifestUrl(_version: string): string {
-  throw new Error(UPDATE_DISABLED_MESSAGE);
+export function nativeManifestUrl(version: string): string {
+  return pythinkerCodeReleaseAssetUrl(version, 'manifest.json');
 }
 
-export function nativeBinaryUrl(_version: string, _filename: string): string {
-  throw new Error(UPDATE_DISABLED_MESSAGE);
+export function nativeBinaryUrl(version: string, filename: string): string {
+  return pythinkerCodeReleaseAssetUrl(version, filename);
 }
 
 /**

--- a/apps/pythinker-code/src/cli/update/native-stage.ts
+++ b/apps/pythinker-code/src/cli/update/native-stage.ts
@@ -3,9 +3,11 @@
  * without touching the running executable. The actual swap happens on the
  * next startup (see `native-swap.ts`).
  *
- * The CDN serves the bare platform binary (e.g. `pythinker-code-win32-x64.exe`),
- * whose sha256 comes from the per-release manifest over HTTPS — a staged
- * binary is byte-exact what the release pipeline produced.
+ * The GitHub release serves a per-platform zip archive holding the single
+ * platform binary; the archive's sha256 comes from the per-release manifest
+ * over HTTPS. The archive is verified before it is opened and the binary is
+ * extracted next to it, so a staged binary is byte-exact what the release
+ * pipeline produced.
  */
 
 import { createHash } from 'node:crypto';
@@ -20,12 +22,12 @@ import { PYTHINKER_CODE_NATIVE_STAGED_STATE_FILE_NAME } from '#/constant/app';
 import { getNativeStagedStateFile, getNativeStagingDir } from '#/utils/paths';
 import { writeJsonFile } from '#/utils/persistence';
 
-import { UPDATE_DISABLED_MESSAGE } from './cdn';
 import {
   fetchNativeReleaseManifest,
   nativeBinaryUrl,
   selectPlatformEntry,
 } from './native-manifest';
+import { extractZipEntry, readSingleZipEntry } from './zip-archive';
 
 const StagedNativeUpdateSchema = z
   .object({
@@ -186,8 +188,9 @@ export async function hashFileSha256(filePath: string): Promise<string | null> {
 
 /**
  * Whether a `.staging/` entry is an updater-owned artifact: a staged
- * executable (`pythinker-<version>[.<pid>.<epoch-ms>.<n>][.exe]`) or a download
- * intermediate (the same plus `.part`). Ownership derives from the
+ * executable (`pythinker-<version>[.<pid>.<epoch-ms>.<n>][.exe]`), an
+ * extraction intermediate (the same plus `.part`), or a download
+ * intermediate (the same plus `.zip.part`). Ownership derives from the
  * semver/file-name contract (prerelease and build metadata included), so
  * foreign files in the directory are never matched.
  */
@@ -195,6 +198,7 @@ function isUpdaterOwnedStagingFile(entry: string): boolean {
   if (!entry.startsWith('pythinker-')) return false;
   let name = entry.slice('pythinker-'.length);
   if (name.endsWith('.part')) name = name.slice(0, -'.part'.length);
+  if (name.endsWith('.zip')) name = name.slice(0, -'.zip'.length);
   if (name.endsWith('.exe')) name = name.slice(0, -'.exe'.length);
   // Published artifacts may carry a unique per-worker infix after the
   // version (.<pid>.<epoch-ms>.<n>, or the older .<pid>.<n>) — try with and
@@ -377,10 +381,6 @@ async function downloadAndHash(
 export async function stageNativeUpdate(
   options: StageNativeUpdateOptions,
 ): Promise<StageNativeUpdateResult> {
-  if (UPDATE_DISABLED_MESSAGE.length > 0) {
-    throw new Error(UPDATE_DISABLED_MESSAGE);
-  }
-
   const platform = options.platform ?? process.platform;
   const arch = options.arch ?? process.arch;
   // Validate BEFORE anything derives a filesystem path from the version: the
@@ -444,31 +444,42 @@ export async function stageNativeUpdate(
     manual: options.manual === true ? true : undefined,
   };
 
-  // The .part intermediate is just the publish name plus the suffix — the
-  // name already carries this worker's unique infix, so concurrent workers
-  // never interleave writes into a shared path.
+  // The intermediates are just the publish name plus a suffix — the name
+  // already carries this worker's unique infix, so concurrent workers never
+  // interleave writes into a shared path. The archive lands in `.zip.part`,
+  // the extracted binary in `.part`.
+  const archivePath = join(stagingDir, `${exeFileName}.zip.part`);
   const partPath = join(stagingDir, `${exeFileName}.part`);
   try {
     const manifest = await fetchNativeReleaseManifest(options.version, fetchImpl);
     const entry = selectPlatformEntry(manifest, platform, arch);
-    const size = await downloadAndHash(
+    await downloadAndHash(
       nativeBinaryUrl(options.version, entry.filename),
-      partPath,
+      archivePath,
       entry.checksum,
       fetchImpl,
       options.onProgress,
       options.idleTimeoutMs,
     );
-    // sha256 matched the manifest. Make the private .part file executable
-    // BEFORE publishing it: a concurrent swap may move the staged exe into
-    // the install path the instant it appears at its published name, so a
-    // post-publish chmod could land on a path that is already gone — leaving
-    // a non-executable installation behind.
+    // The archive's sha256 matched the manifest, so its single entry is the
+    // binary the release pipeline packaged. The extracted bytes get their
+    // own digest: that is what the startup swap re-verifies on disk.
+    const extracted = await extractZipEntry(
+      archivePath,
+      await readSingleZipEntry(archivePath),
+      partPath,
+    );
+    await rm(archivePath, { force: true });
+    // Make the private .part file executable BEFORE publishing it: a
+    // concurrent swap may move the staged exe into the install path the
+    // instant it appears at its published name, so a post-publish chmod
+    // could land on a path that is already gone — leaving a non-executable
+    // installation behind.
     await chmod(partPath, 0o755);
     await rename(partPath, stagedExePath(options.exePath, staged));
 
-    staged.sha256 = entry.checksum;
-    staged.exeSize = size;
+    staged.sha256 = extracted.sha256;
+    staged.exeSize = extracted.size;
     // Atomic write: staged.json only ever appears complete and consistent.
     await writeJsonFile(
       getNativeStagedStateFile(options.exePath),
@@ -477,11 +488,12 @@ export async function stageNativeUpdate(
     );
     return { status: 'staged', staged };
   } catch (error) {
-    // Remove only what THIS attempt privately owns: its unique .part file.
-    // If the failure landed after the publishing rename, this attempt's exe
-    // is already at its unique name with no metadata pointing at it — left
-    // in place (a just-published exe may belong to a concurrent metadata
-    // write) and reaped by the age-gated orphan cleanup.
+    // Remove only what THIS attempt privately owns: its unique intermediate
+    // files. If the failure landed after the publishing rename, this
+    // attempt's exe is already at its unique name with no metadata pointing
+    // at it — left in place (a just-published exe may belong to a concurrent
+    // metadata write) and reaped by the age-gated orphan cleanup.
+    await rm(archivePath, { force: true }).catch(() => {});
     await rm(partPath, { force: true }).catch(() => {});
     // Best effort: drop the staging dir itself when empty (a concurrent
     // worker's files keep it around — rmdir only removes empty dirs).

--- a/apps/pythinker-code/src/cli/update/zip-archive.ts
+++ b/apps/pythinker-code/src/cli/update/zip-archive.ts
@@ -1,0 +1,203 @@
+/**
+ * Minimal reader for the release archives the native updater downloads:
+ * a plain (non-ZIP64) zip holding one platform binary, produced by
+ * `scripts/native/package.mjs` with yazl. Only the two compression methods
+ * zip writers emit in practice are supported (stored, deflate); anything
+ * else is rejected rather than guessed at. Nothing here is a general zip
+ * library — the archive comes from our own release pipeline over HTTPS and
+ * its sha256 was verified before this code ever runs.
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { open, stat } from 'node:fs/promises';
+import { createInflateRaw } from 'node:zlib';
+
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const CENTRAL_DIRECTORY_HEADER_SIGNATURE = 0x02014b50;
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+const CENTRAL_DIRECTORY_HEADER_SIZE = 46;
+const LOCAL_FILE_HEADER_SIZE = 30;
+const MAX_ZIP_COMMENT_SIZE = 0xffff;
+const ZIP64_MARKER_16 = 0xffff;
+const ZIP64_MARKER_32 = 0xffffffff;
+const METHOD_STORED = 0;
+const METHOD_DEFLATE = 8;
+
+export interface ZipEntry {
+  readonly name: string;
+  readonly method: number;
+  readonly compressedSize: number;
+  readonly uncompressedSize: number;
+  readonly localHeaderOffset: number;
+}
+
+export interface ExtractedZipEntry {
+  /** sha256 (hex) of the extracted bytes. */
+  readonly sha256: string;
+  readonly size: number;
+}
+
+async function readRange(zipPath: string, position: number, length: number): Promise<Buffer> {
+  const handle = await open(zipPath, 'r');
+  try {
+    const buffer = Buffer.alloc(length);
+    let filled = 0;
+    while (filled < length) {
+      const { bytesRead } = await handle.read(buffer, filled, length - filled, position + filled);
+      if (bytesRead === 0) {
+        throw new Error('zip archive is truncated');
+      }
+      filled += bytesRead;
+    }
+    return buffer;
+  } finally {
+    await handle.close();
+  }
+}
+
+function findEndOfCentralDirectory(tail: Buffer): number {
+  for (let offset = tail.length - END_OF_CENTRAL_DIRECTORY_SIZE; offset >= 0; offset -= 1) {
+    if (tail.readUInt32LE(offset) === END_OF_CENTRAL_DIRECTORY_SIGNATURE) return offset;
+  }
+  throw new Error('zip archive has no end-of-central-directory record');
+}
+
+/** List the entries recorded in the archive's central directory. */
+export async function readZipEntries(zipPath: string): Promise<readonly ZipEntry[]> {
+  const { size } = await stat(zipPath);
+  if (size < END_OF_CENTRAL_DIRECTORY_SIZE) {
+    throw new Error('zip archive is too small to be valid');
+  }
+  const tailLength = Math.min(size, END_OF_CENTRAL_DIRECTORY_SIZE + MAX_ZIP_COMMENT_SIZE);
+  const tail = await readRange(zipPath, size - tailLength, tailLength);
+  const eocd = findEndOfCentralDirectory(tail);
+  const entryCount = tail.readUInt16LE(eocd + 10);
+  const directorySize = tail.readUInt32LE(eocd + 12);
+  const directoryOffset = tail.readUInt32LE(eocd + 16);
+  if (entryCount === ZIP64_MARKER_16 || directoryOffset === ZIP64_MARKER_32) {
+    throw new Error('ZIP64 archives are not supported');
+  }
+  if (directoryOffset + directorySize > size) {
+    throw new Error('zip central directory lies outside the archive');
+  }
+  const directory = await readRange(zipPath, directoryOffset, directorySize);
+  const entries: ZipEntry[] = [];
+  let offset = 0;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (
+      offset + CENTRAL_DIRECTORY_HEADER_SIZE > directory.length ||
+      directory.readUInt32LE(offset) !== CENTRAL_DIRECTORY_HEADER_SIGNATURE
+    ) {
+      throw new Error('zip central directory is malformed');
+    }
+    const method = directory.readUInt16LE(offset + 10);
+    const compressedSize = directory.readUInt32LE(offset + 20);
+    const uncompressedSize = directory.readUInt32LE(offset + 24);
+    const nameLength = directory.readUInt16LE(offset + 28);
+    const extraLength = directory.readUInt16LE(offset + 30);
+    const commentLength = directory.readUInt16LE(offset + 32);
+    const localHeaderOffset = directory.readUInt32LE(offset + 42);
+    const nameStart = offset + CENTRAL_DIRECTORY_HEADER_SIZE;
+    if (nameStart + nameLength > directory.length) {
+      throw new Error('zip central directory is malformed');
+    }
+    if (
+      compressedSize === ZIP64_MARKER_32 ||
+      uncompressedSize === ZIP64_MARKER_32 ||
+      localHeaderOffset === ZIP64_MARKER_32
+    ) {
+      throw new Error('ZIP64 archives are not supported');
+    }
+    entries.push({
+      name: directory.subarray(nameStart, nameStart + nameLength).toString('utf-8'),
+      method,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
+    });
+    offset = nameStart + nameLength + extraLength + commentLength;
+  }
+  return entries;
+}
+
+/**
+ * Write one entry's decompressed bytes to `destPath`, hashing them on the
+ * way. Short writes are retried so the file on disk is exactly the bytes
+ * that were hashed. **Throws** when the archive is malformed, uses an
+ * unsupported compression method, or the extracted size disagrees with the
+ * central directory.
+ */
+export async function extractZipEntry(
+  zipPath: string,
+  entry: ZipEntry,
+  destPath: string,
+): Promise<ExtractedZipEntry> {
+  if (entry.method !== METHOD_STORED && entry.method !== METHOD_DEFLATE) {
+    throw new Error(`unsupported zip compression method: ${String(entry.method)}`);
+  }
+  const localHeader = await readRange(zipPath, entry.localHeaderOffset, LOCAL_FILE_HEADER_SIZE);
+  if (localHeader.readUInt32LE(0) !== LOCAL_FILE_HEADER_SIGNATURE) {
+    throw new Error('zip local file header is malformed');
+  }
+  const nameLength = localHeader.readUInt16LE(26);
+  const extraLength = localHeader.readUInt16LE(28);
+  const dataStart = entry.localHeaderOffset + LOCAL_FILE_HEADER_SIZE + nameLength + extraLength;
+  const { size: archiveSize } = await stat(zipPath);
+  if (dataStart + entry.compressedSize > archiveSize) {
+    throw new Error('zip entry data lies outside the archive');
+  }
+
+  const hash = createHash('sha256');
+  let size = 0;
+  const file = await open(destPath, 'w');
+  try {
+    if (entry.compressedSize > 0) {
+      const source = createReadStream(zipPath, {
+        start: dataStart,
+        end: dataStart + entry.compressedSize - 1,
+      });
+      const decoded: AsyncIterable<Buffer> =
+        entry.method === METHOD_DEFLATE ? source.pipe(createInflateRaw()) : source;
+      for await (const chunk of decoded) {
+        hash.update(chunk);
+        size += chunk.length;
+        let offset = 0;
+        while (offset < chunk.length) {
+          const { bytesWritten } = await file.write(chunk, offset);
+          if (bytesWritten === 0) {
+            throw new Error('failed to write the extracted binary to disk (disk full?)');
+          }
+          offset += bytesWritten;
+        }
+      }
+    }
+  } finally {
+    await file.close();
+  }
+  if (size !== entry.uncompressedSize) {
+    throw new Error(
+      `zip entry size mismatch: expected ${String(entry.uncompressedSize)} bytes, got ${String(size)}`,
+    );
+  }
+  return { sha256: hash.digest('hex'), size };
+}
+
+/**
+ * The release archive contract: exactly one file entry. Anything else means
+ * the download is not a release artifact this updater knows how to install.
+ */
+export async function readSingleZipEntry(zipPath: string): Promise<ZipEntry> {
+  const entries = await readZipEntries(zipPath);
+  if (entries.length !== 1) {
+    throw new Error(
+      `expected a single-entry archive, found ${String(entries.length)} entries`,
+    );
+  }
+  const [entry] = entries;
+  if (entry === undefined || entry.name.endsWith('/')) {
+    throw new Error('release archive does not contain a file entry');
+  }
+  return entry;
+}

--- a/apps/pythinker-code/src/constant/app.ts
+++ b/apps/pythinker-code/src/constant/app.ts
@@ -41,6 +41,22 @@ export const HEADLESS_STDIO_DRAIN_TIMEOUT_MS = 10000;
 // Published npm package name; this can differ from the executable command.
 export const NPM_PACKAGE_NAME = '@pymodel/pythinker-code';
 
+// Update sources. Version checks read the CDN (`/latest` plain text and the
+// `/latest.json` rollout manifest); native binaries come from the GitHub
+// release for that version: `manifest.json` (per-platform zip name + sha256)
+// next to the `pythinker-code-<target>.zip` archives.
+export const PYTHINKER_CODE_CDN_BASE = 'https://code.pythinker.com/pythinker-code';
+export const PYTHINKER_CODE_CDN_LATEST_URL = `${PYTHINKER_CODE_CDN_BASE}/latest`;
+export const PYTHINKER_CODE_CDN_LATEST_JSON_URL = `${PYTHINKER_CODE_CDN_BASE}/latest.json`;
+export const PYTHINKER_CODE_GITHUB_RELEASES_BASE =
+  'https://github.com/PyModel/pythinker-code/releases/download';
+export function pythinkerCodeReleaseTag(version: string): string {
+  return `${NPM_PACKAGE_NAME}@${version}`;
+}
+export function pythinkerCodeReleaseAssetUrl(version: string, filename: string): string {
+  return `${PYTHINKER_CODE_GITHUB_RELEASES_BASE}/${encodeURIComponent(pythinkerCodeReleaseTag(version))}/${filename}`;
+}
+
 // App-owned data paths. SDK/core runtime config is intentionally not routed here.
 export const PYTHINKER_CODE_HOME_ENV = 'PYTHINKER_CODE_HOME';
 export const PYTHINKER_CODE_DATA_DIR_NAME = '.pythinker-code';

--- a/apps/pythinker-code/test/cli/update/cdn.test.ts
+++ b/apps/pythinker-code/test/cli/update/cdn.test.ts
@@ -1,27 +1,233 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  fetchLatestFromCdn,
-  fetchLatestVersionFromCdn,
-  UPDATE_DISABLED_MESSAGE,
-} from '#/cli/update/cdn';
+import { fetchLatestFromCdn, fetchLatestVersionFromCdn } from '#/cli/update/cdn';
+import { PYTHINKER_CODE_CDN_LATEST_JSON_URL, PYTHINKER_CODE_CDN_LATEST_URL } from '#/constant/app';
 
-describe('disabled CDN update checks', () => {
-  it('disables the plain latest-version fetcher without making a request', async () => {
-    const fetchImpl = vi.fn();
+function mockFetchOk(body: string): typeof fetch {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    text: async () => body,
+  })) as unknown as typeof fetch;
+}
 
-    await expect(fetchLatestVersionFromCdn(fetchImpl as unknown as typeof fetch)).rejects.toThrow(
-      UPDATE_DISABLED_MESSAGE,
+function mockFetchStatus(status: number): typeof fetch {
+  return vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => '',
+  })) as unknown as typeof fetch;
+}
+
+type Route = { readonly status?: number; readonly body?: string } | Error;
+
+/** URL-routed fetch mock: unrouted URLs return 404. */
+function mockRoutedFetch(routes: Record<string, Route>): typeof fetch {
+  return vi.fn(async (input: string | URL) => {
+    const route = routes[String(input)];
+    if (route === undefined) {
+      return { ok: false, status: 404, text: async () => '' };
+    }
+    if (route instanceof Error) throw route;
+    const status = route.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => route.body ?? '',
+    };
+  }) as unknown as typeof fetch;
+}
+
+const MANIFEST_BODY = JSON.stringify({
+  schemaVersion: 1,
+  version: '2.0.0',
+  publishedAt: '2026-06-12T00:00:00.000Z',
+  rollout: [
+    { percent: 30, delaySeconds: 0 },
+    { percent: 30, delaySeconds: 43_200 },
+    { percent: 40, delaySeconds: 86_400 },
+  ],
+});
+
+describe('fetchLatestVersionFromCdn', () => {
+  it('returns the trimmed semver returned by CDN /latest', async () => {
+    const f = mockFetchOk('  0.5.0\n');
+    await expect(fetchLatestVersionFromCdn(f)).resolves.toBe('0.5.0');
+    expect(f).toHaveBeenCalledWith(
+      PYTHINKER_CODE_CDN_LATEST_URL,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
-    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it('disables the manifest fetcher without making a request', async () => {
-    const fetchImpl = vi.fn();
+  it('throws when response is non-2xx', async () => {
+    await expect(fetchLatestVersionFromCdn(mockFetchStatus(404))).rejects.toThrow(/HTTP 404/);
+  });
 
-    await expect(fetchLatestFromCdn(fetchImpl as unknown as typeof fetch)).rejects.toThrow(
-      UPDATE_DISABLED_MESSAGE,
+  it('throws when body is not valid semver', async () => {
+    await expect(fetchLatestVersionFromCdn(mockFetchOk('not-a-version'))).rejects.toThrow(
+      /invalid semver/,
     );
-    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('throws when body is empty', async () => {
+    await expect(fetchLatestVersionFromCdn(mockFetchOk('   '))).rejects.toThrow(/invalid semver/);
+  });
+
+  it('propagates the underlying fetch error', async () => {
+    const f = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    await expect(fetchLatestVersionFromCdn(f)).rejects.toThrow(/network down/);
+  });
+});
+
+describe('fetchLatestFromCdn', () => {
+  it('parses latest.json and returns the manifest', async () => {
+    const f = mockRoutedFetch({ [PYTHINKER_CODE_CDN_LATEST_JSON_URL]: { body: MANIFEST_BODY } });
+    await expect(fetchLatestFromCdn(f)).resolves.toEqual({
+      latest: '2.0.0',
+      manifest: {
+        version: '2.0.0',
+        publishedAt: '2026-06-12T00:00:00.000Z',
+        rollout: [
+          { percent: 30, delaySeconds: 0 },
+          { percent: 30, delaySeconds: 43_200 },
+          { percent: 40, delaySeconds: 86_400 },
+        ],
+      },
+    });
+    expect(f).toHaveBeenCalledWith(
+      PYTHINKER_CODE_CDN_LATEST_JSON_URL,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unknown manifest fields (lenient parsing)', async () => {
+    const body = JSON.stringify({
+      schemaVersion: 99,
+      version: '2.0.0',
+      publishedAt: '2026-06-12T00:00:00.000Z',
+      rollout: [],
+      futureField: { nested: true },
+    });
+    const f = mockRoutedFetch({ [PYTHINKER_CODE_CDN_LATEST_JSON_URL]: { body } });
+    const result = await fetchLatestFromCdn(f);
+    expect(result.manifest).toEqual({
+      version: '2.0.0',
+      publishedAt: '2026-06-12T00:00:00.000Z',
+      rollout: [],
+    });
+  });
+
+  it('defaults a missing rollout to an empty plan (fully rolled out)', async () => {
+    const body = JSON.stringify({
+      version: '2.0.0',
+      publishedAt: '2026-06-12T00:00:00.000Z',
+    });
+    const f = mockRoutedFetch({ [PYTHINKER_CODE_CDN_LATEST_JSON_URL]: { body } });
+    const result = await fetchLatestFromCdn(f);
+    expect(result.manifest?.rollout).toEqual([]);
+  });
+
+  const fallbackCases: ReadonlyArray<readonly [string, Route]> = [
+    ['latest.json is missing (HTTP 404)', { status: 404 }],
+    ['latest.json fetch throws', new Error('network down')],
+    ['body is not valid JSON', { body: 'not json {' }],
+    ['version is not semver', { body: JSON.stringify({ version: 'nope', publishedAt: '2026-06-12T00:00:00.000Z' }) }],
+    ['publishedAt is unparseable', { body: JSON.stringify({ version: '2.0.0', publishedAt: 'garbage' }) }],
+    ['a batch percent is out of range', {
+      body: JSON.stringify({
+        version: '2.0.0',
+        publishedAt: '2026-06-12T00:00:00.000Z',
+        rollout: [{ percent: 150, delaySeconds: 0 }],
+      }),
+    }],
+    ['a batch delay is negative', {
+      body: JSON.stringify({
+        version: '2.0.0',
+        publishedAt: '2026-06-12T00:00:00.000Z',
+        rollout: [{ percent: 100, delaySeconds: -1 }],
+      }),
+    }],
+  ];
+
+  for (const [name, route] of fallbackCases) {
+    it(`falls back to plain /latest when ${name}`, async () => {
+      const f = mockRoutedFetch({
+        [PYTHINKER_CODE_CDN_LATEST_JSON_URL]: route,
+        [PYTHINKER_CODE_CDN_LATEST_URL]: { body: '1.9.0\n' },
+      });
+      await expect(fetchLatestFromCdn(f)).resolves.toEqual({
+        latest: '1.9.0',
+        manifest: null,
+      });
+    });
+  }
+
+  it('throws when both latest.json and plain /latest fail', async () => {
+    const f = mockRoutedFetch({
+      [PYTHINKER_CODE_CDN_LATEST_JSON_URL]: { status: 500 },
+      [PYTHINKER_CODE_CDN_LATEST_URL]: { status: 500 },
+    });
+    await expect(fetchLatestFromCdn(f)).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('propagates the plain /latest error when the fallback also breaks', async () => {
+    const f = mockRoutedFetch({
+      [PYTHINKER_CODE_CDN_LATEST_JSON_URL]: new Error('json down'),
+      [PYTHINKER_CODE_CDN_LATEST_URL]: { body: 'not-a-version' },
+    });
+    await expect(fetchLatestFromCdn(f)).rejects.toThrow(/invalid semver/);
+  });
+
+  it('falls back to plain /latest when latest.json hangs past the request timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const f = vi.fn(async (input: string | URL, init?: RequestInit) => {
+        if (String(input) === PYTHINKER_CODE_CDN_LATEST_JSON_URL) {
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(new Error('aborted'));
+            }, { once: true });
+          });
+        }
+        if (String(input) === PYTHINKER_CODE_CDN_LATEST_URL) {
+          return { ok: true, status: 200, text: async () => '1.9.0\n' };
+        }
+        return { ok: false, status: 404, text: async () => '' };
+      }) as unknown as typeof fetch;
+
+      const result = fetchLatestFromCdn(f);
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      await expect(result).resolves.toEqual({
+        latest: '1.9.0',
+        manifest: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects when plain /latest also hangs past the request timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const f = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new Error('aborted'));
+          }, { once: true });
+        });
+      }) as unknown as typeof fetch;
+
+      const result = fetchLatestFromCdn(f);
+      const expectation = expect(result).rejects.toThrow(/aborted/);
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/pythinker-code/test/cli/update/native-manifest.test.ts
+++ b/apps/pythinker-code/test/cli/update/native-manifest.test.ts
@@ -1,30 +1,123 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { UPDATE_DISABLED_MESSAGE } from '#/cli/update/cdn';
 import {
   fetchNativeReleaseManifest,
   nativeBinaryUrl,
   nativeManifestUrl,
   selectPlatformEntry,
 } from '#/cli/update/native-manifest';
+import { pythinkerCodeReleaseAssetUrl } from '#/constant/app';
 
 const VERSION = '0.7.0';
 
-describe('disabled native release source', () => {
-  it('disables manifest and binary URL resolution', () => {
-    expect(() => nativeManifestUrl(VERSION)).toThrow(UPDATE_DISABLED_MESSAGE);
-    expect(() => nativeBinaryUrl(VERSION, 'pythinker-code-win32-x64.zip')).toThrow(
-      UPDATE_DISABLED_MESSAGE,
+function mockFetch(response: {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly body?: string;
+}): typeof fetch {
+  return vi.fn(async () => ({
+    ok: response.ok,
+    status: response.status,
+    text: async () => response.body ?? '',
+  })) as unknown as typeof fetch;
+}
+
+const MANIFEST_BODY = JSON.stringify({
+  version: VERSION,
+  tag: `@pymodel/pythinker-code@${VERSION}`,
+  platforms: {
+    'win32-x64': {
+      filename: `pythinker-code-win32-x64.zip`,
+      checksum: 'a'.repeat(64),
+    },
+    'darwin-arm64': {
+      filename: `pythinker-code-darwin-arm64.zip`,
+      checksum: 'b'.repeat(64),
+    },
+  },
+});
+
+describe('fetchNativeReleaseManifest', () => {
+  it('fetches and parses the manifest for the given version', async () => {
+    const f = mockFetch({ ok: true, status: 200, body: MANIFEST_BODY });
+    const manifest = await fetchNativeReleaseManifest(VERSION, f);
+    expect(manifest.version).toBe(VERSION);
+    expect(Object.keys(manifest.platforms)).toEqual(['win32-x64', 'darwin-arm64']);
+    expect(f).toHaveBeenCalledWith(
+      nativeManifestUrl(VERSION),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 
-  it('does not fetch a native release manifest', async () => {
-    const fetchImpl = vi.fn();
+  it('ignores unknown fields (lenient parsing)', async () => {
+    const body = JSON.stringify({
+      version: VERSION,
+      platforms: {},
+      futureField: { nested: true },
+    });
+    const manifest = await fetchNativeReleaseManifest(VERSION, mockFetch({ ok: true, status: 200, body }));
+    expect(manifest.version).toBe(VERSION);
+  });
 
+  it('rejects a non-semver version argument before hitting the network', async () => {
+    const f = mockFetch({ ok: true, status: 200, body: MANIFEST_BODY });
+    await expect(fetchNativeReleaseManifest('nope', f)).rejects.toThrow(/invalid semver/);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('rejects a manifest served for a different release', async () => {
+    // A stale/mispublished endpoint answering with another version's manifest
+    // must not apply that release's checksums to this version's binary.
+    const body = JSON.stringify({ version: '0.9.9', platforms: {} });
     await expect(
-      fetchNativeReleaseManifest(VERSION, fetchImpl as unknown as typeof fetch),
-    ).rejects.toThrow(UPDATE_DISABLED_MESSAGE);
-    expect(fetchImpl).not.toHaveBeenCalled();
+      fetchNativeReleaseManifest(VERSION, mockFetch({ ok: true, status: 200, body })),
+    ).rejects.toThrow(/0\.9\.9/);
+  });
+
+  it('throws on non-2xx', async () => {
+    await expect(
+      fetchNativeReleaseManifest(VERSION, mockFetch({ ok: false, status: 404 })),
+    ).rejects.toThrow(/HTTP 404/);
+  });
+
+  it('throws on a malformed checksum', async () => {
+    const body = JSON.stringify({
+      version: VERSION,
+      platforms: { 'win32-x64': { filename: 'pythinker-code-win32-x64.zip', checksum: 'xyz' } },
+    });
+    await expect(
+      fetchNativeReleaseManifest(VERSION, mockFetch({ ok: true, status: 200, body })),
+    ).rejects.toThrow();
+  });
+
+  it('propagates fetch errors', async () => {
+    const f = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    await expect(fetchNativeReleaseManifest(VERSION, f)).rejects.toThrow(/network down/);
+  });
+
+  it('rejects when the response body stalls past the request timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const f = vi.fn(async (_input: string | URL, init?: RequestInit) => ({
+        ok: true,
+        status: 200,
+        // Headers arrive, then the body stalls; only the timeout can end this.
+        text: async () =>
+          new Promise<string>((_, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(new Error('aborted'));
+            }, { once: true });
+          }),
+      })) as unknown as typeof fetch;
+      const promise = fetchNativeReleaseManifest(VERSION, f);
+      const assertion = expect(promise).rejects.toThrow(/aborted/);
+      await vi.advanceTimersByTimeAsync(11_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -46,5 +139,16 @@ describe('selectPlatformEntry', () => {
     expect(() => selectPlatformEntry(manifest, 'linux', 'arm64')).toThrow(
       /linux-arm64 not found/,
     );
+  });
+});
+
+describe('url helpers', () => {
+  it('builds the manifest and binary URLs from the GitHub release of that version', () => {
+    const base = 'https://github.com/PyModel/pythinker-code/releases/download/%40pymodel%2Fpythinker-code%400.7.0';
+    expect(nativeManifestUrl(VERSION)).toBe(`${base}/manifest.json`);
+    expect(nativeBinaryUrl(VERSION, 'pythinker-code-win32-x64.zip')).toBe(
+      `${base}/pythinker-code-win32-x64.zip`,
+    );
+    expect(nativeManifestUrl(VERSION)).toBe(pythinkerCodeReleaseAssetUrl(VERSION, 'manifest.json'));
   });
 });

--- a/apps/pythinker-code/test/cli/update/native-stage.test.ts
+++ b/apps/pythinker-code/test/cli/update/native-stage.test.ts
@@ -1,12 +1,161 @@
-import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ZipFile } from 'yazl';
 
-import { UPDATE_DISABLED_MESSAGE } from '#/cli/update/cdn';
-import { readStagedNativeUpdate, stageNativeUpdate } from '#/cli/update/native-stage';
+import { nativeBinaryUrl, nativeManifestUrl } from '#/cli/update/native-manifest';
+import {
+  promoteStagedUpdateToManual,
+  readStagedNativeUpdate,
+  stagedExePath,
+  stageNativeUpdate,
+} from '#/cli/update/native-stage';
 import { getNativeStagedStateFile, getNativeStagingDir } from '#/utils/paths';
+
+const fsMocks = vi.hoisted(() => ({
+  /** Records chmod/rename calls (path-based) so tests can assert ordering. */
+  calls: [] as Array<{ readonly op: 'chmod' | 'rename'; readonly path: string; readonly dst?: string }>,
+  /** When > 0, the next open() wraps its handle so the first write is short. */
+  shortWriteBudget: 0,
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    chmod: async (
+      path: Parameters<typeof actual.chmod>[0],
+      mode: Parameters<typeof actual.chmod>[1],
+    ) => {
+      fsMocks.calls.push({ op: 'chmod', path: String(path) });
+      return actual.chmod(path, mode);
+    },
+    rename: async (
+      src: Parameters<typeof actual.rename>[0],
+      dst: Parameters<typeof actual.rename>[1],
+    ) => {
+      fsMocks.calls.push({ op: 'rename', path: String(src), dst: String(dst) });
+      return actual.rename(src, dst);
+    },
+    open: async (
+      path: Parameters<typeof actual.open>[0],
+      flags: Parameters<typeof actual.open>[1],
+      mode: Parameters<typeof actual.open>[2],
+    ) => {
+      const handle = await actual.open(path, flags, mode);
+      if (fsMocks.shortWriteBudget <= 0) return handle;
+      fsMocks.shortWriteBudget -= 1;
+      let truncated = false;
+      return {
+        // FileHandle methods live on the prototype, so delegate explicitly.
+        write: async (
+          buffer: Buffer,
+          offset?: number | null,
+          length?: number | null,
+          position?: number | null,
+        ) => {
+          const off = offset ?? 0;
+          const len = length ?? buffer.length - off;
+          // The first write persists only half the requested bytes.
+          const effectiveLen = !truncated && len > 1 ? Math.floor(len / 2) : len;
+          truncated = true;
+          const result = await handle.write(buffer, off, effectiveLen, position ?? null);
+          return { bytesWritten: result.bytesWritten, buffer: result.buffer };
+        },
+        close: () => handle.close(),
+      };
+    },
+  };
+});
+
+const VERSION = '0.7.0';
+const PAYLOAD = Buffer.from('fake-sea-binary-payload');
+// The release serves a zip holding the bare platform binary; the manifest
+// checksum is the archive's sha256, the staged record carries the binary's.
+const BINARY_FILENAME = 'pythinker-code-linux-x64.zip';
+
+function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/** Build the single-entry archive the release pipeline ships (yazl, deflate). */
+async function zipOf(payload: Buffer, entryName = 'pythinker'): Promise<Buffer> {
+  const zip = new ZipFile();
+  zip.addBuffer(payload, entryName, { mode: 0o100755 });
+  zip.end();
+  const chunks: Buffer[] = [];
+  for await (const chunk of zip.outputStream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+const archiveCache = new Map<string, Promise<Buffer>>();
+
+function archiveOf(payload: Buffer): Promise<Buffer> {
+  const key = payload.toString('base64');
+  let archive = archiveCache.get(key);
+  if (archive === undefined) {
+    archive = zipOf(payload);
+    archiveCache.set(key, archive);
+  }
+  return archive;
+}
+
+/** Write a staging artifact old enough for the orphan sweep to reap it. */
+async function agedOrphan(path: string, content: string | Buffer): Promise<void> {
+  await writeFile(path, content);
+  const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  await utimes(path, old, old);
+}
+
+interface MockCdnOptions {
+  readonly version?: string;
+  /** The binary inside the archive. */
+  readonly payload: Buffer;
+  /** Serve these bytes instead of a well-formed archive of `payload`. */
+  readonly archive?: Buffer;
+  readonly checksum?: string;
+}
+
+function mockCdnFetch(options: MockCdnOptions): typeof fetch {
+  const version = options.version ?? VERSION;
+  const archive =
+    options.archive === undefined ? archiveOf(options.payload) : Promise.resolve(options.archive);
+  return vi.fn(async (input: string | URL) => {
+    const url = String(input);
+    const bytes = await archive;
+    if (url === nativeManifestUrl(version)) {
+      const manifestBody = JSON.stringify({
+        version,
+        tag: `@pymodel/pythinker-code@${version}`,
+        platforms: {
+          'linux-x64': {
+            filename: BINARY_FILENAME,
+            checksum: options.checksum ?? sha256Hex(bytes),
+          },
+        },
+      });
+      return { ok: true, status: 200, text: async () => manifestBody, body: null };
+    }
+    if (url === nativeBinaryUrl(version, BINARY_FILENAME)) {
+      return {
+        ok: true,
+        status: 200,
+        text: async (): Promise<string> => '',
+        headers: {
+          get: (name: string): string | null =>
+            name === 'content-length' ? String(bytes.length) : null,
+        },
+        body: [bytes],
+      };
+    }
+    return { ok: false, status: 404, text: async () => '', body: null };
+  }) as unknown as typeof fetch;
+}
 
 describe('stageNativeUpdate', () => {
   let workDir: string;
@@ -15,30 +164,672 @@ describe('stageNativeUpdate', () => {
   beforeEach(async () => {
     workDir = await mkdtemp(join(tmpdir(), 'pythinker-stage-test-'));
     exePath = join(workDir, 'bin', 'pythinker');
+    fsMocks.calls.length = 0;
+    fsMocks.shortWriteBudget = 0;
   });
 
   afterEach(async () => {
     await rm(workDir, { recursive: true, force: true });
   });
 
-  it('rejects with the disabled-update message', async () => {
-    await expect(
-      stageNativeUpdate({ version: '0.7.0', exePath, platform: 'linux', arch: 'x64' }),
-    ).rejects.toThrowError(new Error(UPDATE_DISABLED_MESSAGE));
+  it('downloads, verifies and records the staged metadata', async () => {
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+
+    expect(result.status).toBe('staged');
+    expect(result.staged).toMatchObject({
+      version: VERSION,
+      target: 'linux-x64',
+      sha256: sha256Hex(PAYLOAD),
+      exeSize: PAYLOAD.length,
+    });
+    // The published exe name carries a unique per-worker infix: a staged
+    // executable is never replaced once published, so the pathname a swap
+    // validates at claim time is stable.
+    expect(result.staged.exeFileName).toMatch(/^pythinker-0\.7\.0\.\d+\.\d+\.\d+$/);
+
+    const stagedOnDisk = await readStagedNativeUpdate(exePath);
+    expect(stagedOnDisk).toEqual(result.staged);
+    const exeBytes = await readFile(stagedExePath(exePath, result.staged));
+    expect(exeBytes.equals(PAYLOAD)).toBe(true);
+    // Both intermediates (.zip.part archive, .part binary) are gone once
+    // the download was promoted.
+    const leftovers = (await readdir(getNativeStagingDir(exePath))).filter((entry) =>
+      entry.endsWith('.part'),
+    );
+    expect(leftovers).toEqual([]);
   });
 
-  it('creates no staging state when updates are disabled', async () => {
+  it('marks the staged exe executable', async () => {
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    const info = await stat(stagedExePath(exePath, result.staged));
+    expect(info.mode & 0o111).not.toBe(0);
+  });
+
+  it('records the manual marker when the stage answers an explicit upgrade', async () => {
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+      manual: true,
+    });
+    expect(result.staged.manual).toBe(true);
+    // And it round-trips through the on-disk metadata.
+    expect((await readStagedNativeUpdate(exePath))?.manual).toBe(true);
+  });
+
+  it('makes the download executable before publishing it at the staged name', async () => {
+    // A concurrent swap may move the staged exe into place the instant it
+    // appears at its published name, so the chmod must land on the private
+    // .part file first — a later chmod could hit an already-moved path.
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    const stagedExe = stagedExePath(exePath, result.staged);
+    const chmodCall = fsMocks.calls.find(
+      (call) => call.op === 'chmod' && call.path.endsWith('.part'),
+    );
+    const publishCall = fsMocks.calls.find(
+      (call) => call.op === 'rename' && call.dst === stagedExe,
+    );
+    if (chmodCall === undefined || publishCall === undefined) {
+      throw new Error('expected chmod(.part) and rename(.part → staged) calls');
+    }
+    // The chmod lands on the very .part file that gets published, before it.
+    expect(publishCall.path).toBe(chmodCall.path);
+    expect(fsMocks.calls.indexOf(chmodCall)).toBeLessThan(
+      fsMocks.calls.indexOf(publishCall),
+    );
+  });
+
+  it('reports download progress with the Content-Length total', async () => {
+    const progress: Array<readonly [number, number | null]> = [];
+    await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+      onProgress: (downloaded, total) => {
+        progress.push([downloaded, total]);
+      },
+    });
+    // One frame per chunk; the mock stream delivers the archive in one piece.
+    const archive = await archiveOf(PAYLOAD);
+    expect(progress).toEqual([[archive.length, archive.length]]);
+  });
+
+  it('aborts a stalled download after the idle timeout', async () => {
+    const manifestBody = JSON.stringify({
+      version: VERSION,
+      platforms: {
+        'linux-x64': { filename: BINARY_FILENAME, checksum: 'a'.repeat(64) },
+      },
+    });
+    const fetchImpl = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === nativeManifestUrl(VERSION)) {
+        return { ok: true, status: 200, text: async () => manifestBody, body: null };
+      }
+      if (url === nativeBinaryUrl(VERSION, BINARY_FILENAME)) {
+        const signal = init?.signal;
+        const body = (async function* (): AsyncGenerator<Buffer> {
+          yield Buffer.from('first-chunk');
+          // Stall forever — only the idle timeout's abort can end this.
+          await new Promise((_, reject) => {
+            signal?.addEventListener('abort', () => {
+              reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'));
+            }, { once: true });
+          });
+        })();
+        return {
+          ok: true,
+          status: 200,
+          text: async (): Promise<string> => '',
+          headers: { get: (): string | null => null },
+          body,
+        };
+      }
+      return { ok: false, status: 404, text: async (): Promise<string> => '', body: null };
+    }) as unknown as typeof fetch;
+
+    // Real timers with a 50 ms test override — fake timers interact badly
+    // with async-generator suspension, so the idle timeout is injectable.
     await expect(
       stageNativeUpdate({
-        version: '0.7.0',
+        version: VERSION,
         exePath,
         platform: 'linux',
         arch: 'x64',
+        fetchImpl,
+        idleTimeoutMs: 50,
       }),
-    ).rejects.toThrowError(new Error(UPDATE_DISABLED_MESSAGE));
+    ).rejects.toThrow(/stalled/);
+    // The failed attempt cleans up after itself.
+    expect(await readStagedNativeUpdate(exePath)).toBeNull();
+  });
 
-    await expect(stat(getNativeStagingDir(exePath))).rejects.toMatchObject({ code: 'ENOENT' });
-    await expect(stat(getNativeStagedStateFile(exePath))).rejects.toMatchObject({ code: 'ENOENT' });
+  it('short-circuits when the same version is already staged', async () => {
+    const firstFetch = mockCdnFetch({ payload: PAYLOAD });
+    await stageNativeUpdate({ version: VERSION, exePath, platform: 'linux', arch: 'x64', fetchImpl: firstFetch });
+
+    const secondFetch = mockCdnFetch({ payload: PAYLOAD });
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: secondFetch,
+    });
+
+    expect(result.status).toBe('already-staged');
+    expect(secondFetch).not.toHaveBeenCalled();
+  });
+
+  it('promotes an auto-staged payload to manual when an explicit upgrade adopts it', async () => {
+    // The passive downloader staged the version first (no manual marker).
+    await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+      manual: true,
+    });
+
+    expect(result.status).toBe('already-staged');
+    expect(result.staged.manual).toBe(true);
+    // The promotion persisted to the on-disk metadata.
+    expect((await readStagedNativeUpdate(exePath))?.manual).toBe(true);
+  });
+
+  it('re-stages when the staged exe is corrupted at the same size', async () => {
+    const first = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    // Same-size corruption after the download: the metadata still validates
+    // (size matches), but the bytes no longer hash to the recorded checksum.
+    await writeFile(stagedExePath(exePath, first.staged), Buffer.alloc(PAYLOAD.length));
+    // Size-only readers still see the stage as valid…
+    expect(await readStagedNativeUpdate(exePath)).not.toBeNull();
+
+    const secondFetch = mockCdnFetch({ payload: PAYLOAD });
+    const second = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: secondFetch,
+    });
+
+    // …but adoption re-verifies the digest, so the payload is re-downloaded
+    // and published under a NEW generation name (a published exe is never
+    // replaced — the damaged one is left for the orphan cleanup).
+    expect(second.status).toBe('staged');
+    expect(secondFetch).toHaveBeenCalled();
+    expect(second.staged.exeFileName).not.toBe(first.staged.exeFileName);
+    const repaired = await readFile(stagedExePath(exePath, second.staged));
+    expect(repaired.equals(PAYLOAD)).toBe(true);
+  });
+
+  it('re-stages when the staged exe went missing', async () => {
+    const first = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    // The metadata stays but the exe is deleted → not trustworthy, re-stage.
+    await rm(stagedExePath(exePath, first.staged));
+    expect(await readStagedNativeUpdate(exePath)).toBeNull();
+
+    const second = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    expect(second.status).toBe('staged');
+  });
+
+  it('keeps the previous staged record when the superseding download fails', async () => {
+    await stageNativeUpdate({
+      version: '0.6.0',
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ version: '0.6.0', payload: Buffer.from('old-payload') }),
+    });
+
+    // The superseding download fails verification. The old record must
+    // survive: deleting it before the replacement is ready could remove a
+    // concurrent worker's freshly published record, and here it would lose
+    // a still-valid staged update.
+    await expect(
+      stageNativeUpdate({
+        version: VERSION,
+        exePath,
+        platform: 'linux',
+        arch: 'x64',
+        fetchImpl: mockCdnFetch({ payload: PAYLOAD, checksum: 'f'.repeat(64) }),
+      }),
+    ).rejects.toThrow(/sha256 mismatch/);
+
+    expect((await readStagedNativeUpdate(exePath))?.version).toBe('0.6.0');
+  });
+
+  it('throws on a checksum mismatch and cleans up leftovers', async () => {
+    await expect(
+      stageNativeUpdate({
+        version: VERSION,
+        exePath,
+        platform: 'linux',
+        arch: 'x64',
+        fetchImpl: mockCdnFetch({ payload: PAYLOAD, checksum: 'f'.repeat(64) }),
+      }),
+    ).rejects.toThrow(/sha256 mismatch/);
+
+    expect(await readStagedNativeUpdate(exePath)).toBeNull();
+    // Both the staged metadata and the .part download are gone.
+    await expect(stat(getNativeStagedStateFile(exePath))).rejects.toThrow();
+    await expect(stat(getNativeStagingDir(exePath))).rejects.toThrow();
+  });
+
+  it('rejects an archive that is not a single-entry zip and cleans up leftovers', async () => {
+    const zip = new ZipFile();
+    zip.addBuffer(PAYLOAD, 'pythinker');
+    zip.addBuffer(Buffer.from('extra'), 'README');
+    zip.end();
+    const chunks: Buffer[] = [];
+    for await (const chunk of zip.outputStream) chunks.push(chunk as Buffer);
+    const archive = Buffer.concat(chunks);
+
+    await expect(
+      stageNativeUpdate({
+        version: VERSION,
+        exePath,
+        platform: 'linux',
+        arch: 'x64',
+        fetchImpl: mockCdnFetch({ payload: PAYLOAD, archive }),
+      }),
+    ).rejects.toThrow(/single-entry archive/);
+
+    expect(await readStagedNativeUpdate(exePath)).toBeNull();
+    await expect(stat(getNativeStagingDir(exePath))).rejects.toThrow();
+  });
+
+  it('rejects a download that is not a zip archive even when its checksum matches', async () => {
+    await expect(
+      stageNativeUpdate({
+        version: VERSION,
+        exePath,
+        platform: 'linux',
+        arch: 'x64',
+        fetchImpl: mockCdnFetch({ payload: PAYLOAD, archive: PAYLOAD }),
+      }),
+    ).rejects.toThrow(/zip archive/);
+    expect(await readStagedNativeUpdate(exePath)).toBeNull();
+  });
+
+  it('throws when the platform is missing from the manifest', async () => {
+    await expect(
+      stageNativeUpdate({
+        version: VERSION,
+        exePath,
+        platform: 'win32',
+        arch: 'arm64',
+        fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+      }),
+    ).rejects.toThrow(/win32-arm64 not found/);
+  });
+
+  it('rejects a traversal version before deriving any filesystem path', async () => {
+    const fetchImpl = mockCdnFetch({ payload: PAYLOAD });
+    await expect(
+      stageNativeUpdate({
+        version: 'x/../../pythinker',
+        exePath,
+        platform: 'linux',
+        arch: 'x64',
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/invalid semver/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    // Nothing was created anywhere.
+    await expect(stat(getNativeStagingDir(exePath))).rejects.toThrow();
+  });
+
+  it('supersedes a staged older version', async () => {
+    const first = await stageNativeUpdate({
+      version: '0.6.0',
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ version: '0.6.0', payload: Buffer.from('old-payload') }),
+    });
+
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+
+    expect(result.status).toBe('staged');
+    expect(result.staged.version).toBe(VERSION);
+    // The older stage's exe is left in place (it may be claim-held by a live
+    // swap); an unreferenced one is reaped by a later orphan cleanup.
+    await expect(
+      stat(join(getNativeStagingDir(exePath), first.staged.exeFileName)),
+    ).resolves.toBeDefined();
+  });
+
+  it('preserves the exe referenced by the current record during orphan cleanup', async () => {
+    const first = await stageNativeUpdate({
+      version: '0.6.0',
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ version: '0.6.0', payload: Buffer.from('old-payload') }),
+    });
+    // Age the staged exe past the orphan grace period: it is still the
+    // applicable update (staged.json references it until the final atomic
+    // write replaces the record), so the cleanup must not reap it.
+    const oldExe = stagedExePath(exePath, first.staged);
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await utimes(oldExe, old, old);
+
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    expect(result.status).toBe('staged');
+
+    // Referenced at cleanup time → survives this run (a later cleanup reaps
+    // it once the new record has replaced the old one).
+    await expect(stat(oldExe)).resolves.toBeDefined();
+  });
+
+  it('cleans orphaned staging files before downloading, preserving live swap claims', async () => {
+    const stagingDir = getNativeStagingDir(exePath);
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stagingDir, { recursive: true });
+    // Orphans from interrupted earlier runs: a referenced-by-nothing exe and
+    // a stale .part download (aged past the orphan grace period).
+    await agedOrphan(join(stagingDir, 'pythinker-9.9.9'), Buffer.from('orphan-exe'));
+    await agedOrphan(join(stagingDir, 'pythinker-9.9.9.part'), Buffer.from('partial'));
+    await agedOrphan(join(stagingDir, 'pythinker-9.9.9.zip.part'), Buffer.from('partial-zip'));
+    // A live swap claim referencing its own staged exe must survive.
+    const claimExe = 'pythinker-8.8.8';
+    await writeFile(join(stagingDir, claimExe), Buffer.from('swap-in-progress'));
+    await writeFile(
+      join(stagingDir, 'staged.json.swap-1234'),
+      JSON.stringify({ exeFileName: claimExe }),
+    );
+    // A fresh unreferenced exe is too young to be reaped: a concurrent
+    // worker may be about to publish its metadata.
+    const youngExe = 'pythinker-7.7.7';
+    await writeFile(join(stagingDir, youngExe), Buffer.from('just-published'));
+
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    expect(result.status).toBe('staged');
+
+    await expect(stat(join(stagingDir, 'pythinker-9.9.9'))).rejects.toThrow();
+    await expect(stat(join(stagingDir, 'pythinker-9.9.9.part'))).rejects.toThrow();
+    await expect(stat(join(stagingDir, 'pythinker-9.9.9.zip.part'))).rejects.toThrow();
+    await expect(stat(join(stagingDir, 'staged.json.swap-1234'))).resolves.toBeDefined();
+    await expect(stat(join(stagingDir, claimExe))).resolves.toBeDefined();
+    await expect(stat(join(stagingDir, youngExe))).resolves.toBeDefined();
+  });
+
+  it('retries short writes until each chunk is fully persisted', async () => {
+    // The first write to the .part file persists only half its bytes; the
+    // write loop must make up the remainder or the staged exe is truncated.
+    fsMocks.shortWriteBudget = 1;
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    expect(result.status).toBe('staged');
+    const exeBytes = await readFile(stagedExePath(exePath, result.staged));
+    expect(exeBytes.equals(PAYLOAD)).toBe(true);
+  });
+
+  it('leaves foreign files in the staging directory alone', async () => {
+    const stagingDir = getNativeStagingDir(exePath);
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(join(stagingDir, 'some-other-tool'), { recursive: true });
+    await writeFile(join(stagingDir, 'user-notes.txt'), 'not ours', 'utf-8');
+    await writeFile(join(stagingDir, 'some-other-tool', 'cache.bin'), 'not ours either');
+    // A genuine updater-owned orphan to prove cleanup still works (aged past
+    // the orphan grace period).
+    await agedOrphan(join(stagingDir, 'pythinker-9.9.9'), Buffer.from('orphan-exe'));
+
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    expect(result.status).toBe('staged');
+
+    await expect(stat(join(stagingDir, 'pythinker-9.9.9'))).rejects.toThrow();
+    await expect(stat(join(stagingDir, 'user-notes.txt'))).resolves.toBeDefined();
+    await expect(stat(join(stagingDir, 'some-other-tool', 'cache.bin'))).resolves.toBeDefined();
+  });
+
+  it('cleans orphans with prerelease and build-metadata versions', async () => {
+    const stagingDir = getNativeStagingDir(exePath);
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stagingDir, { recursive: true });
+    await agedOrphan(join(stagingDir, 'pythinker-1.2.3-rc.1'), Buffer.from('orphan'));
+    await agedOrphan(join(stagingDir, 'pythinker-1.2.3+build.5.exe'), Buffer.from('orphan'));
+    await agedOrphan(join(stagingDir, 'pythinker-1.2.3-rc.1.123.0.part'), Buffer.from('partial'));
+    // New-style published name with the unique per-worker infix.
+    await agedOrphan(join(stagingDir, 'pythinker-4.5.6.1234.1700000000000.0'), Buffer.from('orphan'));
+
+    const result = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    expect(result.status).toBe('staged');
+
+    await expect(stat(join(stagingDir, 'pythinker-1.2.3-rc.1'))).rejects.toThrow();
+    await expect(stat(join(stagingDir, 'pythinker-1.2.3+build.5.exe'))).rejects.toThrow();
+    await expect(stat(join(stagingDir, 'pythinker-1.2.3-rc.1.123.0.part'))).rejects.toThrow();
+    await expect(stat(join(stagingDir, 'pythinker-4.5.6.1234.1700000000000.0'))).rejects.toThrow();
+  });
+
+  it("preserves another worker's staged result when this attempt fails", async () => {
+    const stagingDir = getNativeStagingDir(exePath);
+    const exeFileName = `pythinker-${VERSION}`;
+    const otherPayload = Buffer.from('other-worker-payload');
+    const fetchImpl = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === nativeManifestUrl(VERSION)) {
+        const manifestBody = JSON.stringify({
+          version: VERSION,
+          platforms: {
+            'linux-x64': { filename: BINARY_FILENAME, checksum: sha256Hex(PAYLOAD) },
+          },
+        });
+        return { ok: true, status: 200, text: async () => manifestBody, body: null };
+      }
+      if (url === nativeBinaryUrl(VERSION, BINARY_FILENAME)) {
+        // A concurrent worker publishes its valid stage mid-download…
+        const { mkdir } = await import('node:fs/promises');
+        await mkdir(stagingDir, { recursive: true });
+        await writeFile(join(stagingDir, exeFileName), otherPayload);
+        await writeFile(
+          getNativeStagedStateFile(exePath),
+          `${JSON.stringify({
+            version: VERSION,
+            target: 'linux-x64',
+            exeFileName,
+            sha256: sha256Hex(otherPayload),
+            exeSize: otherPayload.length,
+            stagedAt: new Date().toISOString(),
+          })}\n`,
+        );
+        // …then this attempt's download fails.
+        return { ok: false, status: 503, text: async () => '', body: null };
+      }
+      return { ok: false, status: 404, text: async (): Promise<string> => '', body: null };
+    }) as unknown as typeof fetch;
+
+    await expect(
+      stageNativeUpdate({ version: VERSION, exePath, platform: 'linux', arch: 'x64', fetchImpl }),
+    ).rejects.toThrow(/503/);
+
+    // The concurrent worker's stage survives this attempt's failure cleanup.
+    const staged = await readStagedNativeUpdate(exePath);
+    expect(staged?.version).toBe(VERSION);
+    const bytes = await readFile(join(stagingDir, exeFileName));
+    expect(bytes.equals(otherPayload)).toBe(true);
+  });
+
+  it('preserves the staged exe a live swap claim references when this attempt fails', async () => {
+    const stagingDir = getNativeStagingDir(exePath);
+    const exeFileName = `pythinker-${VERSION}`;
+    const fetchImpl = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === nativeManifestUrl(VERSION)) {
+        const manifestBody = JSON.stringify({
+          version: VERSION,
+          platforms: {
+            'linux-x64': { filename: BINARY_FILENAME, checksum: sha256Hex(PAYLOAD) },
+          },
+        });
+        return { ok: true, status: 200, text: async () => manifestBody, body: null };
+      }
+      if (url === nativeBinaryUrl(VERSION, BINARY_FILENAME)) {
+        // A swap claims the stage mid-download: the metadata is renamed
+        // aside (invisible to the metadata check), the exe still referenced
+        // by the live claim.
+        const { mkdir } = await import('node:fs/promises');
+        await mkdir(stagingDir, { recursive: true });
+        await writeFile(join(stagingDir, exeFileName), PAYLOAD);
+        await writeFile(
+          join(stagingDir, 'staged.json.swap-4321'),
+          JSON.stringify({ exeFileName }),
+        );
+        // …then this attempt's download fails.
+        return { ok: false, status: 503, text: async () => '', body: null };
+      }
+      return { ok: false, status: 404, text: async (): Promise<string> => '', body: null };
+    }) as unknown as typeof fetch;
+
+    await expect(
+      stageNativeUpdate({ version: VERSION, exePath, platform: 'linux', arch: 'x64', fetchImpl }),
+    ).rejects.toThrow(/503/);
+
+    // The exe owned by the live swap survives this attempt's failure cleanup.
+    const bytes = await readFile(join(stagingDir, exeFileName));
+    expect(bytes.equals(PAYLOAD)).toBe(true);
+  });
+});
+
+describe('promoteStagedUpdateToManual', () => {
+  let workDir: string;
+  let exePath: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'pythinker-promote-test-'));
+    exePath = join(workDir, 'bin', 'pythinker');
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it('promotes the adopted record to manual', async () => {
+    await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    const adopted = await readStagedNativeUpdate(exePath);
+    if (adopted === null) throw new Error('expected a staged record');
+
+    await expect(promoteStagedUpdateToManual(exePath, adopted)).resolves.toBe(true);
+    expect((await readStagedNativeUpdate(exePath))?.manual).toBe(true);
+  });
+
+  it('refuses to promote a record the staged metadata no longer matches', async () => {
+    await stageNativeUpdate({
+      version: '0.6.0',
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ version: '0.6.0', payload: Buffer.from('old-payload') }),
+    });
+    const adopted = await readStagedNativeUpdate(exePath);
+    if (adopted === null) throw new Error('expected a staged record');
+
+    // A newer stage is published before the explicit upgrade's promote
+    // lands: the stale record must not overwrite it.
+    await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+
+    await expect(promoteStagedUpdateToManual(exePath, adopted)).resolves.toBe(false);
+    const current = await readStagedNativeUpdate(exePath);
+    expect(current?.version).toBe(VERSION);
+    expect(current?.manual).toBeUndefined();
   });
 });
 
@@ -56,14 +847,17 @@ describe('readStagedNativeUpdate', () => {
   });
 
   it('returns null for malformed staged.json content', async () => {
-    await mkdir(getNativeStagingDir(exePath), { recursive: true });
+    const { mkdir } = await import('node:fs/promises');
+    const stagingDir = getNativeStagingDir(exePath);
+    await mkdir(stagingDir, { recursive: true });
     await writeFile(getNativeStagedStateFile(exePath), '{not json', 'utf-8');
-
     expect(await readStagedNativeUpdate(exePath)).toBeNull();
   });
 
   it('returns null when exeFileName is not a plain file name', async () => {
-    await mkdir(getNativeStagingDir(exePath), { recursive: true });
+    const { mkdir } = await import('node:fs/promises');
+    const stagingDir = getNativeStagingDir(exePath);
+    await mkdir(stagingDir, { recursive: true });
     await writeFile(
       getNativeStagedStateFile(exePath),
       JSON.stringify({
@@ -76,27 +870,18 @@ describe('readStagedNativeUpdate', () => {
       }),
       'utf-8',
     );
-
     expect(await readStagedNativeUpdate(exePath)).toBeNull();
   });
 
   it('returns null when the exe size drifted from the metadata', async () => {
-    const stagingDir = getNativeStagingDir(exePath);
-    await mkdir(stagingDir, { recursive: true });
-    await writeFile(join(stagingDir, 'pythinker-0.7.0'), Buffer.alloc(43));
-    await writeFile(
-      getNativeStagedStateFile(exePath),
-      JSON.stringify({
-        version: '0.7.0',
-        target: 'linux-x64',
-        exeFileName: 'pythinker-0.7.0',
-        sha256: 'a'.repeat(64),
-        exeSize: 42,
-        stagedAt: new Date().toISOString(),
-      }),
-      'utf-8',
-    );
-
+    const { staged } = await stageNativeUpdate({
+      version: VERSION,
+      exePath,
+      platform: 'linux',
+      arch: 'x64',
+      fetchImpl: mockCdnFetch({ payload: PAYLOAD }),
+    });
+    await writeFile(stagedExePath(exePath, staged), Buffer.alloc(PAYLOAD.length + 1));
     expect(await readStagedNativeUpdate(exePath)).toBeNull();
   });
 });

--- a/apps/pythinker-code/test/cli/update/zip-archive.test.ts
+++ b/apps/pythinker-code/test/cli/update/zip-archive.test.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ZipFile } from 'yazl';
+
+import { extractZipEntry, readSingleZipEntry, readZipEntries } from '#/cli/update/zip-archive';
+
+interface ZipInput {
+  readonly name: string;
+  readonly bytes: Buffer;
+  readonly compress?: boolean;
+}
+
+async function buildZip(inputs: readonly ZipInput[]): Promise<Buffer> {
+  const zip = new ZipFile();
+  for (const input of inputs) {
+    zip.addBuffer(input.bytes, input.name, { compress: input.compress ?? true });
+  }
+  zip.end();
+  const chunks: Buffer[] = [];
+  for await (const chunk of zip.outputStream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+describe('zip-archive', () => {
+  let workDir: string;
+  let zipPath: string;
+  let outPath: string;
+  const payload = Buffer.from('fake-sea-binary-payload '.repeat(2000));
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'pythinker-zip-test-'));
+    zipPath = join(workDir, 'artifact.zip');
+    outPath = join(workDir, 'out.bin');
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it('lists the entries recorded in the central directory', async () => {
+    await writeFile(
+      zipPath,
+      await buildZip([
+        { name: 'pythinker', bytes: payload },
+        { name: 'README', bytes: Buffer.from('hi'), compress: false },
+      ]),
+    );
+    const entries = await readZipEntries(zipPath);
+    expect(entries.map((entry) => entry.name)).toEqual(['pythinker', 'README']);
+    expect(entries[0]?.method).toBe(8);
+    expect(entries[0]?.uncompressedSize).toBe(payload.length);
+    expect(entries[1]?.method).toBe(0);
+  });
+
+  it('extracts a deflated entry and reports its sha256 and size', async () => {
+    await writeFile(zipPath, await buildZip([{ name: 'pythinker', bytes: payload }]));
+    const entry = await readSingleZipEntry(zipPath);
+    const result = await extractZipEntry(zipPath, entry, outPath);
+    expect(result).toEqual({ sha256: sha256Hex(payload), size: payload.length });
+    expect((await readFile(outPath)).equals(payload)).toBe(true);
+  });
+
+  it('extracts a stored entry', async () => {
+    await writeFile(
+      zipPath,
+      await buildZip([{ name: 'pythinker.exe', bytes: payload, compress: false }]),
+    );
+    const entry = await readSingleZipEntry(zipPath);
+    const result = await extractZipEntry(zipPath, entry, outPath);
+    expect(result.sha256).toBe(sha256Hex(payload));
+    expect((await readFile(outPath)).equals(payload)).toBe(true);
+  });
+
+  it('rejects an archive with more than one entry', async () => {
+    await writeFile(
+      zipPath,
+      await buildZip([
+        { name: 'pythinker', bytes: payload },
+        { name: 'README', bytes: Buffer.from('hi') },
+      ]),
+    );
+    await expect(readSingleZipEntry(zipPath)).rejects.toThrow(/single-entry archive, found 2/);
+  });
+
+  it('rejects bytes that are not a zip archive', async () => {
+    await writeFile(zipPath, payload);
+    await expect(readZipEntries(zipPath)).rejects.toThrow(/end-of-central-directory/);
+  });
+
+  it('rejects a truncated archive', async () => {
+    const archive = await buildZip([{ name: 'pythinker', bytes: payload }]);
+    await writeFile(zipPath, archive.subarray(0, 10));
+    await expect(readZipEntries(zipPath)).rejects.toThrow(/too small/);
+  });
+
+  it('rejects an unsupported compression method', async () => {
+    await writeFile(zipPath, await buildZip([{ name: 'pythinker', bytes: payload }]));
+    const entry = await readSingleZipEntry(zipPath);
+    await expect(extractZipEntry(zipPath, { ...entry, method: 12 }, outPath)).rejects.toThrow(
+      /unsupported zip compression method: 12/,
+    );
+  });
+
+  it('rejects an entry whose extracted size disagrees with the directory', async () => {
+    await writeFile(zipPath, await buildZip([{ name: 'pythinker', bytes: payload }]));
+    const entry = await readSingleZipEntry(zipPath);
+    await expect(
+      extractZipEntry(zipPath, { ...entry, uncompressedSize: entry.uncompressedSize + 1 }, outPath),
+    ).rejects.toThrow(/size mismatch/);
+  });
+});


### PR DESCRIPTION
## Related Issue

No issue. Reported directly: `pythinker update` fails with "Self-update is disabled in this build" on every install.

## Problem

Both CDN fetchers and the native staging entry point threw a fixed disabled-message error, so `pythinker update` and `pythinker upgrade` could never check for or install a release. The infrastructure was fine the whole time: `code.pythinker.com/pythinker-code/latest` and `latest.json` serve the current version, and every GitHub release carries `manifest.json` plus the six per-platform zips.

## What changed

- Version checks read the CDN `/latest` (plain text) and `/latest.json` (rollout manifest) again, with the plain-text fallback restored.
- The native manifest and binary URLs resolve to the GitHub release of the requested version (`manifest.json` and `pythinker-code-<target>.zip`), matching what `release.yml` publishes and what `install.sh` consumes.
- Native staging now verifies the archive sha256 against the manifest, then extracts its single entry with a small built-in zip reader (stored and deflate only, ZIP64 and multi-entry archives rejected) and records the extracted binary's own digest and size. The startup swap re-verifies against that digest, unchanged.
- Orphan cleanup recognizes the new `.zip.part` download intermediate.

Tests: the three update suites were restored from their pre-disable versions and adapted to the zip contract (yazl-built fixtures), plus a new suite for the zip reader. A one-off live check confirmed `fetchLatestFromCdn` and `fetchNativeReleaseManifest` resolve the current 1.11.1 release end to end.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/PyModel/pythinker-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.