### PR TITLE
fix: finalize the update manifest the desktop release channel produces

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -245,11 +245,13 @@ jobs:
       # electron-builder notarizes and staples the .app but never the disk
       # image around it; a quarantined, unnotarized DMG is what Gatekeeper
       # reports as "damaged". Stapling changes the DMG bytes, so the same
-      # script also rewrites its latest-mac.yml entry and drops the stale
+      # script also rewrites the channel's update manifest and drops the stale
       # blockmap, keeping the update manifest verification below honest.
       - name: Notarize and staple macOS DMG
         working-directory: apps/desktop
-        run: node --import tsx scripts/finalize-mac-artifacts.ts dist
+        env:
+          UPDATE_MANIFEST: ${{ needs.prepare.outputs.mac_manifest }}
+        run: node --import tsx scripts/finalize-mac-artifacts.ts dist "$UPDATE_MANIFEST"
 
       - name: Verify macOS update artifacts
         shell: bash

--- a/apps/desktop/scripts/finalize-mac-artifacts.ts
+++ b/apps/desktop/scripts/finalize-mac-artifacts.ts
@@ -26,8 +26,13 @@ export interface FinalizeMacArtifactsOptions {
   readonly distDir: string
   readonly env: NodeJS.ProcessEnv
   readonly log?: (message: string) => void
+  // electron-builder names the manifest after the release channel, so only the
+  // stable channel produces latest-mac.yml.
+  readonly manifestName?: string
   readonly runCommand?: CommandRunner
 }
+
+const DEFAULT_MAC_MANIFEST = 'latest-mac.yml'
 
 function requiredValue(env: NodeJS.ProcessEnv, name: string): string {
   return env[name]!.trim()
@@ -72,6 +77,7 @@ export function rewriteLatestMacYaml(
   filename: string,
   sha512: string,
   size: number,
+  manifestName: string = DEFAULT_MAC_MANIFEST,
 ): string {
   const lines = yaml.split('\n')
   let fileEntryIndent: number | undefined
@@ -126,7 +132,7 @@ export function rewriteLatestMacYaml(
   }
 
   if (checksumUpdates === 0 || sizeUpdates === 0) {
-    throw new Error(`latest-mac.yml does not contain complete metadata for ${filename}`)
+    throw new Error(`${manifestName} does not contain complete metadata for ${filename}`)
   }
   return lines.join('\n')
 }
@@ -147,7 +153,8 @@ export function finalizeMacArtifacts(options: FinalizeMacArtifactsOptions): void
     .sort()
   if (dmgs.length === 0) throw new Error(`No DMG artifacts found in ${options.distDir}`)
 
-  const metadataPath = join(options.distDir, 'latest-mac.yml')
+  const manifestName = options.manifestName ?? DEFAULT_MAC_MANIFEST
+  const metadataPath = join(options.distDir, manifestName)
   let metadata = readFileSync(metadataPath, 'utf8')
   const credentialArgs = buildNotarytoolArguments(options.env)
 
@@ -181,7 +188,7 @@ export function finalizeMacArtifacts(options: FinalizeMacArtifactsOptions): void
 
     const size = statSync(dmgPath).size
     const sha512 = createHash('sha512').update(readFileSync(dmgPath)).digest('base64')
-    metadata = rewriteLatestMacYaml(metadata, filename, sha512, size)
+    metadata = rewriteLatestMacYaml(metadata, filename, sha512, size, manifestName)
 
     const blockmapPath = `${dmgPath}.blockmap`
     if (existsSync(blockmapPath)) {
@@ -196,9 +203,10 @@ export function finalizeMacArtifacts(options: FinalizeMacArtifactsOptions): void
 const invokedPath = process.argv[1]
 if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
   const distDir = process.argv[2]
+  const manifestName = process.argv[3]
   try {
-    if (distDir === undefined) throw new Error('Usage: finalize-mac-artifacts.ts <dist-directory>')
-    finalizeMacArtifacts({ distDir: resolve(distDir), env: process.env })
+    if (distDir === undefined) throw new Error('Usage: finalize-mac-artifacts.ts <dist-directory> [manifest-name]')
+    finalizeMacArtifacts({ distDir: resolve(distDir), env: process.env, manifestName })
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error))
     process.exitCode = 1

--- a/apps/desktop/tests/finalize-mac-artifacts.spec.ts
+++ b/apps/desktop/tests/finalize-mac-artifacts.spec.ts
@@ -132,6 +132,32 @@ sha512: old
     expect(runCommand).toHaveBeenNthCalledWith(2, 'xcrun', ['stapler', 'staple', join(distDir, filename)])
   })
 
+  it('finalizes the channel manifest a prerelease build actually produces', () => {
+    const distDir = mkdtempSync(join(tmpdir(), 'pythinker-mac-artifacts-'))
+    directories.push(distDir)
+    const filename = 'Pythinker-0.11.1-nightly.304-arm64.dmg'
+    const dmg = Buffer.from('nightly dmg fixture')
+    writeFileSync(join(distDir, filename), dmg)
+    writeFileSync(join(distDir, 'nightly-mac.yml'), `files:
+  - url: ${filename}
+    sha512: old
+    size: 1
+path: ${filename}
+sha512: old
+`)
+
+    finalizeMacArtifacts({
+      distDir,
+      env: { APPLE_KEYCHAIN_PROFILE: 'pythinker-notary' },
+      log: () => {},
+      manifestName: 'nightly-mac.yml',
+      runCommand: () => ({ status: 0, stderr: '', stdout: '{"status":"Accepted"}' }),
+    })
+
+    const checksum = createHash('sha512').update(dmg).digest('base64')
+    expect(readFileSync(join(distDir, 'nightly-mac.yml'), 'utf8')).toContain(`sha512: ${checksum}`)
+  })
+
   it('prints and rejects a non-accepted notarytool result before stapling', () => {
     const distDir = mkdtempSync(join(tmpdir(), 'pythinker-mac-artifacts-'))
     directories.push(distDir)


### PR DESCRIPTION
[skip changeset] — release-workflow and build-script only; no user-perceivable CLI or app behavior change.

## Summary

Every Nightly desktop run has failed since at least 2026-09-08, after notarization had already succeeded:

```
ENOENT: no such file or directory, open '.../apps/desktop/dist/latest-mac.yml'
```

`finalize-mac-artifacts.ts` always read `latest-mac.yml`, but electron-builder names the update manifest after the release channel — a Nightly build (`0.11.1-nightly.304`) writes `nightly-mac.yml`. That name was already resolved by the `prepare` job and consumed by the verify step (`needs.prepare.outputs.mac_manifest`); only the finalize step still hardcoded the stable name.

The DMG was notarized and stapled before the crash, so each failed run also left `Desktop Nightly` unpublished and kept the release-lane drift issue (#202) open.

## Changes

- `finalizeMacArtifacts` takes an optional `manifestName`, defaulting to `latest-mac.yml`, so the stable path and the local `release-mac.ts` caller are unchanged.
- The workflow passes the channel manifest the `prepare` job already resolves.
- The incomplete-metadata error names the manifest it actually read, instead of misreporting `latest-mac.yml` during a Nightly incident.

## Test plan

- [x] New spec case finalizes a `nightly-mac.yml` fixture and asserts the rewritten checksum.
- [x] Mutation-proven: re-hardcoding `DEFAULT_MAC_MANIFEST` makes the new test fail with the exact CI error (`ENOENT ... latest-mac.yml`); restoring it passes 8/8.
- [x] `typecheck` (desktop, both tsconfigs) and `lint` (0 errors) pass.
- [ ] Verified end-to-end by the next Nightly run.